### PR TITLE
Make FlashQuest reusable: verified accounts, custom decks, and featured demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,67 +2,104 @@
 
 **Learn it. Break it. Fix it. Remember it.**
 
-FlashQuest’s is a game-like **Platform Engineering study + troubleshooting app** built with React, FastAPI, PostgreSQL, Alembic, and Docker.
+FlashQuest’s is a reusable, game-like study engine built with **React, FastAPI, PostgreSQL, Alembic, and Docker**.
 
-[![CI](https://github.com/mergemaven11/flashcards/actions/workflows/ci.yml/badge.svg)](https://github.com/mergemaven11/flashcards/actions/workflows/ci.yml)
-[![Docs Deploy](https://github.com/mergemaven11/flashcards/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/mergemaven11/flashcards/actions/workflows/docs-deploy.yml)
-[![Docs](https://img.shields.io/badge/docs-live-brightgreen)](https://flashcards-docs.netlify.app/)
+Start instantly with a featured **216-card Platform Engineering deck**, then create a verified account and make private decks for anything you want to learn.
 
-FlashQuest’s ships with **216 built-in Platform Engineering challenges**:
+[![CI](https://github.com/mergemaven11/FlashQuest/actions/workflows/ci.yml/badge.svg)](https://github.com/mergemaven11/FlashQuest/actions/workflows/ci.yml)
+[![Docs Build](https://github.com/mergemaven11/FlashQuest/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/mergemaven11/FlashQuest/actions/workflows/docs-deploy.yml)
+[![Docs](https://img.shields.io/badge/docs-live-ffba08)](https://flashquest-docs.netlify.app/)
 
-- **144 concept / interview cards** — understand the systems.
-- **72 hands-on lab / break-fix cards** — diagnose, design, and fix the systems.
-- **12 domains** — Linux through incident response.
-- **PostgreSQL-backed progress** — study state survives browser sessions.
-- **Game feedback** — XP, levels, combos, accuracy, mastery, and deck progression.
-
-The application itself is also a Platform Engineering portfolio project: dependency-aware health checks, explicit Alembic migrations, request correlation, non-root containers, environment-driven configuration, PostgreSQL migration testing, and CI quality gates.
+**App:** https://flashcards-tobias.netlify.app/  
+**Docs:** https://flashquest-docs.netlify.app/
 
 ---
 
-## 🚀 Quick start
+## What FlashQuest’s does
 
-A fresh environment should be brought up in this order: **start → migrate → seed → verify**.
+### ⭐ Try the featured Platform Engineering deck
 
-```bash
-git clone https://github.com/mergemaven11/flashcards.git
-cd flashcards
+No account is required to understand the product. The starter pack contains:
 
-docker compose up --build -d
+- **144 concept / interview cards**
+- **72 break/fix lab cards**
+- **12 Platform Engineering domains**
+- **216 total challenges**
+- **12 spaced-repetition mastery levels**
 
-docker compose exec api \
-  alembic -c /app/alembic.ini upgrade head
+### ✨ Make your own deck
 
-docker compose exec api python -m app.seed
+The product flow is:
+
+```text
+Try featured demo
+      ↓
+Sign up
+      ↓
+Verify email
+      ↓
+Sign in
+      ↓
+Create private deck
+      ↓
+Add concept + lab cards
+      ↓
+Study with XP + mastery + spaced repetition
 ```
 
-Open:
+A custom deck can be anything: AWS, Python, Spanish, certification prep, school notes, interview questions, database engineering, or another topic entirely.
 
-- **FlashQuest’s:** `http://localhost:5173`
-- **FastAPI / OpenAPI:** `http://localhost:8080/docs`
-- **API readiness:** `http://localhost:8080/health/ready`
-- **PostgreSQL host port:** `5433`
-
-Verify the stack:
-
-```bash
-curl http://localhost:8080/health/live
-curl http://localhost:8080/health/ready
-```
-
-The seed command is safe to run again whenever the built-in curriculum changes:
-
-```bash
-docker compose exec api python -m app.seed
-```
-
-It is **idempotent**: existing cards are reused, new built-in cards are added, and missing default-user progress rows are repaired without duplicating the deck.
+Users can also **copy the featured Platform Engineering deck** into their account and customize their private copy without changing the public demo.
 
 ---
 
-# 📚 216-card Platform Engineering curriculum
+## 🎮 Study loop
 
-Every domain contains **12 concept cards + 6 lab scenarios = 18 challenges**.
+The Play screen explains itself in simple steps:
+
+1. **Pick a deck.**
+2. **Read the question and think first.**
+3. **Reveal the answer.**
+4. **Choose Missed it or Got it.**
+5. **Keep going — weak cards return sooner.**
+
+A **concept** card teaches an idea. A **lab** card asks you to pretend something is broken or needs to be built, explain what you would check first, then compare your answer with a recovery/implementation path.
+
+Game feedback includes:
+
+- session XP + player levels
+- combos + best streak
+- accuracy
+- backend-backed mastery
+- 12-level mastery map
+- keyboard controls: `Space` reveal, `1` missed, `2` got it
+
+XP/streak presentation is session-local. Durable accounts, decks, cards, mastery, and review history live in PostgreSQL.
+
+---
+
+## 🔐 Accounts and email verification
+
+Custom deck creation requires a verified account.
+
+Security boundaries include:
+
+- salted **PBKDF2-HMAC-SHA256** password hashes;
+- high-entropy opaque bearer sessions stored in PostgreSQL **only as SHA-256 hashes**;
+- one-time, expiring email-verification tokens stored only as hashes;
+- private deck/card APIs scoped to the signed-in owner;
+- built-in starter content read-only for normal users;
+- server-side `DEMO_DELETE_PASSWORD` protection for destructive demo maintenance.
+
+Local development uses `EMAIL_DELIVERY_MODE=console`, which prints verification URLs to API logs. Hosted delivery is designed for **Resend**.
+
+See [Accounts & Email Verification](docs/AUTHENTICATION.md).
+
+---
+
+## 📚 Featured Platform Engineering curriculum
+
+Every domain contains **12 concepts + 6 labs = 18 challenges**.
 
 | Domain | Concepts | Labs | Total |
 | --- | ---: | ---: | ---: |
@@ -80,202 +117,137 @@ Every domain contains **12 concept cards + 6 lab scenarios = 18 challenges**.
 | Incident Response | 12 | 6 | 18 |
 | **Total** | **144** | **72** | **216** |
 
-## Concept cards
-
-These are written more like **Platform Engineer interview questions** than vocabulary definitions.
-
-Examples:
-
-```text
-Kubernetes · What is the difference between liveness and readiness probes?
-Terraform · What does drift mean?
-Observability · What is an error budget?
-SRE · What is exponential backoff with jitter?
-Databases · What is point-in-time recovery?
-```
-
-## 🧪 Lab / break-fix cards
-
-Lab prompts start with `LAB ·` and put you inside an operational situation. The answer gives you a troubleshooting path, implementation plan, or safe recovery sequence.
-
-Examples:
-
-```text
-LAB · Linux · A service works manually but fails after reboot.
-What do you check and fix?
-```
-
-```text
-LAB · Kubernetes · A Service has no traffic even though Pods are Running.
-What do you check?
-```
-
-```text
-LAB · CI/CD · Tests pass locally but fail in CI.
-What do you compare first?
-```
-
-```text
-LAB · Terraform · plan wants to recreate a critical database unexpectedly.
-What do you do?
-```
-
-```text
-LAB · Databases · The API reports "too many connections".
-What do you inspect and fix?
-```
-
-```text
-LAB · Incident · Error rate jumps immediately after a deployment.
-What is your first operational move?
-```
-
-The lab deck covers work such as:
-
-- setting up services and environments safely;
-- troubleshooting systemd, disk, memory, load, inodes, and file descriptors;
-- debugging DNS, TCP, TLS, proxies, MTU, routing, and 502s;
-- fixing container startup, networking, persistence, permissions, and health checks;
-- debugging `CrashLoopBackOff`, Pending Pods, probes, failed rollouts, and Services with no endpoints;
-- repairing CI failures, slow pipelines, leaked secrets, rollbacks, and artifact flow;
-- investigating cloud exposure, autoscaling, cost spikes, private networking, and workload identity;
-- handling Terraform drift, state locks, imports, dangerous plans, secrets, and module design;
-- diagnosing latency, noisy alerts, tracing gaps, SLOs, and telemetry cost;
-- fixing database connection exhaustion, slow queries, risky migrations, deadlocks, and recovery;
-- responding to CVEs, leaked credentials, excessive IAM, and software supply-chain risk;
-- designing retries, idempotent jobs, graceful degradation, circuit breakers, and chaos tests;
-- running incidents: triage, mitigation, incident command, rollback, communications, timelines, and postmortems.
-
-### Curriculum data
-
-The built-in curriculum is versioned separately from application code:
+Versioned starter data lives in:
 
 ```text
 backend/app/data/
-├── platform_engineering_cards.json   # 144 concepts
-└── platform_engineering_labs.json    # 72 break/fix labs
+├── platform_engineering_cards.json
+└── platform_engineering_labs.json
 ```
 
-Automated tests verify:
-
-- 144 concept cards;
-- 72 lab cards;
-- 216 unique prompts total;
-- balanced domain counts;
-- rerunning the seed does not create duplicate cards or progress rows.
+The seeder is idempotent and repairs the featured deck/card metadata and missing anonymous-demo progress without duplicating content.
 
 ---
 
-# 🎮 Study experience
-
-FlashQuest’s is designed as a **memory quest**, not a plain CRUD dashboard.
-
-- ⚡ session XP and player levels
-- 🔥 correct-answer combos and best streak
-- 🎯 session accuracy
-- ⭐ mastery based on the real backend spaced-repetition bin
-- ✨ animated answer/reward feedback
-- 🗺️ 12-level mastery map
-- 🏆 checkpoint and deck-completion states
-- ⌨️ keyboard controls: `Space` reveal, `1` missed, `2` nailed it
-- 🧪 **Deck Lab** for card administration
-- 🗺️ **Deck Map** for learning progress + runtime status
-
-XP and combo values are intentionally session-local presentation state. **Durable mastery, review history, and card state live in PostgreSQL.**
-
----
-
-# 🧠 Spaced repetition
-
-Cards move through **12 mastery bins (`0`–`11`)**. Higher bins wait longer before becoming due again.
-
-| Bin | Approx. delay |
-| --- | --- |
-| 0 | new |
-| 1 | 5s |
-| 2 | 30s |
-| 3 | 5m |
-| 4 | 30m |
-| 5 | 2h |
-| 6 | 6h |
-| 7 | 1d |
-| 8 | 2d |
-| 9 | 4d |
-| 10 | 7d |
-| 11 | terminal mastery |
-
-Rules:
-
-- **Correct** → advance one bin.
-- **Wrong** → return to bin 1 and increment the lifetime wrong count.
-- Repeated misses can mark a card `hard_to_remember`.
-- Terminal mastery removes a card from the active study queue.
-- Due cards are selected before new cards.
-- Every submitted answer creates a `Review` record for later analytics.
-
----
-
-# 🏗️ Architecture
+## 🏗️ Architecture
 
 ```text
-┌──────────────────────┐
-│ React + TypeScript   │
-│ FlashQuest’s frontend │
-└──────────┬───────────┘
-           │ HTTP / JSON
-           ▼
-┌──────────────────────┐
-│ FastAPI              │
-│ study + card API     │
-└──────────┬───────────┘
-           │ SQLModel / SQLAlchemy
-           ▼
-┌──────────────────────┐
-│ PostgreSQL 16        │
-│ cards + reviews      │
-└──────────────────────┘
-           ▲
-           │ schema lifecycle
-┌──────────┴───────────┐
-│ Alembic migrations   │
-└──────────────────────┘
+Browser
+  │
+  ▼
+React / TypeScript
+  │ HTTP / JSON + bearer session
+  ▼
+FastAPI
+  │
+  ├── Resend (email verification)
+  │
+  ▼
+PostgreSQL 16
+  ▲
+  │ schema lifecycle
+Alembic
 ```
 
-### Core stack
+Persistent product model:
 
-| Layer | Technology |
-| --- | --- |
-| Frontend | React 19, TypeScript, Vite, Tailwind CSS, Axios, React Router |
-| Backend | FastAPI, SQLModel / SQLAlchemy, Pydantic Settings, Uvicorn |
-| Database | PostgreSQL 16 |
-| Schema lifecycle | Alembic |
-| Containers | Docker + Docker Compose |
-| Docs | MkDocs Material + mkdocstrings + TypeDoc |
-| CI | GitHub Actions |
+```text
+User
+  └── Deck
+       └── Card
+            ├── domain / category
+            └── kind: concept | lab
 
----
+User + Card
+  └── UserCard mastery state
+       └── Review history
+```
 
-# 🛠️ Platform Engineering built into FlashQuest’s
-
-| Area | Implementation |
-| --- | --- |
-| **Liveness** | lightweight process/service endpoint |
-| **Readiness** | executes a real database query; returns `503` when PostgreSQL is unavailable |
-| **Request correlation** | caller-provided or generated `X-Request-ID` |
-| **Timing** | `X-Response-Time-Ms` on API responses |
-| **Configuration** | environment-driven DB, CORS, app environment/version, and frontend API URL |
-| **Database lifecycle** | explicit Alembic migrations; startup does not silently mutate schema |
-| **Seed lifecycle** | reproducible, versioned, idempotent 216-card curriculum |
-| **Containers** | React/FastAPI/Postgres Compose stack; API runs as a non-root user |
-| **Dependency ordering** | API waits for PostgreSQL health; web waits for API readiness |
-| **CI/CD** | backend matrix, frontend lint/build, PostgreSQL migration smoke test, image builds |
-| **State boundaries** | durable domain state in PostgreSQL; ephemeral game feedback in the browser session |
-
-See [`docs/PLATFORM_ENGINEERING.md`](docs/PLATFORM_ENGINEERING.md) for the deeper architecture and operational design.
+The anonymous public demo uses a reserved demo study identity; authenticated users receive their own mastery state even when studying the featured deck.
 
 ---
 
-# ❤️ Health and readiness
+## 🚀 Quick start
+
+A fresh environment should come up in this order:
+
+**start → migrate → seed → verify**
+
+```bash
+git clone https://github.com/mergemaven11/FlashQuest.git
+cd FlashQuest
+
+docker compose up --build -d
+
+docker compose exec api \
+  alembic -c /app/alembic.ini upgrade head
+
+docker compose exec api python -m app.seed
+```
+
+Verify:
+
+```bash
+curl http://localhost:8080/health/live
+curl http://localhost:8080/health/ready
+```
+
+Open:
+
+- React: `http://localhost:5173`
+- FastAPI/OpenAPI: `http://localhost:8080/docs`
+- readiness: `http://localhost:8080/health/ready`
+
+For local email verification, watch API logs after signup for the verification URL.
+
+---
+
+## 🌐 Hosted deployment
+
+### React / Netlify
+
+```text
+Site: flashcards-tobias
+Base directory: frontend
+Build command: npm run build
+Publish directory: dist
+VITE_API_URL=https://flashcards-tobias.fly.dev
+```
+
+### MkDocs / Netlify
+
+```text
+Site: flashquest-docs
+URL: https://flashquest-docs.netlify.app/
+Publish directory: site
+```
+
+The root `netlify.toml` belongs to the MkDocs site, not the React application.
+
+### FastAPI / Fly.io
+
+The Fly release command runs:
+
+```text
+alembic upgrade head && python -m app.seed
+```
+
+Before public signup works in hosted `resend` mode, configure at least:
+
+```bash
+fly secrets set \
+  RESEND_API_KEY='...' \
+  DEMO_DELETE_PASSWORD='...' \
+  -a flashcards-tobias
+```
+
+Configure `EMAIL_FROM` to a sender accepted by your Resend account.
+
+**Netlify deploying the frontend does not migrate PostgreSQL.** The backend commit must also deploy to Fly so the account/deck migration and seed release command run.
+
+---
+
+## ❤️ Operational endpoints
 
 ```text
 GET /health
@@ -283,195 +255,78 @@ GET /health/live
 GET /health/ready
 ```
 
-- `/health` — backwards-compatible lightweight response.
-- `/health/live` — confirms the service process is alive and exposes service metadata.
-- `/health/ready` — verifies the API can query PostgreSQL and returns `503` when it cannot.
+- `/health/live` confirms the process is alive.
+- `/health/ready` executes a real PostgreSQL query and returns `503` when the dependency is unavailable.
 
-API responses also include:
+Every API response also receives:
 
 ```text
 X-Request-ID
 X-Response-Time-Ms
 ```
 
-If the caller supplies `X-Request-ID`, FlashQuest’s propagates it. Otherwise the API generates one.
+---
+
+## ✅ CI quality gates
+
+Pull requests validate:
+
+1. **Backend** — Python 3.11/3.12, compile, pytest, Ruff, Black.
+2. **Frontend** — ESLint + TypeScript/Vite production build.
+3. **Database** — Alembic against clean PostgreSQL 16.
+4. **Containers** — Compose model + API/web image builds.
+5. **Docs** — strict MkDocs + TypeDoc build.
 
 ---
 
-# 🗃️ Database migrations
-
-After starting a **fresh** database, apply migrations before seeding:
-
-```bash
-docker compose exec api \
-  alembic -c /app/alembic.ini upgrade head
-```
-
-Create a migration after changing models:
-
-```bash
-docker compose exec api \
-  alembic -c /app/alembic.ini revision --autogenerate -m "describe change"
-```
-
-Inspect migration state:
-
-```bash
-docker compose exec api \
-  alembic -c /app/alembic.ini current
-```
-
-CI provisions a clean PostgreSQL 16 instance and runs `alembic upgrade head`, so migration failures are caught before merge.
-
----
-
-# ✅ CI quality gates
-
-Pull requests validate four layers:
-
-1. **Backend — Python 3.11 + 3.12**
-   - compile
-   - pytest
-   - curriculum size/balance/idempotency tests
-   - Ruff correctness checks
-   - Black formatting check for the upgraded platform code
-2. **Frontend**
-   - clean `npm ci`
-   - ESLint
-   - TypeScript + production Vite build
-3. **Database migrations**
-   - clean PostgreSQL 16 service
-   - Alembic upgrade to `head`
-4. **Containers**
-   - `docker compose config`
-   - API image build
-   - web image build
-
-CI is intentionally a **quality gate**, not a workflow that silently rewrites contributor code and pushes it back to the branch.
-
----
-
-# 🌐 Deployment notes
-
-The repository currently contains two separate web-facing concerns:
-
-- the **FlashQuest’s React application** under `frontend/`;
-- the **FlashQuest’s MkDocs documentation site** built from `netlify.toml` at the repository root.
-
-For a Netlify site that deploys the React application, use:
+## 📁 Key paths
 
 ```text
-Base directory: frontend
-Build command: npm run build
-Publish directory: dist
-```
+backend/app/
+├── data/              # featured curriculum JSON
+├── routers/
+│   ├── auth.py        # signup / verify / login / logout
+│   ├── decks.py       # featured + owned decks
+│   ├── cards.py       # owner-scoped card CRUD
+│   └── study.py       # deck-aware spaced repetition
+├── email_service.py   # verification delivery
+├── security.py        # password + opaque-session primitives
+├── models.py          # users, decks, cards, progress
+└── seed.py            # featured deck seeder
 
-Set `VITE_API_URL` in that app site to the deployed FastAPI base URL. The root `netlify.toml` is for the documentation site and should not be repurposed accidentally for the React application.
+frontend/src/
+├── pages/             # landing, auth, Play, My Decks, Deck Lab
+├── auth.tsx           # account state
+├── api.ts             # typed API client
+└── index.css          # ember/amber visual system
 
----
-
-# 💻 Development without Docker
-
-### Backend
-
-```bash
-cd backend
-python -m venv .venv
-
-# Windows PowerShell
-.\.venv\Scripts\Activate.ps1
-
-# macOS / Linux
-source .venv/bin/activate
-
-python -m pip install -r requirements.txt
-alembic -c alembic.ini upgrade head
-python -m app.seed
-uvicorn app.main:app --reload --port 8080
-```
-
-### Frontend
-
-```bash
-cd frontend
-npm ci
-npm run dev
+docs/
+├── MAKE_YOUR_OWN_DECK.md
+├── AUTHENTICATION.md
+├── OPERATIONS.md
+└── PLATFORM_ENGINEERING.md
 ```
 
 ---
 
-# 📁 Repository layout
+## 🎯 Portfolio story
 
-```text
-.
-├── .github/workflows/          # CI + docs workflows
-├── backend/
-│   ├── alembic/                # schema migrations
-│   ├── app/
-│   │   ├── data/
-│   │   │   ├── platform_engineering_cards.json
-│   │   │   └── platform_engineering_labs.json
-│   │   ├── routers/            # cards + study API routes
-│   │   ├── main.py             # FastAPI + operational endpoints
-│   │   ├── models.py           # persistent domain models
-│   │   └── seed.py             # curriculum loader + idempotent seeder
-│   ├── tests/                  # domain, API, operations, seed regression tests
-│   └── Dockerfile
-├── frontend/
-│   ├── src/pages/              # Memory Quest, Deck Lab, Deck Map
-│   ├── src/api.ts              # typed API client
-│   └── Dockerfile
-├── docs/                       # MkDocs + Platform Engineering docs
-├── docker-compose.yml
-└── mkdocs.yml
-```
+FlashQuest’s now demonstrates more than CRUD:
 
----
+- reusable product/data modeling;
+- account ownership boundaries;
+- email-verification lifecycle;
+- password/token handling;
+- explicit migration + seed lifecycle;
+- environment-driven deployment configuration;
+- liveness/readiness semantics;
+- request correlation;
+- non-root containers;
+- PostgreSQL migration smoke tests;
+- multi-runtime CI quality gates;
+- a public demo separated from private user content.
 
-# 🎯 Why FlashQuest’s belongs in a Platform Engineering portfolio
-
-FlashQuest’s is both **the project and the practice environment**.
-
-You can use it to prepare answers for questions such as:
-
-- What is the difference between liveness and readiness?
-- Why does this Kubernetes Service have no endpoints?
-- Why does a test pass locally and fail in CI?
-- Why does Terraform want to replace this database?
-- How would you roll out a risky schema migration?
-- Why are DB connections exhausted?
-- How should retries, backoff, jitter, and idempotency interact?
-- How do request IDs help during distributed troubleshooting?
-- What is mitigation versus root-cause analysis during an incident?
-
-At the same time, the repository gives you concrete implementation decisions to discuss:
-
-- dependency-aware startup;
-- reproducible environment data;
-- explicit schema lifecycle management;
-- non-root container execution;
-- CI migration validation;
-- operational endpoint design;
-- durable versus ephemeral state boundaries;
-- automated regression coverage for the study curriculum itself.
-
----
-
-## Stop / reset
-
-Stop the stack:
-
-```bash
-docker compose down
-```
-
-Delete the local PostgreSQL volume and start from scratch:
-
-```bash
-docker compose down -v
-```
-
-Then repeat **start → migrate → seed** from the Quick start section.
+It remains grounded: this is a portfolio-grade full-stack platform, not a claim of hyperscale production operation.
 
 ---
 
@@ -479,6 +334,6 @@ Then repeat **start → migrate → seed** from the Quick start section.
 
 ### ⚡ FlashQuest’s
 
-**Learn it. Break it. Fix it. Remember it.**
+**Featured Platform Engineering. Your decks next.**
 
 </div>

--- a/backend/alembic/versions/b7f8c1a2d3e4_add_reusable_card_metadata.py
+++ b/backend/alembic/versions/b7f8c1a2d3e4_add_reusable_card_metadata.py
@@ -1,0 +1,52 @@
+"""add reusable card metadata
+
+Revision ID: b7f8c1a2d3e4
+Revises: 4fb175d7540d
+Create Date: 2026-08-18
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b7f8c1a2d3e4"
+down_revision: Union[str, Sequence[str], None] = "4fb175d7540d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add reusable deck metadata and built-in content protection flags."""
+    op.add_column(
+        "card",
+        sa.Column("topic", sa.String(), nullable=False, server_default="Custom"),
+    )
+    op.add_column(
+        "card",
+        sa.Column("domain", sa.String(), nullable=False, server_default="General"),
+    )
+    op.add_column(
+        "card",
+        sa.Column("kind", sa.String(), nullable=False, server_default="concept"),
+    )
+    op.add_column(
+        "card",
+        sa.Column("is_builtin", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.create_index(op.f("ix_card_topic"), "card", ["topic"], unique=False)
+    op.create_index(op.f("ix_card_domain"), "card", ["domain"], unique=False)
+    op.create_index(op.f("ix_card_kind"), "card", ["kind"], unique=False)
+    op.create_index(op.f("ix_card_is_builtin"), "card", ["is_builtin"], unique=False)
+
+
+def downgrade() -> None:
+    """Remove reusable deck metadata."""
+    op.drop_index(op.f("ix_card_is_builtin"), table_name="card")
+    op.drop_index(op.f("ix_card_kind"), table_name="card")
+    op.drop_index(op.f("ix_card_domain"), table_name="card")
+    op.drop_index(op.f("ix_card_topic"), table_name="card")
+    op.drop_column("card", "is_builtin")
+    op.drop_column("card", "kind")
+    op.drop_column("card", "domain")
+    op.drop_column("card", "topic")

--- a/backend/alembic/versions/c8a9d2e3f4b5_add_accounts_and_decks.py
+++ b/backend/alembic/versions/c8a9d2e3f4b5_add_accounts_and_decks.py
@@ -1,0 +1,133 @@
+"""add accounts decks and verification
+
+Revision ID: c8a9d2e3f4b5
+Revises: b7f8c1a2d3e4
+Create Date: 2026-08-18
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c8a9d2e3f4b5"
+down_revision: Union[str, Sequence[str], None] = "b7f8c1a2d3e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add verified accounts, owned decks, sessions, and email verification tokens."""
+    op.create_table(
+        "app_user",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email", name="uq_app_user_email"),
+    )
+    op.create_index(op.f("ix_app_user_email"), "app_user", ["email"], unique=False)
+    op.create_index(
+        op.f("ix_app_user_is_verified"), "app_user", ["is_verified"], unique=False
+    )
+
+    op.create_table(
+        "deck",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("owner_id", sa.Integer(), nullable=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False, server_default=""),
+        sa.Column("is_builtin", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["owner_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug", name="uq_deck_slug"),
+    )
+    op.create_index(op.f("ix_deck_owner_id"), "deck", ["owner_id"], unique=False)
+    op.create_index(op.f("ix_deck_title"), "deck", ["title"], unique=False)
+    op.create_index(op.f("ix_deck_slug"), "deck", ["slug"], unique=False)
+    op.create_index(op.f("ix_deck_is_builtin"), "deck", ["is_builtin"], unique=False)
+
+    op.create_table(
+        "authsession",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash", name="uq_authsession_token_hash"),
+    )
+    op.create_index(
+        op.f("ix_authsession_user_id"), "authsession", ["user_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_authsession_token_hash"), "authsession", ["token_hash"], unique=False
+    )
+
+    op.create_table(
+        "emailverificationtoken",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash", name="uq_emailverificationtoken_token_hash"),
+    )
+    op.create_index(
+        op.f("ix_emailverificationtoken_user_id"),
+        "emailverificationtoken",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_emailverificationtoken_token_hash"),
+        "emailverificationtoken",
+        ["token_hash"],
+        unique=False,
+    )
+
+    op.add_column("card", sa.Column("deck_id", sa.Integer(), nullable=True))
+    op.create_foreign_key("fk_card_deck_id", "card", "deck", ["deck_id"], ["id"])
+    op.create_index(op.f("ix_card_deck_id"), "card", ["deck_id"], unique=False)
+
+    # Reserve user id 0 for the anonymous public demo. Existing installs used 1.
+    op.execute(sa.text("UPDATE usercard SET user_id = 0 WHERE user_id = 1"))
+    op.execute(sa.text("UPDATE review SET user_id = 0 WHERE user_id = 1"))
+
+
+def downgrade() -> None:
+    """Remove account/deck schema and restore the legacy demo user id."""
+    op.execute(sa.text("UPDATE usercard SET user_id = 1 WHERE user_id = 0"))
+    op.execute(sa.text("UPDATE review SET user_id = 1 WHERE user_id = 0"))
+
+    op.drop_index(op.f("ix_card_deck_id"), table_name="card")
+    op.drop_constraint("fk_card_deck_id", "card", type_="foreignkey")
+    op.drop_column("card", "deck_id")
+
+    op.drop_index(op.f("ix_emailverificationtoken_token_hash"), table_name="emailverificationtoken")
+    op.drop_index(op.f("ix_emailverificationtoken_user_id"), table_name="emailverificationtoken")
+    op.drop_table("emailverificationtoken")
+
+    op.drop_index(op.f("ix_authsession_token_hash"), table_name="authsession")
+    op.drop_index(op.f("ix_authsession_user_id"), table_name="authsession")
+    op.drop_table("authsession")
+
+    op.drop_index(op.f("ix_deck_is_builtin"), table_name="deck")
+    op.drop_index(op.f("ix_deck_slug"), table_name="deck")
+    op.drop_index(op.f("ix_deck_title"), table_name="deck")
+    op.drop_index(op.f("ix_deck_owner_id"), table_name="deck")
+    op.drop_table("deck")
+
+    op.drop_index(op.f("ix_app_user_is_verified"), table_name="app_user")
+    op.drop_index(op.f("ix_app_user_email"), table_name="app_user")
+    op.drop_table("app_user")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,11 +8,25 @@ class Settings(BaseSettings):
 
     DATABASE_URL: str = "postgresql://postgres:postgres@localhost:5432/flashcards"
     APP_ENV: str = "development"
-    APP_VERSION: str = "1.0.0"
+    APP_VERSION: str = "1.1.0"
     LOG_LEVEL: str = "INFO"
     # Accept JSON-looking or comma-separated text; main.py normalizes it.
     ALLOWED_ORIGINS: str = ""
-    # Server-side only. Built-in demo cards cannot be deleted when this is blank.
+
+    # Authentication. Override JWT_SECRET in every hosted environment.
+    JWT_SECRET: str = "dev-only-change-me"
+    JWT_ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_MINUTES: int = 60 * 24 * 7
+
+    # Email verification. `console` prints the verification URL locally/tests.
+    # Hosted environments should use `resend` with RESEND_API_KEY configured.
+    EMAIL_DELIVERY_MODE: str = "console"
+    RESEND_API_KEY: str = ""
+    EMAIL_FROM: str = "FlashQuest <onboarding@resend.dev>"
+    VERIFICATION_TOKEN_MINUTES: int = 60
+    FRONTEND_URL: str = "http://localhost:5173"
+
+    # Server-side only. Built-in demo cards cannot be deleted/reset when blank.
     DEMO_DELETE_PASSWORD: str = ""
 
     model_config = SettingsConfigDict(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,9 +13,7 @@ class Settings(BaseSettings):
     # Accept JSON-looking or comma-separated text; main.py normalizes it.
     ALLOWED_ORIGINS: str = ""
 
-    # Authentication. Override JWT_SECRET in every hosted environment.
-    JWT_SECRET: str = "dev-only-change-me"
-    JWT_ALGORITHM: str = "HS256"
+    # Opaque bearer sessions are stored only as hashes in PostgreSQL.
     ACCESS_TOKEN_MINUTES: int = 60 * 24 * 7
 
     # Email verification. `console` prints the verification URL locally/tests.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     # Accept JSON-looking or comma-separated text; main.py normalizes it.
     ALLOWED_ORIGINS: str = ""
+    # Server-side only. Built-in demo cards cannot be deleted when this is blank.
+    DEMO_DELETE_PASSWORD: str = ""
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/app/email_service.py
+++ b/backend/app/email_service.py
@@ -1,0 +1,85 @@
+"""Email verification token creation and delivery."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
+
+import httpx
+from sqlmodel import Session, select
+
+from .config import settings
+from .models import EmailVerificationToken, User
+from .security import hash_token, new_token
+
+
+def create_verification_token(session: Session, user: User) -> str:
+    """Invalidate older verification links and return a fresh raw token."""
+    now = datetime.now(timezone.utc)
+    existing = session.exec(
+        select(EmailVerificationToken).where(
+            EmailVerificationToken.user_id == user.id,
+            EmailVerificationToken.used_at.is_(None),  # type: ignore[union-attr]
+        )
+    ).all()
+    for token in existing:
+        token.used_at = now
+        session.add(token)
+
+    raw = new_token()
+    session.add(
+        EmailVerificationToken(
+            user_id=int(user.id or 0),
+            token_hash=hash_token(raw),
+            expires_at=now + timedelta(minutes=settings.VERIFICATION_TOKEN_MINUTES),
+        )
+    )
+    session.commit()
+    return raw
+
+
+def verification_url(raw_token: str) -> str:
+    """Build the frontend URL users click from the verification email."""
+    return (
+        f"{settings.FRONTEND_URL.rstrip('/')}/verify-email"
+        f"?token={quote(raw_token, safe='')}"
+    )
+
+
+def send_verification_email(user: User, raw_token: str) -> None:
+    """Deliver a verification link via Resend or print it for local development."""
+    url = verification_url(raw_token)
+    mode = settings.EMAIL_DELIVERY_MODE.strip().lower()
+    if mode == "console":
+        print(f"FlashQuest verification for {user.email}: {url}")
+        return
+    if mode != "resend":
+        raise RuntimeError(f"Unsupported EMAIL_DELIVERY_MODE: {mode}")
+    if not settings.RESEND_API_KEY:
+        raise RuntimeError("RESEND_API_KEY is not configured")
+
+    response = httpx.post(
+        "https://api.resend.com/emails",
+        headers={
+            "Authorization": f"Bearer {settings.RESEND_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "from": settings.EMAIL_FROM,
+            "to": [user.email],
+            "subject": "Verify your FlashQuest email",
+            "html": (
+                "<div style='font-family:system-ui,sans-serif;line-height:1.6'>"
+                "<h2>Unlock your FlashQuest deck builder 🎮</h2>"
+                f"<p>Hey {user.display_name}, click the button below to verify your email.</p>"
+                f"<p><a href='{url}' style='display:inline-block;padding:12px 18px;"
+                "background:#faa307;color:#03071e;border-radius:10px;font-weight:800;"
+                "text-decoration:none'>Verify my email</a></p>"
+                f"<p>This link expires in {settings.VERIFICATION_TOKEN_MINUTES} minutes.</p>"
+                "<p>If you did not create this account, you can ignore this email.</p>"
+                "</div>"
+            ),
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 
 from .config import settings
 from .db import get_session
-from .routers import cards, study
+from .routers import auth, cards, decks, study
 
 
 def _allowed_origins() -> list[str]:
@@ -69,6 +69,8 @@ async def request_context(request: Request, call_next):
     return response
 
 
+app.include_router(auth.router)
+app.include_router(decks.router)
 app.include_router(cards.router)
 app.include_router(study.router)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-"""Database and API models for FlashQuest’s study engine."""
+"""Database and API models for FlashQuest’s reusable study engine."""
 
 from __future__ import annotations
 
@@ -6,27 +6,126 @@ from datetime import datetime, timezone
 from typing import Dict, Optional
 
 import sqlalchemy as sa
+from pydantic import EmailStr
 from sqlmodel import Field, SQLModel
 
 
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+class User(SQLModel, table=True):
+    """A FlashQuest account. Email must be verified before deck creation."""
+
+    __tablename__ = "app_user"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, sa_type=sa.String)
+    display_name: str = Field(sa_type=sa.String)
+    password_hash: str = Field(sa_type=sa.String)
+    is_verified: bool = Field(default=False, index=True, sa_type=sa.Boolean)
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+
+
+class UserRead(SQLModel):
+    id: int
+    email: EmailStr
+    display_name: str
+    is_verified: bool
+
+
+class SignupRequest(SQLModel):
+    display_name: str
+    email: EmailStr
+    password: str
+
+
+class LoginRequest(SQLModel):
+    email: EmailStr
+    password: str
+
+
+class AuthSession(SQLModel, table=True):
+    """Hashed opaque bearer session. Raw tokens are never stored."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="app_user.id", index=True, sa_type=sa.Integer)
+    token_hash: str = Field(index=True, sa_type=sa.String)
+    expires_at: datetime = Field(sa_type=sa.DateTime(timezone=True))
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    revoked_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
+class EmailVerificationToken(SQLModel, table=True):
+    """One-time hashed token used to verify an account email address."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="app_user.id", index=True, sa_type=sa.Integer)
+    token_hash: str = Field(index=True, sa_type=sa.String)
+    expires_at: datetime = Field(sa_type=sa.DateTime(timezone=True))
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    used_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
+class DeckBase(SQLModel):
+    title: str
+    description: str = ""
+
+
+class DeckCreate(DeckBase):
+    """Payload for a verified user to create a custom deck."""
+
+
+class DeckUpdate(SQLModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+
+class DeckRead(DeckBase):
+    id: int
+    slug: str
+    is_builtin: bool
+    owner_id: Optional[int]
+    card_count: int = 0
+    created_at: datetime
+
+
+class Deck(SQLModel, table=True):
+    """A topic pack. Built-ins are public; custom decks belong to one user."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    owner_id: Optional[int] = Field(
+        default=None, foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    title: str = Field(index=True, sa_type=sa.String)
+    slug: str = Field(index=True, sa_type=sa.String)
+    description: str = Field(default="", sa_type=sa.String)
+    is_builtin: bool = Field(default=False, index=True, sa_type=sa.Boolean)
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+
+
 class CardBase(SQLModel):
-    """Fields used when creating a user-owned study card."""
+    """Fields shared by card create/read models."""
 
     word: str
     definition: str
-    topic: str = "Custom"
     domain: str = "General"
     kind: str = "concept"
 
 
 class CardCreate(CardBase):
-    """Payload used to create a custom study card."""
+    """Payload used to create a card inside an owned deck."""
+
+    deck_id: int
 
 
 class CardRead(CardBase):
     """Public card representation."""
 
     id: int
+    deck_id: Optional[int] = None
+    topic: str = "Custom"
     created_at: datetime
     is_builtin: bool = False
 
@@ -39,36 +138,39 @@ class CardAdminRead(CardRead):
 
 
 class CardUpdate(SQLModel):
-    """Fields a user may customize on a card."""
+    """Fields a user may customize on an owned card."""
 
     word: Optional[str] = None
     definition: Optional[str] = None
-    topic: Optional[str] = None
     domain: Optional[str] = None
     kind: Optional[str] = None
 
 
 class Card(SQLModel, table=True):
-    """A reusable study card that can belong to any topic or learning mode."""
+    """A study card belonging to a built-in or user-owned deck."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
+    deck_id: Optional[int] = Field(
+        default=None, foreign_key="deck.id", index=True, sa_type=sa.Integer
+    )
     word: str = Field(sa_type=sa.String)
     definition: str = Field(sa_type=sa.String)
+    # `topic` remains denormalized for backwards-compatible exports and diagnostics.
     topic: str = Field(default="Custom", index=True, sa_type=sa.String)
     domain: str = Field(default="General", index=True, sa_type=sa.String)
     kind: str = Field(default="concept", index=True, sa_type=sa.String)
     is_builtin: bool = Field(default=False, index=True, sa_type=sa.Boolean)
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        sa_type=sa.DateTime(timezone=True),
-    )
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
 
 
 class UserCard(SQLModel, table=True):
-    """Per-user spaced-repetition state for a card."""
+    """Per-user spaced-repetition state for a card.
+
+    User id 0 is reserved for the anonymous public demo. Authenticated users start at 1.
+    """
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: Optional[int] = Field(default=1, index=True, sa_type=sa.Integer)
+    user_id: Optional[int] = Field(default=0, index=True, sa_type=sa.Integer)
     card_id: int = Field(foreign_key="card.id", index=True, sa_type=sa.Integer)
     bin: int = Field(default=0, sa_type=sa.Integer)
     wrong_count: int = Field(default=0, sa_type=sa.Integer)
@@ -83,18 +185,15 @@ class Review(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     card_id: int = Field(foreign_key="card.id", sa_type=sa.Integer)
-    user_id: Optional[int] = Field(default=1, index=True, sa_type=sa.Integer)
+    user_id: Optional[int] = Field(default=0, index=True, sa_type=sa.Integer)
     result: str = Field(sa_type=sa.String)
     from_bin: int = Field(sa_type=sa.Integer)
     to_bin: int = Field(sa_type=sa.Integer)
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
-        sa_type=sa.DateTime(timezone=True),
-    )
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
 
 
 class CardStats(SQLModel):
-    """Aggregated study stats for the default demo user."""
+    """Aggregated study stats for the selected user/deck."""
 
     total_cards: int
     active: int

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,105 +1,63 @@
-"""Database and Pydantic models for the flashcards app.
-
-This module defines:
-- SQLModel ORM tables (Card, UserCard, Review)
-- Pydantic schemas for requests/responses (CardCreate, CardRead, CardAdminRead, CardUpdate, CardStats)
-
-Notes:
-    We explicitly set `sa_type=` on fields so Alembic autogenerate emits plain
-    SQLAlchemy types (e.g., `sa.String`) instead of `AutoString`.
-"""
+"""Database and API models for FlashQuest’s study engine."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 import sqlalchemy as sa
-from sqlmodel import SQLModel, Field
+from sqlmodel import Field, SQLModel
 
 
 class CardBase(SQLModel):
-    """Base fields shared by Card schemas.
-
-    Attributes:
-        word: The vocabulary term.
-        definition: The meaning of the term.
-    """
+    """Fields used when creating a user-owned study card."""
 
     word: str
     definition: str
+    topic: str = "Custom"
+    domain: str = "General"
+    kind: str = "concept"
 
 
 class CardCreate(CardBase):
-    """Payload schema used to create a new card.
-
-    Inherits:
-        CardBase
-    """
-
-    pass
+    """Payload used to create a custom study card."""
 
 
 class CardRead(CardBase):
-    """Response schema for reading a card.
-
-    Attributes:
-        id: Primary key of the card.
-        created_at: Timestamp when the card was created (UTC).
-    """
+    """Public card representation."""
 
     id: int
     created_at: datetime
+    is_builtin: bool = False
 
 
-class CardAdminRead(SQLModel):
-    """Admin response schema with per-user study state.
+class CardAdminRead(CardRead):
+    """Card representation with spaced-repetition state."""
 
-    Attributes:
-        id: Card id.
-        word: The vocabulary term.
-        definition: The meaning of the term.
-        created_at: Card creation timestamp (UTC).
-        bin: Current spaced-repetition bin for the default user (0–11).
-        status: 'active', 'never', or 'hard_to_remember'.
-    """
-
-    id: int
-    word: str
-    definition: str
-    created_at: datetime
     bin: int
     status: str
 
 
 class CardUpdate(SQLModel):
-    """PATCH/PUT schema for updating a card.
-
-    Notes:
-        All fields are optional to support partial updates.
-
-    Attributes:
-        word: Optional new word value.
-        definition: Optional new definition value.
-    """
+    """Fields a user may customize on a card."""
 
     word: Optional[str] = None
     definition: Optional[str] = None
+    topic: Optional[str] = None
+    domain: Optional[str] = None
+    kind: Optional[str] = None
 
 
 class Card(SQLModel, table=True):
-    """ORM model representing a vocabulary flashcard.
-
-    Attributes:
-        id: Primary key.
-        word: The vocabulary term.
-        definition: The meaning of the term.
-        created_at: UTC timestamp when the card was created.
-    """
+    """A reusable study card that can belong to any topic or learning mode."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     word: str = Field(sa_type=sa.String)
     definition: str = Field(sa_type=sa.String)
+    topic: str = Field(default="Custom", index=True, sa_type=sa.String)
+    domain: str = Field(default="General", index=True, sa_type=sa.String)
+    kind: str = Field(default="concept", index=True, sa_type=sa.String)
+    is_builtin: bool = Field(default=False, index=True, sa_type=sa.Boolean)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_type=sa.DateTime(timezone=True),
@@ -107,17 +65,7 @@ class Card(SQLModel, table=True):
 
 
 class UserCard(SQLModel, table=True):
-    """ORM model tracking a user's progress on a specific card.
-
-    Attributes:
-        id: Primary key.
-        user_id: User identifier (MVP uses default=1).
-        card_id: Foreign key to `Card.id`.
-        bin: Current spaced-repetition bin (0–11).
-        wrong_count: Lifetime count of incorrect answers.
-        next_review_at: Next time the card becomes due (UTC).
-        status: 'active', 'never', or 'hard_to_remember'.
-    """
+    """Per-user spaced-repetition state for a card."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     user_id: Optional[int] = Field(default=1, index=True, sa_type=sa.Integer)
@@ -131,17 +79,7 @@ class UserCard(SQLModel, table=True):
 
 
 class Review(SQLModel, table=True):
-    """ORM model recording an individual study attempt.
-
-    Attributes:
-        id: Primary key.
-        card_id: Foreign key to `Card.id`.
-        user_id: User identifier (MVP uses default=1).
-        result: 'correct' or 'wrong'.
-        from_bin: Bin before the answer.
-        to_bin: Bin after applying the answer.
-        created_at: UTC timestamp when the review was recorded.
-    """
+    """Audit record for one answer in the study loop."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     card_id: int = Field(foreign_key="card.id", sa_type=sa.Integer)
@@ -156,15 +94,7 @@ class Review(SQLModel, table=True):
 
 
 class CardStats(SQLModel):
-    """Aggregated stats for admin dashboard.
-
-    Attributes:
-        total_cards: Number of cards tracked for the default user.
-        active: Count of cards with status 'active'.
-        never: Count of cards with status 'never' (last bin).
-        hard_to_remember: Count of cards hidden due to many wrong answers.
-        by_bin: A mapping of bin index (0..11) to count.
-    """
+    """Aggregated study stats for the default demo user."""
 
     total_cards: int
     active: int

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,178 @@
+"""Account signup, email verification, login, and session endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from ..db import get_session
+from ..email_service import create_verification_token, send_verification_email
+from ..models import (
+    AuthSession,
+    EmailVerificationToken,
+    LoginRequest,
+    SignupRequest,
+    User,
+    UserRead,
+)
+from ..security import (
+    bearer_scheme,
+    create_auth_session,
+    get_current_user,
+    hash_password,
+    hash_token,
+    verify_password,
+)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _user_read(user: User) -> UserRead:
+    return UserRead(
+        id=int(user.id or 0),
+        email=user.email,
+        display_name=user.display_name,
+        is_verified=user.is_verified,
+    )
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@router.post("/signup", status_code=201)
+def signup(payload: SignupRequest, session: Session = Depends(get_session)) -> dict:
+    """Create an unverified account and send a one-time verification email."""
+    email = str(payload.email).strip().lower()
+    name = payload.display_name.strip()
+    if len(name) < 2:
+        raise HTTPException(status_code=422, detail="Display name is too short")
+    if len(payload.password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+
+    if session.exec(select(User).where(User.email == email)).first() is not None:
+        raise HTTPException(status_code=409, detail="An account with that email already exists")
+
+    user = User(
+        email=email,
+        display_name=name,
+        password_hash=hash_password(payload.password),
+        is_verified=False,
+    )
+    session.add(user)
+    try:
+        session.commit()
+        session.refresh(user)
+    except IntegrityError as exc:
+        session.rollback()
+        raise HTTPException(status_code=409, detail="Account already exists") from exc
+
+    raw = create_verification_token(session, user)
+    try:
+        send_verification_email(user, raw)
+    except (RuntimeError, httpx.HTTPError) as exc:  # type: ignore[name-defined]
+        raise HTTPException(
+            status_code=503,
+            detail="Account created, but the verification email could not be sent. Use resend verification.",
+        ) from exc
+
+    return {
+        "ok": True,
+        "message": "Check your inbox to verify your email and unlock deck creation.",
+        "email": user.email,
+    }
+
+
+@router.post("/resend-verification")
+def resend_verification(payload: dict, session: Session = Depends(get_session)) -> dict:
+    """Send a new verification link without revealing whether an account exists."""
+    email = str(payload.get("email", "")).strip().lower()
+    user = session.exec(select(User).where(User.email == email)).first()
+    if user is not None and not user.is_verified:
+        raw = create_verification_token(session, user)
+        try:
+            send_verification_email(user, raw)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503, detail="Verification email service is unavailable"
+            ) from exc
+    return {"ok": True, "message": "If that account needs verification, a new link was sent."}
+
+
+@router.post("/verify")
+def verify_email(payload: dict, session: Session = Depends(get_session)) -> dict:
+    """Verify an email using a one-time opaque token."""
+    raw = str(payload.get("token", "")).strip()
+    if not raw:
+        raise HTTPException(status_code=422, detail="Verification token is required")
+
+    token = session.exec(
+        select(EmailVerificationToken).where(
+            EmailVerificationToken.token_hash == hash_token(raw)
+        )
+    ).first()
+    if token is None or token.used_at is not None:
+        raise HTTPException(status_code=400, detail="Verification link is invalid or already used")
+    if _aware_utc(token.expires_at) <= datetime.now(timezone.utc):
+        raise HTTPException(status_code=400, detail="Verification link expired. Request a new one.")
+
+    user = session.get(User, token.user_id)
+    if user is None:
+        raise HTTPException(status_code=400, detail="Verification account no longer exists")
+
+    user.is_verified = True
+    token.used_at = datetime.now(timezone.utc)
+    session.add(user)
+    session.add(token)
+    session.commit()
+    return {"ok": True, "message": "Email verified. You can now make your own decks."}
+
+
+@router.post("/login")
+def login(payload: LoginRequest, session: Session = Depends(get_session)) -> dict:
+    """Exchange email/password for an opaque bearer session."""
+    email = str(payload.email).strip().lower()
+    user = session.exec(select(User).where(User.email == email)).first()
+    if user is None or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Email or password is incorrect")
+    if not user.is_verified:
+        raise HTTPException(status_code=403, detail="Verify your email before signing in")
+
+    access_token = create_auth_session(session, int(user.id or 0))
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": _user_read(user).model_dump(mode="json"),
+    }
+
+
+@router.get("/me", response_model=UserRead)
+def me(user: User = Depends(get_current_user)) -> UserRead:
+    """Return the current signed-in account."""
+    return _user_read(user)
+
+
+@router.post("/logout")
+def logout(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+) -> dict:
+    """Revoke the current bearer session."""
+    if credentials is None:
+        return {"ok": True}
+    auth_session = session.exec(
+        select(AuthSession).where(
+            AuthSession.token_hash == hash_token(credentials.credentials)
+        )
+    ).first()
+    if auth_session is not None and auth_session.revoked_at is None:
+        auth_session.revoked_at = datetime.now(timezone.utc)
+        session.add(auth_session)
+        session.commit()
+    return {"ok": True}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.exc import IntegrityError
@@ -76,7 +77,7 @@ def signup(payload: SignupRequest, session: Session = Depends(get_session)) -> d
     raw = create_verification_token(session, user)
     try:
         send_verification_email(user, raw)
-    except (RuntimeError, httpx.HTTPError) as exc:  # type: ignore[name-defined]
+    except (RuntimeError, httpx.HTTPError) as exc:
         raise HTTPException(
             status_code=503,
             detail="Account created, but the verification email could not be sent. Use resend verification.",
@@ -98,7 +99,7 @@ def resend_verification(payload: dict, session: Session = Depends(get_session)) 
         raw = create_verification_token(session, user)
         try:
             send_verification_email(user, raw)
-        except Exception as exc:
+        except (RuntimeError, httpx.HTTPError) as exc:
             raise HTTPException(
                 status_code=503, detail="Verification email service is unavailable"
             ) from exc

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -1,11 +1,12 @@
-# app/routers/cards.py
+"""Card CRUD, demo protection, and scoped card-management endpoints."""
+
 from __future__ import annotations
 
 from hmac import compare_digest
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from sqlalchemy import asc, desc, func, or_, update
+from sqlalchemy import and_, desc, func, or_, update
 from sqlmodel import Session, delete, select
 
 from app.config import settings
@@ -17,32 +18,33 @@ from app.models import (
     CardRead,
     CardStats,
     CardUpdate,
+    Deck,
     Review,
+    User,
     UserCard,
 )
+from app.security import DEMO_USER_ID, get_optional_user, require_verified_user
 
 router = APIRouter()
-DEFAULT_USER_ID = 1
 VALID_KINDS = {"concept", "lab"}
 
 
-def _clean_card_fields(data: dict[str, Any]) -> dict[str, Any]:
-    """Normalize user-provided reusable deck metadata."""
-    for field in ("word", "definition", "topic", "domain", "kind"):
-        if field in data and isinstance(data[field], str):
-            data[field] = data[field].strip()
-    data["topic"] = data.get("topic") or "Custom"
-    data["domain"] = data.get("domain") or "General"
-    data["kind"] = (data.get("kind") or "concept").lower()
-    if data["kind"] not in VALID_KINDS:
+def _clean_text(value: str, field: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise HTTPException(status_code=422, detail=f"{field} is required")
+    return cleaned
+
+
+def _clean_kind(value: str) -> str:
+    kind = value.strip().lower() or "concept"
+    if kind not in VALID_KINDS:
         raise HTTPException(status_code=422, detail="kind must be 'concept' or 'lab'")
-    if not data.get("word") or not data.get("definition"):
-        raise HTTPException(status_code=422, detail="question and answer are required")
-    return data
+    return kind
 
 
 def _require_demo_password(password: str | None) -> None:
-    """Require the server-side demo password for global/built-in destructive actions."""
+    """Require the server-side demo password for built-in destructive actions."""
     expected = settings.DEMO_DELETE_PASSWORD
     if not expected:
         raise HTTPException(
@@ -53,67 +55,106 @@ def _require_demo_password(password: str | None) -> None:
         raise HTTPException(status_code=403, detail="Incorrect demo admin password")
 
 
-@router.post("/cards", response_model=CardRead)
+def _owned_deck(session: Session, deck_id: int, user: User) -> Deck:
+    deck = session.get(Deck, deck_id)
+    if deck is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    if deck.is_builtin or deck.owner_id != user.id:
+        raise HTTPException(status_code=403, detail="You can only change your own decks")
+    return deck
+
+
+def _owned_card(session: Session, card_id: int, user: User) -> tuple[Card, Deck]:
+    card = session.get(Card, card_id)
+    if card is None:
+        raise HTTPException(status_code=404, detail="Card not found")
+    if card.is_builtin:
+        raise HTTPException(
+            status_code=403,
+            detail="Built-in cards are read-only. Copy the featured deck to customize it.",
+        )
+    if card.deck_id is None:
+        raise HTTPException(status_code=403, detail="Legacy card is not attached to your deck")
+    return card, _owned_deck(session, card.deck_id, user)
+
+
+@router.post("/cards", response_model=CardRead, status_code=201)
 def create_card(
-    payload: CardCreate, session: Session = Depends(get_session)
+    payload: CardCreate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
 ) -> CardRead:
-    """Create a user-owned card in any topic/domain and initialize progress."""
-    data = _clean_card_fields(payload.model_dump())
-    card = Card(**data, is_builtin=False)
+    """Create a card in a deck owned by the verified user."""
+    deck = _owned_deck(session, payload.deck_id, user)
+    card = Card(
+        deck_id=deck.id,
+        word=_clean_text(payload.word, "question"),
+        definition=_clean_text(payload.definition, "answer"),
+        topic=deck.title,
+        domain=payload.domain.strip() or "General",
+        kind=_clean_kind(payload.kind),
+        is_builtin=False,
+    )
     session.add(card)
+    session.flush()
+    session.add(UserCard(user_id=user.id, card_id=int(card.id or 0), bin=0))
     session.commit()
     session.refresh(card)
-
-    session.add(UserCard(user_id=DEFAULT_USER_ID, card_id=card.id))
-    session.commit()
     return card
 
 
 @router.get("/cards", response_model=List[CardRead])
-def list_cards(session: Session = Depends(get_session)) -> List[CardRead]:
-    """Return every card in stable ID order."""
-    rows = session.exec(select(Card).order_by(asc(cast(Any, Card.id)))).all()
+def list_cards(
+    deck_id: int | None = Query(None),
+    user: User | None = Depends(get_optional_user),
+    session: Session = Depends(get_session),
+) -> List[CardRead]:
+    """List public built-ins plus cards owned by the signed-in user."""
+    stmt = select(Card).outerjoin(Deck, Card.deck_id == Deck.id)
+    if user is None:
+        stmt = stmt.where(Card.is_builtin == True)  # noqa: E712
+    else:
+        stmt = stmt.where(
+            or_(Card.is_builtin == True, Deck.owner_id == user.id)  # noqa: E712
+        )
+    if deck_id is not None:
+        stmt = stmt.where(Card.deck_id == deck_id)
+    rows = session.exec(stmt.order_by(cast(Any, Card.id))).all()
     return list(rows)
 
 
 @router.put("/cards/{card_id}", response_model=CardRead)
 def replace_card(
-    card_id: int, payload: CardUpdate, session: Session = Depends(get_session)
+    card_id: int,
+    payload: CardUpdate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
 ) -> CardRead:
-    """Update the editable fields of a custom card."""
-    return _update_card(card_id, payload, session)
+    return _update_card(card_id, payload, user, session)
 
 
 @router.patch("/cards/{card_id}", response_model=CardRead)
 def update_card(
-    card_id: int, payload: CardUpdate, session: Session = Depends(get_session)
+    card_id: int,
+    payload: CardUpdate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
 ) -> CardRead:
-    """Partially update a custom card."""
-    return _update_card(card_id, payload, session)
+    return _update_card(card_id, payload, user, session)
 
 
-def _update_card(card_id: int, payload: CardUpdate, session: Session) -> CardRead:
-    card = session.get(Card, card_id)
-    if not card:
-        raise HTTPException(status_code=404, detail="Card not found")
-    if card.is_builtin:
-        raise HTTPException(
-            status_code=403,
-            detail="Built-in demo cards are read-only; make a custom copy to edit them",
-        )
-
+def _update_card(card_id: int, payload: CardUpdate, user: User, session: Session) -> CardRead:
+    card, deck = _owned_card(session, card_id, user)
     data = payload.model_dump(exclude_unset=True)
-    merged = {
-        "word": data.get("word", card.word),
-        "definition": data.get("definition", card.definition),
-        "topic": data.get("topic", card.topic),
-        "domain": data.get("domain", card.domain),
-        "kind": data.get("kind", card.kind),
-    }
-    cleaned = _clean_card_fields(merged)
-    for field, value in cleaned.items():
-        setattr(card, field, value)
-
+    if "word" in data and data["word"] is not None:
+        card.word = _clean_text(data["word"], "question")
+    if "definition" in data and data["definition"] is not None:
+        card.definition = _clean_text(data["definition"], "answer")
+    if "domain" in data and data["domain"] is not None:
+        card.domain = data["domain"].strip() or "General"
+    if "kind" in data and data["kind"] is not None:
+        card.kind = _clean_kind(data["kind"])
+    card.topic = deck.title
     session.add(card)
     session.commit()
     session.refresh(card)
@@ -123,28 +164,24 @@ def _update_card(card_id: int, payload: CardUpdate, session: Session) -> CardRea
 @router.delete("/cards/{card_id}")
 def delete_card(
     card_id: int,
+    user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
     demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
 ) -> Dict[str, bool]:
-    """Delete a card; built-in demo cards require the server-side admin password."""
+    """Delete an owned card; built-in cards require the server-side admin password."""
     card = session.get(Card, card_id)
-    if not card:
+    if card is None:
         raise HTTPException(status_code=404, detail="Card not found")
+
     if card.is_builtin:
         _require_demo_password(demo_password)
+    else:
+        if user is None:
+            raise HTTPException(status_code=401, detail="Sign in required")
+        _owned_card(session, card_id, user)
 
-    session.exec(
-        delete(Review).where(
-            Review.card_id == card_id,
-            Review.user_id == DEFAULT_USER_ID,
-        )
-    )
-    session.exec(
-        delete(UserCard).where(
-            UserCard.card_id == card_id,
-            UserCard.user_id == DEFAULT_USER_ID,
-        )
-    )
+    session.exec(delete(Review).where(Review.card_id == card_id))
+    session.exec(delete(UserCard).where(UserCard.card_id == card_id))
     session.delete(card)
     session.commit()
     return {"ok": True}
@@ -152,18 +189,31 @@ def delete_card(
 
 @router.get("/cards/admin", response_model=List[CardAdminRead])
 def list_cards_admin(
-    q: Optional[str] = Query(
-        None, description="Case-insensitive search over card content and metadata"
-    ),
+    q: Optional[str] = Query(None),
+    deck_id: int | None = Query(None),
+    user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> List[CardAdminRead]:
-    """Return cards with reusable deck metadata and per-user study state."""
+    """Return manageable cards with current-user/demo study state."""
+    user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
+    uc_card_id = cast(Any, UserCard.card_id)
+    card_id = cast(Any, Card.id)
     stmt = (
         select(Card, UserCard)
-        .join(UserCard, cast(Any, UserCard.card_id) == cast(Any, Card.id))
-        .where(UserCard.user_id == DEFAULT_USER_ID)
+        .outerjoin(
+            UserCard,
+            and_(uc_card_id == card_id, UserCard.user_id == user_id),
+        )
+        .outerjoin(Deck, Card.deck_id == Deck.id)
     )
-
+    if user is None:
+        stmt = stmt.where(Card.is_builtin == True)  # noqa: E712
+    else:
+        stmt = stmt.where(
+            or_(Card.is_builtin == True, Deck.owner_id == user.id)  # noqa: E712
+        )
+    if deck_id is not None:
+        stmt = stmt.where(Card.deck_id == deck_id)
     if q:
         like = f"%{q.lower()}%"
         stmt = stmt.where(
@@ -176,12 +226,11 @@ def list_cards_admin(
             )
         )
 
-    stmt = stmt.order_by(desc(cast(Any, Card.id)))
-    rows = session.exec(stmt).all()
-
+    rows = session.exec(stmt.order_by(desc(card_id))).all()
     return [
         CardAdminRead(
-            id=card.id,
+            id=int(card.id or 0),
+            deck_id=card.deck_id,
             word=card.word,
             definition=card.definition,
             topic=card.topic,
@@ -189,87 +238,78 @@ def list_cards_admin(
             kind=card.kind,
             is_builtin=card.is_builtin,
             created_at=card.created_at,
-            bin=uc.bin,
-            status=uc.status,
+            bin=uc.bin if uc is not None else 0,
+            status=uc.status if uc is not None else "active",
         )
         for card, uc in rows
     ]
 
 
 @router.get("/cards/stats", response_model=CardStats)
-def card_stats(session: Session = Depends(get_session)) -> CardStats:
-    """Return aggregate study stats for the shared demo user."""
-    total_cards = session.exec(
-        select(func.count())
-        .select_from(UserCard)
-        .where(UserCard.user_id == DEFAULT_USER_ID)
-    ).one()
+def card_stats(
+    deck_id: int | None = Query(None),
+    user: User | None = Depends(get_optional_user),
+    session: Session = Depends(get_session),
+) -> CardStats:
+    """Return aggregate progress for the selected user and optional deck."""
+    user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
+    conditions: list[Any] = [UserCard.user_id == user_id]
+    if deck_id is not None:
+        conditions.append(Card.deck_id == deck_id)
 
-    status_rows = session.exec(
-        select(UserCard.status, func.count())
-        .where(UserCard.user_id == DEFAULT_USER_ID)
-        .group_by(UserCard.status)
-    ).all()
-    status_counts: Dict[str, int] = {str(s): int(c) for s, c in status_rows}
-
-    bin_rows = session.exec(
-        select(cast(Any, UserCard.bin), func.count())
-        .where(UserCard.user_id == DEFAULT_USER_ID)
-        .group_by(cast(Any, UserCard.bin))
-    ).all()
+    base = select(UserCard).join(Card, UserCard.card_id == Card.id).where(*conditions)
+    rows = session.exec(base).all()
     by_bin: Dict[int, int] = {i: 0 for i in range(12)}
-    for b, c in bin_rows:
-        by_bin[int(b)] = int(c)
+    status_counts: Dict[str, int] = {}
+    for uc in rows:
+        by_bin[int(uc.bin)] += 1
+        status_counts[uc.status] = status_counts.get(uc.status, 0) + 1
 
     return CardStats(
-        total_cards=int(total_cards or 0),
-        active=int(status_counts.get("active", 0)),
-        never=int(status_counts.get("never", 0)),
-        hard_to_remember=int(status_counts.get("hard_to_remember", 0)),
+        total_cards=len(rows),
+        active=status_counts.get("active", 0),
+        never=status_counts.get("never", 0),
+        hard_to_remember=status_counts.get("hard_to_remember", 0),
         by_bin=by_bin,
     )
 
 
-@router.post("/admin/reset")
 @router.post("/cards/admin/reset")
-def reset_all_progress(
+def reset_demo_progress(
     session: Session = Depends(get_session),
     demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
 ) -> dict[str, int | bool]:
-    """Reset shared demo progress after verifying the demo admin password."""
+    """Reset only the anonymous featured-demo progress after admin verification."""
     _require_demo_password(demo_password)
-
-    card_ids = session.exec(select(Card.id)).all()
-    existing_card_ids = set(
+    builtin_ids = list(
+        session.exec(select(Card.id).where(Card.is_builtin == True)).all()  # noqa: E712
+    )
+    existing_ids = set(
         session.exec(
-            select(UserCard.card_id).where(UserCard.user_id == DEFAULT_USER_ID)
+            select(UserCard.card_id).where(
+                UserCard.user_id == DEMO_USER_ID,
+                cast(Any, UserCard.card_id).in_(builtin_ids),
+            )
         ).all()
     )
-    to_insert = [cid for cid in card_ids if cid not in existing_card_ids]
+    to_insert = [cid for cid in builtin_ids if cid not in existing_ids]
     for cid in to_insert:
-        session.add(
-            UserCard(
-                user_id=DEFAULT_USER_ID,
-                card_id=cid,
-                bin=0,
-                wrong_count=0,
-                next_review_at=None,
-                status="active",
-            )
-        )
+        session.add(UserCard(user_id=DEMO_USER_ID, card_id=cid, bin=0))
 
-    deleted_reviews = (
-        session.exec(delete(Review).where(Review.user_id == DEFAULT_USER_ID)).rowcount
-        or 0
-    )
-    updated_usercards = (
-        session.exec(
-            update(UserCard)
-            .where(UserCard.user_id == DEFAULT_USER_ID)
-            .values(bin=0, wrong_count=0, next_review_at=None, status="active")
-        ).rowcount
-        or 0
-    )
+    deleted_reviews = session.exec(
+        delete(Review).where(
+            Review.user_id == DEMO_USER_ID,
+            cast(Any, Review.card_id).in_(builtin_ids),
+        )
+    ).rowcount or 0
+    updated_usercards = session.exec(
+        update(UserCard)
+        .where(
+            UserCard.user_id == DEMO_USER_ID,
+            cast(Any, UserCard.card_id).in_(builtin_ids),
+        )
+        .values(bin=0, wrong_count=0, next_review_at=None, status="active")
+    ).rowcount or 0
 
     session.commit()
     return {

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -6,7 +6,7 @@ from hmac import compare_digest
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from sqlalchemy import and_, desc, func, or_, update
+from sqlalchemy import and_, desc, or_, update
 from sqlmodel import Session, delete, select
 
 from app.config import settings
@@ -44,7 +44,6 @@ def _clean_kind(value: str) -> str:
 
 
 def _require_demo_password(password: str | None) -> None:
-    """Require the server-side demo password for built-in destructive actions."""
     expected = settings.DEMO_DELETE_PASSWORD
     if not expected:
         raise HTTPException(
@@ -84,7 +83,6 @@ def create_card(
     user: User = Depends(require_verified_user),
     session: Session = Depends(get_session),
 ) -> CardRead:
-    """Create a card in a deck owned by the verified user."""
     deck = _owned_deck(session, payload.deck_id, user)
     card = Card(
         deck_id=deck.id,
@@ -109,7 +107,6 @@ def list_cards(
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> List[CardRead]:
-    """List public built-ins plus cards owned by the signed-in user."""
     stmt = select(Card).outerjoin(Deck, Card.deck_id == Deck.id)
     if user is None:
         stmt = stmt.where(Card.is_builtin == True)  # noqa: E712
@@ -119,8 +116,7 @@ def list_cards(
         )
     if deck_id is not None:
         stmt = stmt.where(Card.deck_id == deck_id)
-    rows = session.exec(stmt.order_by(cast(Any, Card.id))).all()
-    return list(rows)
+    return list(session.exec(stmt.order_by(cast(Any, Card.id))).all())
 
 
 @router.put("/cards/{card_id}", response_model=CardRead)
@@ -143,16 +139,18 @@ def update_card(
     return _update_card(card_id, payload, user, session)
 
 
-def _update_card(card_id: int, payload: CardUpdate, user: User, session: Session) -> CardRead:
+def _update_card(
+    card_id: int, payload: CardUpdate, user: User, session: Session
+) -> CardRead:
     card, deck = _owned_card(session, card_id, user)
     data = payload.model_dump(exclude_unset=True)
-    if "word" in data and data["word"] is not None:
+    if data.get("word") is not None:
         card.word = _clean_text(data["word"], "question")
-    if "definition" in data and data["definition"] is not None:
+    if data.get("definition") is not None:
         card.definition = _clean_text(data["definition"], "answer")
-    if "domain" in data and data["domain"] is not None:
+    if data.get("domain") is not None:
         card.domain = data["domain"].strip() or "General"
-    if "kind" in data and data["kind"] is not None:
+    if data.get("kind") is not None:
         card.kind = _clean_kind(data["kind"])
     card.topic = deck.title
     session.add(card)
@@ -168,7 +166,6 @@ def delete_card(
     session: Session = Depends(get_session),
     demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
 ) -> Dict[str, bool]:
-    """Delete an owned card; built-in cards require the server-side admin password."""
     card = session.get(Card, card_id)
     if card is None:
         raise HTTPException(status_code=404, detail="Card not found")
@@ -194,7 +191,6 @@ def list_cards_admin(
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> List[CardAdminRead]:
-    """Return manageable cards with current-user/demo study state."""
     user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
     uc_card_id = cast(Any, UserCard.card_id)
     card_id = cast(Any, Card.id)
@@ -251,14 +247,14 @@ def card_stats(
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> CardStats:
-    """Return aggregate progress for the selected user and optional deck."""
     user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
     conditions: list[Any] = [UserCard.user_id == user_id]
     if deck_id is not None:
         conditions.append(Card.deck_id == deck_id)
 
-    base = select(UserCard).join(Card, UserCard.card_id == Card.id).where(*conditions)
-    rows = session.exec(base).all()
+    rows = session.exec(
+        select(UserCard).join(Card, UserCard.card_id == Card.id).where(*conditions)
+    ).all()
     by_bin: Dict[int, int] = {i: 0 for i in range(12)}
     status_counts: Dict[str, int] = {}
     for uc in rows:
@@ -279,7 +275,6 @@ def reset_demo_progress(
     session: Session = Depends(get_session),
     demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
 ) -> dict[str, int | bool]:
-    """Reset only the anonymous featured-demo progress after admin verification."""
     _require_demo_password(demo_password)
     builtin_ids = list(
         session.exec(select(Card.id).where(Card.is_builtin == True)).all()  # noqa: E712
@@ -296,20 +291,26 @@ def reset_demo_progress(
     for cid in to_insert:
         session.add(UserCard(user_id=DEMO_USER_ID, card_id=cid, bin=0))
 
-    deleted_reviews = session.exec(
-        delete(Review).where(
-            Review.user_id == DEMO_USER_ID,
-            cast(Any, Review.card_id).in_(builtin_ids),
-        )
-    ).rowcount or 0
-    updated_usercards = session.exec(
-        update(UserCard)
-        .where(
-            UserCard.user_id == DEMO_USER_ID,
-            cast(Any, UserCard.card_id).in_(builtin_ids),
-        )
-        .values(bin=0, wrong_count=0, next_review_at=None, status="active")
-    ).rowcount or 0
+    deleted_reviews = (
+        session.exec(
+            delete(Review).where(
+                Review.user_id == DEMO_USER_ID,
+                cast(Any, Review.card_id).in_(builtin_ids),
+            )
+        ).rowcount
+        or 0
+    )
+    updated_usercards = (
+        session.exec(
+            update(UserCard)
+            .where(
+                UserCard.user_id == DEMO_USER_ID,
+                cast(Any, UserCard.card_id).in_(builtin_ids),
+            )
+            .values(bin=0, wrong_count=0, next_review_at=None, status="active")
+        ).rowcount
+        or 0
+    )
 
     session.commit()
     return {

--- a/backend/app/routers/cards.py
+++ b/backend/app/routers/cards.py
@@ -1,64 +1,77 @@
 # app/routers/cards.py
 from __future__ import annotations
 
+from hmac import compare_digest
 from typing import Any, Dict, List, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy import asc, desc, func, or_, update
-from sqlmodel import Session, select, delete
+from sqlmodel import Session, delete, select
 
+from app.config import settings
 from app.db import get_session
 from app.models import (
     Card,
+    CardAdminRead,
     CardCreate,
     CardRead,
-    CardAdminRead,
-    CardUpdate,
-    UserCard,
     CardStats,
+    CardUpdate,
     Review,
+    UserCard,
 )
 
 router = APIRouter()
 DEFAULT_USER_ID = 1
+VALID_KINDS = {"concept", "lab"}
+
+
+def _clean_card_fields(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize user-provided reusable deck metadata."""
+    for field in ("word", "definition", "topic", "domain", "kind"):
+        if field in data and isinstance(data[field], str):
+            data[field] = data[field].strip()
+    data["topic"] = data.get("topic") or "Custom"
+    data["domain"] = data.get("domain") or "General"
+    data["kind"] = (data.get("kind") or "concept").lower()
+    if data["kind"] not in VALID_KINDS:
+        raise HTTPException(status_code=422, detail="kind must be 'concept' or 'lab'")
+    if not data.get("word") or not data.get("definition"):
+        raise HTTPException(status_code=422, detail="question and answer are required")
+    return data
+
+
+def _require_demo_password(password: str | None) -> None:
+    """Require the server-side demo password for global/built-in destructive actions."""
+    expected = settings.DEMO_DELETE_PASSWORD
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Demo admin password is not configured; protected action is disabled",
+        )
+    if not password or not compare_digest(password, expected):
+        raise HTTPException(status_code=403, detail="Incorrect demo admin password")
 
 
 @router.post("/cards", response_model=CardRead)
 def create_card(
     payload: CardCreate, session: Session = Depends(get_session)
 ) -> CardRead:
-    """Create a new vocabulary card and initialize user tracking.
-
-    Args:
-        payload: The data for the new card.
-        session: Database session.
-
-    Returns:
-        The newly created card (with ID and timestamps).
-    """
-    card = Card(**payload.model_dump())
+    """Create a user-owned card in any topic/domain and initialize progress."""
+    data = _clean_card_fields(payload.model_dump())
+    card = Card(**data, is_builtin=False)
     session.add(card)
     session.commit()
     session.refresh(card)
 
-    # Ensure per-user tracking exists so /cards/admin can include bin/status.
-    uc = UserCard(user_id=DEFAULT_USER_ID, card_id=card.id)  # bin=0, status='active'
-    session.add(uc)
+    session.add(UserCard(user_id=DEFAULT_USER_ID, card_id=card.id))
     session.commit()
-
     return card
 
 
 @router.get("/cards", response_model=List[CardRead])
 def list_cards(session: Session = Depends(get_session)) -> List[CardRead]:
-    """Retrieve all vocabulary cards.
-
-    Args:
-        session: Database session.
-
-    Returns:
-        All cards in the database.
-    """
+    """Return every card in stable ID order."""
     rows = session.exec(select(Card).order_by(asc(cast(Any, Card.id)))).all()
     return list(rows)
 
@@ -67,57 +80,39 @@ def list_cards(session: Session = Depends(get_session)) -> List[CardRead]:
 def replace_card(
     card_id: int, payload: CardUpdate, session: Session = Depends(get_session)
 ) -> CardRead:
-    """Replace a card's fields (acts like an upsert-style full update for this API).
-
-    Args:
-        card_id: The card ID to replace.
-        payload: Fields to set on the card (missing fields are left as-is).
-        session: Database session.
-
-    Raises:
-        HTTPException: If the card does not exist.
-
-    Returns:
-        The updated card.
-    """
-    card = session.get(Card, card_id)
-    if not card:
-        raise HTTPException(status_code=404, detail="Card not found")
-
-    data = payload.model_dump(exclude_unset=True)
-    for k, v in data.items():
-        setattr(card, k, v)
-
-    session.add(card)
-    session.commit()
-    session.refresh(card)
-    return card
+    """Update the editable fields of a custom card."""
+    return _update_card(card_id, payload, session)
 
 
 @router.patch("/cards/{card_id}", response_model=CardRead)
 def update_card(
     card_id: int, payload: CardUpdate, session: Session = Depends(get_session)
 ) -> CardRead:
-    """Partially update a card (only provided fields are changed).
+    """Partially update a custom card."""
+    return _update_card(card_id, payload, session)
 
-    Args:
-        card_id: The card ID to update.
-        payload: Partial fields to change.
-        session: Database session.
 
-    Raises:
-        HTTPException: If the card does not exist.
-
-    Returns:
-        The updated card.
-    """
+def _update_card(card_id: int, payload: CardUpdate, session: Session) -> CardRead:
     card = session.get(Card, card_id)
     if not card:
         raise HTTPException(status_code=404, detail="Card not found")
+    if card.is_builtin:
+        raise HTTPException(
+            status_code=403,
+            detail="Built-in demo cards are read-only; make a custom copy to edit them",
+        )
 
     data = payload.model_dump(exclude_unset=True)
-    for k, v in data.items():
-        setattr(card, k, v)
+    merged = {
+        "word": data.get("word", card.word),
+        "definition": data.get("definition", card.definition),
+        "topic": data.get("topic", card.topic),
+        "domain": data.get("domain", card.domain),
+        "kind": data.get("kind", card.kind),
+    }
+    cleaned = _clean_card_fields(merged)
+    for field, value in cleaned.items():
+        setattr(card, field, value)
 
     session.add(card)
     session.commit()
@@ -127,25 +122,23 @@ def update_card(
 
 @router.delete("/cards/{card_id}")
 def delete_card(
-    card_id: int, session: Session = Depends(get_session)
+    card_id: int,
+    session: Session = Depends(get_session),
+    demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
 ) -> Dict[str, bool]:
-    """Delete a vocabulary card (and its user tracking rows).
-
-    Args:
-        card_id: The ID of the card to delete.
-        session: Database session.
-
-    Raises:
-        HTTPException: If the card does not exist.
-
-    Returns:
-        Confirmation message indicating success.
-    """
+    """Delete a card; built-in demo cards require the server-side admin password."""
     card = session.get(Card, card_id)
     if not card:
         raise HTTPException(status_code=404, detail="Card not found")
+    if card.is_builtin:
+        _require_demo_password(demo_password)
 
-    # Remove user mappings first.
+    session.exec(
+        delete(Review).where(
+            Review.card_id == card_id,
+            Review.user_id == DEFAULT_USER_ID,
+        )
+    )
     session.exec(
         delete(UserCard).where(
             UserCard.card_id == card_id,
@@ -160,21 +153,11 @@ def delete_card(
 @router.get("/cards/admin", response_model=List[CardAdminRead])
 def list_cards_admin(
     q: Optional[str] = Query(
-        None, description="Case-insensitive search over word/definition"
+        None, description="Case-insensitive search over card content and metadata"
     ),
     session: Session = Depends(get_session),
 ) -> List[CardAdminRead]:
-    """Admin listing: return cards with per-user study fields.
-
-    Supports optional search by ``q`` matching Card.word or Card.definition.
-
-    Args:
-        q: Optional query string for case-insensitive search.
-        session: Database session.
-
-    Returns:
-        A list of cards augmented with ``bin`` and ``status`` for the default user.
-    """
+    """Return cards with reusable deck metadata and per-user study state."""
     stmt = (
         select(Card, UserCard)
         .join(UserCard, cast(Any, UserCard.card_id) == cast(Any, Card.id))
@@ -183,11 +166,16 @@ def list_cards_admin(
 
     if q:
         like = f"%{q.lower()}%"
-        word_col = cast(Any, Card.word)
-        def_col = cast(Any, Card.definition)
-        stmt = stmt.where(or_(word_col.ilike(like), def_col.ilike(like)))
+        stmt = stmt.where(
+            or_(
+                cast(Any, Card.word).ilike(like),
+                cast(Any, Card.definition).ilike(like),
+                cast(Any, Card.topic).ilike(like),
+                cast(Any, Card.domain).ilike(like),
+                cast(Any, Card.kind).ilike(like),
+            )
+        )
 
-    # Newest first (by id); cast for mypy/SQLAlchemy typing harmony.
     stmt = stmt.order_by(desc(cast(Any, Card.id)))
     rows = session.exec(stmt).all()
 
@@ -196,6 +184,10 @@ def list_cards_admin(
             id=card.id,
             word=card.word,
             definition=card.definition,
+            topic=card.topic,
+            domain=card.domain,
+            kind=card.kind,
+            is_builtin=card.is_builtin,
             created_at=card.created_at,
             bin=uc.bin,
             status=uc.status,
@@ -206,26 +198,13 @@ def list_cards_admin(
 
 @router.get("/cards/stats", response_model=CardStats)
 def card_stats(session: Session = Depends(get_session)) -> CardStats:
-    """Return aggregate study stats for the default user.
-
-    Includes:
-      * ``total_cards``: number of tracked cards for this user
-      * ``active`` / ``never`` / ``hard_to_remember``: counts by status
-      * ``by_bin``: counts per bin (0..11), with missing bins reported as 0
-
-    Args:
-        session: Database session.
-
-    Returns:
-        Aggregated statistics for the default user.
-    """
+    """Return aggregate study stats for the shared demo user."""
     total_cards = session.exec(
         select(func.count())
         .select_from(UserCard)
         .where(UserCard.user_id == DEFAULT_USER_ID)
     ).one()
 
-    # Counts by status (single grouped query)
     status_rows = session.exec(
         select(UserCard.status, func.count())
         .where(UserCard.user_id == DEFAULT_USER_ID)
@@ -233,7 +212,6 @@ def card_stats(session: Session = Depends(get_session)) -> CardStats:
     ).all()
     status_counts: Dict[str, int] = {str(s): int(c) for s, c in status_rows}
 
-    # Counts by bin (0..11)
     bin_rows = session.exec(
         select(cast(Any, UserCard.bin), func.count())
         .where(UserCard.user_id == DEFAULT_USER_ID)
@@ -254,16 +232,13 @@ def card_stats(session: Session = Depends(get_session)) -> CardStats:
 
 @router.post("/admin/reset")
 @router.post("/cards/admin/reset")
-def reset_all_progress(session: Session = Depends(get_session)):
-    """
-    Reset ALL progress for the default user:
+def reset_all_progress(
+    session: Session = Depends(get_session),
+    demo_password: str | None = Header(None, alias="X-Demo-Admin-Password"),
+) -> dict[str, int | bool]:
+    """Reset shared demo progress after verifying the demo admin password."""
+    _require_demo_password(demo_password)
 
-    - ensure a UserCard exists for every Card
-    - delete all Review rows for the user
-    - set UserCard: bin=0, wrong_count=0, next_review_at=NULL, status='active'
-    Returns basic counts for UI feedback.
-    """
-    # Ensure a UserCard exists for every Card
     card_ids = session.exec(select(Card.id)).all()
     existing_card_ids = set(
         session.exec(
@@ -283,13 +258,10 @@ def reset_all_progress(session: Session = Depends(get_session)):
             )
         )
 
-    # Delete all reviews for the user
     deleted_reviews = (
         session.exec(delete(Review).where(Review.user_id == DEFAULT_USER_ID)).rowcount
         or 0
     )
-
-    # Reset all usercards
     updated_usercards = (
         session.exec(
             update(UserCard)

--- a/backend/app/routers/decks.py
+++ b/backend/app/routers/decks.py
@@ -1,0 +1,187 @@
+"""Public featured decks and verified-user deck management."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
+from sqlmodel import Session, delete, select
+
+from ..db import get_session
+from ..models import Card, Deck, DeckCreate, DeckRead, DeckUpdate, Review, User, UserCard
+from ..security import get_current_user, require_verified_user
+
+router = APIRouter(prefix="/decks", tags=["decks"])
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "deck"
+
+
+def _unique_slug(session: Session, title: str, owner_id: int) -> str:
+    base = _slugify(title)
+    candidate = f"{base}-{owner_id}"
+    suffix = 2
+    while session.exec(select(Deck.id).where(Deck.slug == candidate)).first() is not None:
+        candidate = f"{base}-{owner_id}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def _card_count(session: Session, deck_id: int) -> int:
+    count = session.exec(
+        select(func.count()).select_from(Card).where(Card.deck_id == deck_id)
+    ).one()
+    return int(count or 0)
+
+
+def _read(session: Session, deck: Deck) -> DeckRead:
+    return DeckRead(
+        id=int(deck.id or 0),
+        owner_id=deck.owner_id,
+        title=deck.title,
+        slug=deck.slug,
+        description=deck.description,
+        is_builtin=deck.is_builtin,
+        card_count=_card_count(session, int(deck.id or 0)),
+        created_at=deck.created_at,
+    )
+
+
+def _owned_deck(session: Session, deck_id: int, user_id: int) -> Deck:
+    deck = session.get(Deck, deck_id)
+    if deck is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    if deck.owner_id != user_id or deck.is_builtin:
+        raise HTTPException(status_code=403, detail="You can only change your own decks")
+    return deck
+
+
+@router.get("/featured", response_model=list[DeckRead])
+def featured_decks(session: Session = Depends(get_session)) -> list[DeckRead]:
+    """Return public starter/demo decks. Platform Engineering is the first one."""
+    decks = session.exec(
+        select(Deck).where(Deck.is_builtin == True).order_by(Deck.id)  # noqa: E712
+    ).all()
+    return [_read(session, deck) for deck in decks]
+
+
+@router.get("/mine", response_model=list[DeckRead])
+def my_decks(
+    user: User = Depends(get_current_user), session: Session = Depends(get_session)
+) -> list[DeckRead]:
+    """Return decks owned by the signed-in user."""
+    decks = session.exec(
+        select(Deck).where(Deck.owner_id == user.id).order_by(Deck.created_at.desc())  # type: ignore[union-attr]
+    ).all()
+    return [_read(session, deck) for deck in decks]
+
+
+@router.post("", response_model=DeckRead, status_code=201)
+def create_deck(
+    payload: DeckCreate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> DeckRead:
+    """Create an empty reusable study deck for a verified user."""
+    title = payload.title.strip()
+    if len(title) < 2:
+        raise HTTPException(status_code=422, detail="Deck title is too short")
+    deck = Deck(
+        owner_id=user.id,
+        title=title,
+        slug=_unique_slug(session, title, int(user.id or 0)),
+        description=payload.description.strip(),
+        is_builtin=False,
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return _read(session, deck)
+
+
+@router.patch("/{deck_id}", response_model=DeckRead)
+def update_deck(
+    deck_id: int,
+    payload: DeckUpdate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> DeckRead:
+    """Rename or describe an owned deck."""
+    deck = _owned_deck(session, deck_id, int(user.id or 0))
+    if payload.title is not None:
+        title = payload.title.strip()
+        if len(title) < 2:
+            raise HTTPException(status_code=422, detail="Deck title is too short")
+        deck.title = title
+    if payload.description is not None:
+        deck.description = payload.description.strip()
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return _read(session, deck)
+
+
+@router.post("/{deck_id}/copy", response_model=DeckRead, status_code=201)
+def copy_featured_deck(
+    deck_id: int,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> DeckRead:
+    """Copy a featured deck so a user can customize it safely."""
+    source = session.get(Deck, deck_id)
+    if source is None or not source.is_builtin:
+        raise HTTPException(status_code=404, detail="Featured deck not found")
+
+    title = f"{source.title} — My Copy"
+    target = Deck(
+        owner_id=user.id,
+        title=title,
+        slug=_unique_slug(session, title, int(user.id or 0)),
+        description=source.description,
+        is_builtin=False,
+    )
+    session.add(target)
+    session.flush()
+
+    source_cards = session.exec(select(Card).where(Card.deck_id == source.id)).all()
+    for source_card in source_cards:
+        card = Card(
+            deck_id=target.id,
+            word=source_card.word,
+            definition=source_card.definition,
+            topic=title,
+            domain=source_card.domain,
+            kind=source_card.kind,
+            is_builtin=False,
+        )
+        session.add(card)
+        session.flush()
+        session.add(UserCard(user_id=user.id, card_id=int(card.id or 0), bin=0))
+
+    session.commit()
+    session.refresh(target)
+    return _read(session, target)
+
+
+@router.delete("/{deck_id}")
+def delete_deck(
+    deck_id: int,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> dict[str, bool]:
+    """Delete an owned deck plus its cards, progress, and review history."""
+    deck = _owned_deck(session, deck_id, int(user.id or 0))
+    card_ids = list(
+        session.exec(select(Card.id).where(Card.deck_id == deck.id)).all()
+    )
+    if card_ids:
+        session.exec(delete(Review).where(cast(Any, Review.card_id).in_(card_ids)))
+        session.exec(delete(UserCard).where(cast(Any, UserCard.card_id).in_(card_ids)))
+        session.exec(delete(Card).where(cast(Any, Card.id).in_(card_ids)))
+    session.delete(deck)
+    session.commit()
+    return {"ok": True}

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -1,30 +1,28 @@
 # app/routers/study.py
 from __future__ import annotations
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import and_, asc, desc, func
 from sqlmodel import Session, select
-from sqlalchemy import asc, desc, func, and_
 
 from ..db import get_session
-from ..models import UserCard, Card, Review
+from ..models import Card, Review, UserCard
 
 router = APIRouter(prefix="/study", tags=["study"])
 DEFAULT_USER_ID = 1
 VALID_TRACKS = {"mixed", "concept", "lab"}
 
 
-# ---------- Time helpers (timezone-aware UTC) ----------
 def _now_utc() -> datetime:
     """Return timezone-aware UTC datetime."""
     return datetime.now(timezone.utc)
 
 
-# Spec-accurate bin delays (bins 1–11); bin 11 = never
 BIN_DELAYS: dict[int, Optional[timedelta]] = {
-    0: timedelta(seconds=0),  # new
+    0: timedelta(seconds=0),
     1: timedelta(seconds=5),
     2: timedelta(seconds=25),
     3: timedelta(minutes=2),
@@ -34,69 +32,58 @@ BIN_DELAYS: dict[int, Optional[timedelta]] = {
     7: timedelta(days=1),
     8: timedelta(days=5),
     9: timedelta(days=25),
-    10: timedelta(days=120),  # ~4 months
-    11: None,  # never
+    10: timedelta(days=120),
+    11: None,
 }
 
 
 def _fallback_delay_for_bin(b: int) -> Optional[timedelta]:
-    """Return the spec delay for a bin; None means 'never'."""
+    """Return the configured delay for a bin; None means terminal mastery."""
     return BIN_DELAYS.get(int(b), timedelta(minutes=1))
 
 
 def _next_review_at_from_bin(b: int) -> Optional[datetime]:
-    """Compute next review time as timezone-aware UTC; None for 'never'."""
+    """Compute the next review time in UTC."""
     delay = _fallback_delay_for_bin(b)
     return None if delay is None else _now_utc() + delay
 
 
-def _track_clause(track: str) -> Any | None:
-    """Return a SQL clause that limits study to concepts or break/fix labs."""
-    word = cast(Any, Card.word)
-    if track == "lab":
-        return word.like("LAB ·%")
-    if track == "concept":
-        return ~word.like("LAB ·%")
-    return None
+def _card_filters(topic: str | None, track: str) -> list[Any]:
+    """Build reusable card filters for topic and learning mode."""
+    filters: list[Any] = []
+    if topic:
+        filters.append(cast(Any, Card.topic) == topic)
+    if track in {"concept", "lab"}:
+        filters.append(cast(Any, Card.kind) == track)
+    return filters
 
 
-# ---------- Selection logic ----------
 def _select_next_card_pair(
-    session: Session, track: str = "mixed"
+    session: Session,
+    topic: str | None = None,
+    track: str = "mixed",
 ) -> Optional[tuple[Card, UserCard]]:
-    """
-    Select the next card for the default user and requested study track.
-
-    Selection priority:
-      1) Any due active card (next_review_at <= now), preferring:
-         - Higher bin numbers first
-         - Then earliest due time
-         - Then lowest Card.id (stable)
-      2) If no due cards, return the newest "new" card:
-         - bin = 0 and next_review_at IS NULL
-         - Ordered by created_at DESC, then Card.id DESC
-    """
+    """Select the next due/new card for a topic and learning mode."""
     nr = cast(Any, UserCard.next_review_at)
     b = cast(Any, UserCard.bin)
     cid = cast(Any, Card.id)
     created = cast(Any, Card.created_at)
     uc_card_id = cast(Any, UserCard.card_id)
-    track_clause = _track_clause(track)
+    card_filters = _card_filters(topic, track)
 
     due_conditions: list[Any] = [
         UserCard.user_id == DEFAULT_USER_ID,
         UserCard.status == "active",
         and_(nr.is_not(None), nr <= func.now()),
+        *card_filters,
     ]
     new_conditions: list[Any] = [
         UserCard.user_id == DEFAULT_USER_ID,
         UserCard.status == "active",
         cast(Any, UserCard.bin) == 0,
         nr.is_(None),
+        *card_filters,
     ]
-    if track_clause is not None:
-        due_conditions.append(track_clause)
-        new_conditions.append(track_clause)
 
     due_stmt = (
         select(Card, UserCard)
@@ -123,16 +110,35 @@ def _select_next_card_pair(
     return None
 
 
-# --- Public function expected by tests ---
 def select_next_card(session: Session) -> Optional[Card]:
-    """Return only the Card (or None) using the mixed-deck priority."""
+    """Compatibility helper used by tests and callers that want a mixed deck."""
     pair = _select_next_card_pair(session)
     return pair[0] if pair else None
 
 
-# ---------- Routes ----------
+@router.get("/topics")
+def study_topics(session: Session = Depends(get_session)) -> list[dict[str, Any]]:
+    """Return available topics with concept/lab counts for the topic picker."""
+    rows = session.exec(select(Card.topic, Card.kind)).all()
+    topics: dict[str, dict[str, Any]] = {}
+    for topic_value, kind_value in rows:
+        topic = str(topic_value or "Custom")
+        kind = str(kind_value or "concept")
+        item = topics.setdefault(
+            topic,
+            {"topic": topic, "total": 0, "concepts": 0, "labs": 0},
+        )
+        item["total"] += 1
+        if kind == "lab":
+            item["labs"] += 1
+        else:
+            item["concepts"] += 1
+    return sorted(topics.values(), key=lambda item: (-item["total"], item["topic"]))
+
+
 @router.get("/next")
 def study_next(
+    topic: str | None = Query(None, description="Optional topic/deck name"),
     track: str = Query(
         "mixed",
         description="Study track: mixed, concept, or lab",
@@ -140,7 +146,7 @@ def study_next(
     ),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """Return the next due/new card for the selected study track."""
+    """Return the next due/new card for the selected topic and track."""
     if track not in VALID_TRACKS:
         raise HTTPException(status_code=422, detail="invalid study track")
 
@@ -149,10 +155,8 @@ def study_next(
     active_conditions: list[Any] = [
         UserCard.user_id == DEFAULT_USER_ID,
         UserCard.status == "active",
+        *_card_filters(topic, track),
     ]
-    track_clause = _track_clause(track)
-    if track_clause is not None:
-        active_conditions.append(track_clause)
 
     has_active = session.exec(
         select(UserCard.id)
@@ -162,7 +166,7 @@ def study_next(
     if has_active is None:
         return {"status": "permanently_done"}
 
-    pair = _select_next_card_pair(session, track)
+    pair = _select_next_card_pair(session, topic, track)
     if pair:
         card, uc = pair
         return {
@@ -171,6 +175,10 @@ def study_next(
                 "id": card.id,
                 "word": card.word,
                 "definition": card.definition,
+                "topic": card.topic,
+                "domain": card.domain,
+                "kind": card.kind,
+                "is_builtin": card.is_builtin,
                 "bin": uc.bin,
                 "status": uc.status,
             },
@@ -185,16 +193,7 @@ def submit_answer(
     result: str = Query(..., description="'correct' or 'wrong'"),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """
-    Accept an answer and update spaced-repetition state.
-
-    Query Args:
-        card_id: Card to answer.
-        result: 'correct' or 'wrong'.
-
-    Returns:
-        {"ok": True, "to_bin": int, "status": "active|hard_to_remember|never"}
-    """
+    """Accept an answer and update spaced-repetition state."""
     if result not in ("correct", "wrong"):
         raise HTTPException(
             status_code=422, detail="result must be 'correct' or 'wrong'"
@@ -210,7 +209,6 @@ def submit_answer(
         raise HTTPException(status_code=404, detail="Card not found")
 
     from_bin = uc.bin
-
     if result == "correct":
         uc.bin = min(uc.bin + 1, 11)
     else:
@@ -220,7 +218,6 @@ def submit_answer(
             uc.status = "hard_to_remember"
 
     uc.next_review_at = _next_review_at_from_bin(uc.bin)
-
     if uc.bin == 11:
         uc.status = "never"
         uc.next_review_at = None

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -1,4 +1,5 @@
-# app/routers/study.py
+"""Spaced-repetition study routes for featured and user-owned decks."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -9,15 +10,14 @@ from sqlalchemy import and_, asc, desc, func
 from sqlmodel import Session, select
 
 from ..db import get_session
-from ..models import Card, Review, UserCard
+from ..models import Card, Deck, Review, User, UserCard
+from ..security import DEMO_USER_ID, get_optional_user
 
 router = APIRouter(prefix="/study", tags=["study"])
-DEFAULT_USER_ID = 1
 VALID_TRACKS = {"mixed", "concept", "lab"}
 
 
 def _now_utc() -> datetime:
-    """Return timezone-aware UTC datetime."""
     return datetime.now(timezone.utc)
 
 
@@ -38,47 +38,45 @@ BIN_DELAYS: dict[int, Optional[timedelta]] = {
 
 
 def _fallback_delay_for_bin(b: int) -> Optional[timedelta]:
-    """Return the configured delay for a bin; None means terminal mastery."""
     return BIN_DELAYS.get(int(b), timedelta(minutes=1))
 
 
 def _next_review_at_from_bin(b: int) -> Optional[datetime]:
-    """Compute the next review time in UTC."""
     delay = _fallback_delay_for_bin(b)
     return None if delay is None else _now_utc() + delay
 
 
-def _card_filters(topic: str | None, track: str) -> list[Any]:
-    """Build reusable card filters for topic and learning mode."""
+def _card_filters(deck_id: int | None, track: str) -> list[Any]:
     filters: list[Any] = []
-    if topic:
-        filters.append(cast(Any, Card.topic) == topic)
+    if deck_id is not None:
+        filters.append(Card.deck_id == deck_id)
     if track in {"concept", "lab"}:
-        filters.append(cast(Any, Card.kind) == track)
+        filters.append(Card.kind == track)
     return filters
 
 
 def _select_next_card_pair(
     session: Session,
-    topic: str | None = None,
+    user_id: int = DEMO_USER_ID,
+    deck_id: int | None = None,
     track: str = "mixed",
 ) -> Optional[tuple[Card, UserCard]]:
-    """Select the next due/new card for a topic and learning mode."""
+    """Select the next due/new card for one user, deck, and learning mode."""
     nr = cast(Any, UserCard.next_review_at)
     b = cast(Any, UserCard.bin)
     cid = cast(Any, Card.id)
     created = cast(Any, Card.created_at)
     uc_card_id = cast(Any, UserCard.card_id)
-    card_filters = _card_filters(topic, track)
+    card_filters = _card_filters(deck_id, track)
 
     due_conditions: list[Any] = [
-        UserCard.user_id == DEFAULT_USER_ID,
+        UserCard.user_id == user_id,
         UserCard.status == "active",
         and_(nr.is_not(None), nr <= func.now()),
         *card_filters,
     ]
     new_conditions: list[Any] = [
-        UserCard.user_id == DEFAULT_USER_ID,
+        UserCard.user_id == user_id,
         UserCard.status == "active",
         cast(Any, UserCard.bin) == 0,
         nr.is_(None),
@@ -103,76 +101,88 @@ def _select_next_card_pair(
         .order_by(desc(created), desc(cid))
         .limit(1)
     )
-    new_row = session.exec(new_stmt).first()
-    if new_row:
-        return new_row
-
-    return None
+    return session.exec(new_stmt).first()
 
 
 def select_next_card(session: Session) -> Optional[Card]:
-    """Compatibility helper used by tests and callers that want a mixed deck."""
+    """Compatibility helper used by unit tests."""
     pair = _select_next_card_pair(session)
     return pair[0] if pair else None
 
 
-@router.get("/topics")
-def study_topics(session: Session = Depends(get_session)) -> list[dict[str, Any]]:
-    """Return available topics with concept/lab counts for the topic picker."""
-    rows = session.exec(select(Card.topic, Card.kind)).all()
-    topics: dict[str, dict[str, Any]] = {}
-    for topic_value, kind_value in rows:
-        topic = str(topic_value or "Custom")
-        kind = str(kind_value or "concept")
-        item = topics.setdefault(
-            topic,
-            {"topic": topic, "total": 0, "concepts": 0, "labs": 0},
-        )
-        item["total"] += 1
-        if kind == "lab":
-            item["labs"] += 1
-        else:
-            item["concepts"] += 1
-    return sorted(topics.values(), key=lambda item: (-item["total"], item["topic"]))
+def _default_featured_deck(session: Session) -> Deck | None:
+    return session.exec(
+        select(Deck).where(Deck.is_builtin == True).order_by(Deck.id)  # noqa: E712
+    ).first()
+
+
+def _resolve_deck(
+    session: Session, deck_id: int | None, user: User | None
+) -> tuple[Deck, int]:
+    deck = session.get(Deck, deck_id) if deck_id is not None else _default_featured_deck(session)
+    if deck is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    if not deck.is_builtin:
+        if user is None:
+            raise HTTPException(status_code=401, detail="Sign in to study this deck")
+        if deck.owner_id != user.id:
+            raise HTTPException(status_code=403, detail="This deck belongs to another account")
+    user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
+    return deck, user_id
+
+
+def _ensure_progress(session: Session, user_id: int, deck_id: int) -> None:
+    """Create missing per-user progress rows for every card in a selected deck."""
+    card_ids = list(session.exec(select(Card.id).where(Card.deck_id == deck_id)).all())
+    if not card_ids:
+        return
+    existing = set(
+        session.exec(
+            select(UserCard.card_id).where(
+                UserCard.user_id == user_id,
+                cast(Any, UserCard.card_id).in_(card_ids),
+            )
+        ).all()
+    )
+    missing = [card_id for card_id in card_ids if card_id not in existing]
+    for card_id in missing:
+        session.add(UserCard(user_id=user_id, card_id=card_id, bin=0))
+    if missing:
+        session.commit()
 
 
 @router.get("/next")
 def study_next(
-    topic: str | None = Query(None, description="Optional topic/deck name"),
+    deck_id: int | None = Query(None, description="Featured or owned deck id"),
     track: str = Query(
         "mixed",
         description="Study track: mixed, concept, or lab",
         pattern="^(mixed|concept|lab)$",
     ),
+    user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """Return the next due/new card for the selected topic and track."""
+    """Return the next due/new card for a featured or owned deck."""
     if track not in VALID_TRACKS:
         raise HTTPException(status_code=422, detail="invalid study track")
 
-    cid = cast(Any, Card.id)
-    uc_card_id = cast(Any, UserCard.card_id)
-    active_conditions: list[Any] = [
-        UserCard.user_id == DEFAULT_USER_ID,
-        UserCard.status == "active",
-        *_card_filters(topic, track),
-    ]
+    deck, user_id = _resolve_deck(session, deck_id, user)
+    resolved_deck_id = int(deck.id or 0)
+    _ensure_progress(session, user_id, resolved_deck_id)
 
-    has_active = session.exec(
-        select(UserCard.id)
-        .join(Card, uc_card_id == cid)
-        .where(*active_conditions)
-    ).first()
-    if has_active is None:
-        return {"status": "permanently_done"}
-
-    pair = _select_next_card_pair(session, topic, track)
+    pair = _select_next_card_pair(session, user_id, resolved_deck_id, track)
     if pair:
         card, uc = pair
         return {
             "status": "ok",
+            "deck": {
+                "id": resolved_deck_id,
+                "title": deck.title,
+                "is_builtin": deck.is_builtin,
+            },
             "card": {
                 "id": card.id,
+                "deck_id": card.deck_id,
                 "word": card.word,
                 "definition": card.definition,
                 "topic": card.topic,
@@ -184,29 +194,44 @@ def study_next(
             },
         }
 
-    return {"status": "temporarily_done"}
+    active = session.exec(
+        select(UserCard.id)
+        .join(Card, UserCard.card_id == Card.id)
+        .where(
+            UserCard.user_id == user_id,
+            UserCard.status == "active",
+            Card.deck_id == resolved_deck_id,
+            *_card_filters(None, track),
+        )
+    ).first()
+    return {"status": "permanently_done" if active is None else "temporarily_done"}
 
 
 @router.post("/answer")
 def submit_answer(
-    card_id: int = Query(..., description="Card ID to answer"),
-    result: str = Query(..., description="'correct' or 'wrong'"),
+    card_id: int = Query(...),
+    result: str = Query(..., pattern="^(correct|wrong)$"),
+    user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """Accept an answer and update spaced-repetition state."""
-    if result not in ("correct", "wrong"):
-        raise HTTPException(
-            status_code=422, detail="result must be 'correct' or 'wrong'"
-        )
+    """Update spaced-repetition state for the current demo/account user."""
+    if result not in {"correct", "wrong"}:
+        raise HTTPException(status_code=422, detail="result must be 'correct' or 'wrong'")
+
+    card = session.get(Card, card_id)
+    if card is None or card.deck_id is None:
+        raise HTTPException(status_code=404, detail="Card not found")
+    _deck, user_id = _resolve_deck(session, card.deck_id, user)
+    _ensure_progress(session, user_id, card.deck_id)
 
     uc = session.exec(
         select(UserCard).where(
             UserCard.card_id == card_id,
-            UserCard.user_id == DEFAULT_USER_ID,
+            UserCard.user_id == user_id,
         )
     ).first()
-    if not uc:
-        raise HTTPException(status_code=404, detail="Card not found")
+    if uc is None:
+        raise HTTPException(status_code=404, detail="Study progress not found")
 
     from_bin = uc.bin
     if result == "correct":
@@ -225,7 +250,7 @@ def submit_answer(
     session.add(
         Review(
             card_id=card_id,
-            user_id=DEFAULT_USER_ID,
+            user_id=user_id,
             result=result,
             from_bin=from_bin,
             to_bin=uc.bin,
@@ -234,5 +259,4 @@ def submit_answer(
     )
     session.add(uc)
     session.commit()
-
     return {"ok": True, "to_bin": uc.bin, "status": uc.status}

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -13,6 +13,7 @@ from ..models import UserCard, Card, Review
 
 router = APIRouter(prefix="/study", tags=["study"])
 DEFAULT_USER_ID = 1
+VALID_TRACKS = {"mixed", "concept", "lab"}
 
 
 # ---------- Time helpers (timezone-aware UTC) ----------
@@ -49,10 +50,22 @@ def _next_review_at_from_bin(b: int) -> Optional[datetime]:
     return None if delay is None else _now_utc() + delay
 
 
+def _track_clause(track: str) -> Any | None:
+    """Return a SQL clause that limits study to concepts or break/fix labs."""
+    word = cast(Any, Card.word)
+    if track == "lab":
+        return word.like("LAB ·%")
+    if track == "concept":
+        return ~word.like("LAB ·%")
+    return None
+
+
 # ---------- Selection logic ----------
-def _select_next_card_pair(session: Session) -> Optional[tuple[Card, UserCard]]:
+def _select_next_card_pair(
+    session: Session, track: str = "mixed"
+) -> Optional[tuple[Card, UserCard]]:
     """
-    Select the next card for the default user to study.
+    Select the next card for the default user and requested study track.
 
     Selection priority:
       1) Any due active card (next_review_at <= now), preferring:
@@ -63,43 +76,43 @@ def _select_next_card_pair(session: Session) -> Optional[tuple[Card, UserCard]]:
          - bin = 0 and next_review_at IS NULL
          - Ordered by created_at DESC, then Card.id DESC
     """
-    # Cast ORM attributes to SQL expressions for mypy
     nr = cast(Any, UserCard.next_review_at)
     b = cast(Any, UserCard.bin)
     cid = cast(Any, Card.id)
     created = cast(Any, Card.created_at)
     uc_card_id = cast(Any, UserCard.card_id)
+    track_clause = _track_clause(track)
 
-    # 1) due active card(s): prefer higher bin, then earliest due
+    due_conditions: list[Any] = [
+        UserCard.user_id == DEFAULT_USER_ID,
+        UserCard.status == "active",
+        and_(nr.is_not(None), nr <= func.now()),
+    ]
+    new_conditions: list[Any] = [
+        UserCard.user_id == DEFAULT_USER_ID,
+        UserCard.status == "active",
+        cast(Any, UserCard.bin) == 0,
+        nr.is_(None),
+    ]
+    if track_clause is not None:
+        due_conditions.append(track_clause)
+        new_conditions.append(track_clause)
+
     due_stmt = (
         select(Card, UserCard)
-        .join(UserCard, uc_card_id == cid)  # casted ON clause
-        .where(
-            UserCard.user_id == DEFAULT_USER_ID,
-            UserCard.status == "active",
-            and_(nr.is_not(None), nr <= func.now()),
-        )
-        .order_by(
-            desc(b),  # prefer higher bin
-            asc(nr),  # then earliest due
-            asc(cid),  # stable tiebreaker
-        )
+        .join(UserCard, uc_card_id == cid)
+        .where(*due_conditions)
+        .order_by(desc(b), asc(nr), asc(cid))
         .limit(1)
     )
     due_row = session.exec(due_stmt).first()
     if due_row:
-        return due_row  # (Card, UserCard)
+        return due_row
 
-    # 2) newest "new" bin-0 card (next_review_at is NULL)
     new_stmt = (
         select(Card, UserCard)
-        .join(UserCard, uc_card_id == cid)  # casted ON clause
-        .where(
-            UserCard.user_id == DEFAULT_USER_ID,
-            UserCard.status == "active",
-            cast(Any, UserCard.bin) == 0,  # cast to avoid bool typing
-            nr.is_(None),
-        )
+        .join(UserCard, uc_card_id == cid)
+        .where(*new_conditions)
         .order_by(desc(created), desc(cid))
         .limit(1)
     )
@@ -112,33 +125,44 @@ def _select_next_card_pair(session: Session) -> Optional[tuple[Card, UserCard]]:
 
 # --- Public function expected by tests ---
 def select_next_card(session: Session) -> Optional[Card]:
-    """Return only the Card (or None) using the same priority as _select_next_card_pair."""
+    """Return only the Card (or None) using the mixed-deck priority."""
     pair = _select_next_card_pair(session)
     return pair[0] if pair else None
 
 
 # ---------- Routes ----------
 @router.get("/next")
-def study_next(session: Session = Depends(get_session)) -> dict[str, Any]:
-    """
-    Return the next card to study for the default user.
+def study_next(
+    track: str = Query(
+        "mixed",
+        description="Study track: mixed, concept, or lab",
+        pattern="^(mixed|concept|lab)$",
+    ),
+    session: Session = Depends(get_session),
+) -> dict[str, Any]:
+    """Return the next due/new card for the selected study track."""
+    if track not in VALID_TRACKS:
+        raise HTTPException(status_code=422, detail="invalid study track")
 
-    - If there are no ACTIVE cards at all -> {"status":"permanently_done"}
-    - Else if there are ACTIVE cards but none due/new -> {"status":"temporarily_done"}
-    - Else -> {"status":"ok", "card": {...}}
-    """
-    # 0) If there are no ACTIVE cards, we are permanently done
+    cid = cast(Any, Card.id)
+    uc_card_id = cast(Any, UserCard.card_id)
+    active_conditions: list[Any] = [
+        UserCard.user_id == DEFAULT_USER_ID,
+        UserCard.status == "active",
+    ]
+    track_clause = _track_clause(track)
+    if track_clause is not None:
+        active_conditions.append(track_clause)
+
     has_active = session.exec(
-        select(UserCard.id).where(
-            UserCard.user_id == DEFAULT_USER_ID,
-            UserCard.status == "active",
-        )
+        select(UserCard.id)
+        .join(Card, uc_card_id == cid)
+        .where(*active_conditions)
     ).first()
     if has_active is None:
         return {"status": "permanently_done"}
 
-    # 1) Try to pick a due/new active card
-    pair = _select_next_card_pair(session)
+    pair = _select_next_card_pair(session, track)
     if pair:
         card, uc = pair
         return {
@@ -152,7 +176,6 @@ def study_next(session: Session = Depends(get_session)) -> dict[str, Any]:
             },
         }
 
-    # 2) We have active cards but none are due/new right now
     return {"status": "temporarily_done"}
 
 
@@ -196,10 +219,8 @@ def submit_answer(
         if uc.wrong_count >= 10:
             uc.status = "hard_to_remember"
 
-    # Compute next review time per spec (bin 11 => never/None)
     uc.next_review_at = _next_review_at_from_bin(uc.bin)
 
-    # If card reached bin 11, mark never and clear next review (per spec)
     if uc.bin == 11:
         uc.status = "never"
         uc.next_review_at = None

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,128 @@
+"""Authentication primitives for passwords and opaque bearer sessions."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlmodel import Session, select
+
+from .config import settings
+from .db import get_session
+from .models import AuthSession, User
+
+PBKDF2_ITERATIONS = 600_000
+DEMO_USER_ID = 0
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _aware_utc(value: datetime) -> datetime:
+    """Normalize DB datetimes that may be returned without timezone info."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def hash_password(password: str) -> str:
+    """Hash a password with PBKDF2-HMAC-SHA256 and a random salt."""
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256", password.encode("utf-8"), salt, PBKDF2_ITERATIONS
+    )
+    return "$".join(
+        [
+            "pbkdf2_sha256",
+            str(PBKDF2_ITERATIONS),
+            base64.urlsafe_b64encode(salt).decode("ascii"),
+            base64.urlsafe_b64encode(digest).decode("ascii"),
+        ]
+    )
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    """Verify a password without leaking comparison timing."""
+    try:
+        algorithm, rounds, salt_b64, digest_b64 = encoded.split("$", 3)
+        if algorithm != "pbkdf2_sha256":
+            return False
+        salt = base64.urlsafe_b64decode(salt_b64.encode("ascii"))
+        expected = base64.urlsafe_b64decode(digest_b64.encode("ascii"))
+        actual = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), salt, int(rounds)
+        )
+        return hmac.compare_digest(actual, expected)
+    except (ValueError, TypeError):
+        return False
+
+
+def new_token() -> str:
+    """Return a high-entropy URL-safe opaque token."""
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """Hash an opaque token before database lookup/storage."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_auth_session(session: Session, user_id: int) -> str:
+    """Create a bearer session and return the raw token exactly once."""
+    raw = new_token()
+    session.add(
+        AuthSession(
+            user_id=user_id,
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(timezone.utc)
+            + timedelta(minutes=settings.ACCESS_TOKEN_MINUTES),
+        )
+    )
+    session.commit()
+    return raw
+
+
+def user_for_token(session: Session, raw_token: str) -> Optional[User]:
+    """Resolve an active bearer token to a user."""
+    auth_session = session.exec(
+        select(AuthSession).where(AuthSession.token_hash == hash_token(raw_token))
+    ).first()
+    if auth_session is None or auth_session.revoked_at is not None:
+        return None
+    if _aware_utc(auth_session.expires_at) <= datetime.now(timezone.utc):
+        return None
+    return session.get(User, auth_session.user_id)
+
+
+def get_optional_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+) -> Optional[User]:
+    """Return the signed-in user when a valid bearer token is present."""
+    if credentials is None:
+        return None
+    return user_for_token(session, credentials.credentials)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    """Require a valid signed-in user."""
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Sign in required")
+    user = user_for_token(session, credentials.credentials)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Session expired or invalid")
+    return user
+
+
+def require_verified_user(user: User = Depends(get_current_user)) -> User:
+    """Require an authenticated account with a verified email address."""
+    if not user.is_verified:
+        raise HTTPException(status_code=403, detail="Verify your email first")
+    return user

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -3,8 +3,8 @@
 Run with Docker:
     docker compose exec api python -m app.seed
 
-The seed operation is idempotent: existing cards are reused and missing
-default-user study state is repaired without duplicating content.
+The seed operation is idempotent: existing cards are reused, built-in metadata is
+repaired, and missing default-user study state is created without duplicates.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ from .models import Card, UserCard
 DATA_DIR = Path(__file__).parent / "data"
 CONCEPT_DECK_PATH = DATA_DIR / "platform_engineering_cards.json"
 LAB_DECK_PATH = DATA_DIR / "platform_engineering_labs.json"
+PLATFORM_TOPIC = "Platform Engineering"
 
 
 def load_deck(path: Path) -> dict[str, list[tuple[str, str]]]:
@@ -61,6 +62,17 @@ def flatten_deck(
     return [card for cards in domains.values() for card in cards]
 
 
+def deck_metadata(
+    domains: dict[str, list[tuple[str, str]]], kind: str
+) -> dict[str, tuple[str, str]]:
+    """Map each prompt to its domain and learning mode."""
+    return {
+        prompt: (domain, kind)
+        for domain, cards in domains.items()
+        for prompt, _answer in cards
+    }
+
+
 PLATFORM_ENGINEERING_DECK_BY_DOMAIN = load_deck(CONCEPT_DECK_PATH)
 PLATFORM_ENGINEERING_LABS_BY_DOMAIN = load_deck(LAB_DECK_PATH)
 PLATFORM_ENGINEERING_CONCEPT_DECK = flatten_deck(PLATFORM_ENGINEERING_DECK_BY_DOMAIN)
@@ -68,6 +80,10 @@ PLATFORM_ENGINEERING_LAB_DECK = flatten_deck(PLATFORM_ENGINEERING_LABS_BY_DOMAIN
 PLATFORM_ENGINEERING_DECK = (
     PLATFORM_ENGINEERING_CONCEPT_DECK + PLATFORM_ENGINEERING_LAB_DECK
 )
+PLATFORM_ENGINEERING_METADATA = {
+    **deck_metadata(PLATFORM_ENGINEERING_DECK_BY_DOMAIN, "concept"),
+    **deck_metadata(PLATFORM_ENGINEERING_LABS_BY_DOMAIN, "lab"),
+}
 
 if len({prompt for prompt, _ in PLATFORM_ENGINEERING_DECK}) != len(
     PLATFORM_ENGINEERING_DECK
@@ -76,7 +92,7 @@ if len({prompt for prompt, _ in PLATFORM_ENGINEERING_DECK}) != len(
 
 
 def seed_platform_deck(session: Session) -> dict[str, int]:
-    """Insert the complete Platform Engineering deck and default-user study state."""
+    """Insert or repair the built-in Platform Engineering demo deck."""
     existing_cards = {card.word: card for card in session.exec(select(Card)).all()}
     existing_progress_ids = set(
         session.exec(select(UserCard.card_id).where(UserCard.user_id == 1)).all()
@@ -84,18 +100,42 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
 
     inserted_cards = 0
     existing_count = 0
+    updated_cards = 0
     created_progress = 0
 
     for prompt, answer in PLATFORM_ENGINEERING_DECK:
+        domain, kind = PLATFORM_ENGINEERING_METADATA[prompt]
         card = existing_cards.get(prompt)
         if card is None:
-            card = Card(word=prompt, definition=answer)
+            card = Card(
+                word=prompt,
+                definition=answer,
+                topic=PLATFORM_TOPIC,
+                domain=domain,
+                kind=kind,
+                is_builtin=True,
+            )
             session.add(card)
             session.flush()
             existing_cards[prompt] = card
             inserted_cards += 1
         else:
             existing_count += 1
+            desired = {
+                "definition": answer,
+                "topic": PLATFORM_TOPIC,
+                "domain": domain,
+                "kind": kind,
+                "is_builtin": True,
+            }
+            changed = False
+            for field, value in desired.items():
+                if getattr(card, field) != value:
+                    setattr(card, field, value)
+                    changed = True
+            if changed:
+                session.add(card)
+                updated_cards += 1
 
         if card.id is not None and card.id not in existing_progress_ids:
             session.add(UserCard(card_id=card.id, user_id=1, bin=0))
@@ -109,6 +149,7 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
         "lab_cards": len(PLATFORM_ENGINEERING_LAB_DECK),
         "inserted_cards": inserted_cards,
         "existing_cards": existing_count,
+        "updated_cards": updated_cards,
         "created_progress": created_progress,
     }
 
@@ -123,6 +164,7 @@ def run() -> None:
         f"{result['deck_size']} cards "
         f"({result['concept_cards']} concepts + {result['lab_cards']} labs; "
         f"{result['inserted_cards']} inserted, "
+        f"{result['updated_cards']} metadata repaired, "
         f"{result['existing_cards']} already present, "
         f"{result['created_progress']} progress rows created)."
     )

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,10 +1,11 @@
-"""Seed the built-in Platform Engineering concept and lab decks.
+"""Seed the built-in Platform Engineering concept and lab deck.
 
 Run with Docker:
     docker compose exec api python -m app.seed
 
-The seed operation is idempotent: existing cards are reused, built-in metadata is
-repaired, and missing default-user study state is created without duplicates.
+The seed operation is idempotent: the featured deck and cards are reused,
+metadata is repaired, and missing anonymous-demo study state is created without
+duplicates.
 """
 
 from __future__ import annotations
@@ -16,16 +17,18 @@ from typing import Any
 from sqlmodel import Session, select
 
 from .db import engine
-from .models import Card, UserCard
+from .models import Card, Deck, UserCard
 
 DATA_DIR = Path(__file__).parent / "data"
 CONCEPT_DECK_PATH = DATA_DIR / "platform_engineering_cards.json"
 LAB_DECK_PATH = DATA_DIR / "platform_engineering_labs.json"
 PLATFORM_TOPIC = "Platform Engineering"
+PLATFORM_SLUG = "platform-engineering"
+DEMO_USER_ID = 0
 
 
 def load_deck(path: Path) -> dict[str, list[tuple[str, str]]]:
-    """Load and validate a versioned FlashQuest’s curriculum file."""
+    """Load and validate a versioned FlashQuest curriculum file."""
     payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
     domains: dict[str, list[tuple[str, str]]] = {}
     prompts: set[str] = set()
@@ -58,7 +61,7 @@ def load_deck(path: Path) -> dict[str, list[tuple[str, str]]]:
 def flatten_deck(
     domains: dict[str, list[tuple[str, str]]],
 ) -> list[tuple[str, str]]:
-    """Flatten domain-grouped cards into the database seed order."""
+    """Flatten domain-grouped cards into database seed order."""
     return [card for cards in domains.values() for card in cards]
 
 
@@ -91,11 +94,41 @@ if len({prompt for prompt, _ in PLATFORM_ENGINEERING_DECK}) != len(
     raise ValueError("Duplicate prompts exist across concept and lab decks")
 
 
+def _featured_deck(session: Session) -> Deck:
+    """Create or repair the public featured Platform Engineering deck."""
+    deck = session.exec(select(Deck).where(Deck.slug == PLATFORM_SLUG)).first()
+    description = (
+        "216 Platform Engineering challenges: 144 concepts and 72 hands-on "
+        "break/fix labs across 12 domains."
+    )
+    if deck is None:
+        deck = Deck(
+            owner_id=None,
+            title=PLATFORM_TOPIC,
+            slug=PLATFORM_SLUG,
+            description=description,
+            is_builtin=True,
+        )
+        session.add(deck)
+        session.flush()
+    else:
+        deck.owner_id = None
+        deck.title = PLATFORM_TOPIC
+        deck.description = description
+        deck.is_builtin = True
+        session.add(deck)
+        session.flush()
+    return deck
+
+
 def seed_platform_deck(session: Session) -> dict[str, int]:
     """Insert or repair the built-in Platform Engineering demo deck."""
+    deck = _featured_deck(session)
     existing_cards = {card.word: card for card in session.exec(select(Card)).all()}
     existing_progress_ids = set(
-        session.exec(select(UserCard.card_id).where(UserCard.user_id == 1)).all()
+        session.exec(
+            select(UserCard.card_id).where(UserCard.user_id == DEMO_USER_ID)
+        ).all()
     )
 
     inserted_cards = 0
@@ -108,6 +141,7 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
         card = existing_cards.get(prompt)
         if card is None:
             card = Card(
+                deck_id=deck.id,
                 word=prompt,
                 definition=answer,
                 topic=PLATFORM_TOPIC,
@@ -122,6 +156,7 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
         else:
             existing_count += 1
             desired = {
+                "deck_id": deck.id,
                 "definition": answer,
                 "topic": PLATFORM_TOPIC,
                 "domain": domain,
@@ -138,12 +173,13 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
                 updated_cards += 1
 
         if card.id is not None and card.id not in existing_progress_ids:
-            session.add(UserCard(card_id=card.id, user_id=1, bin=0))
+            session.add(UserCard(card_id=card.id, user_id=DEMO_USER_ID, bin=0))
             existing_progress_ids.add(card.id)
             created_progress += 1
 
     session.commit()
     return {
+        "deck_id": int(deck.id or 0),
         "deck_size": len(PLATFORM_ENGINEERING_DECK),
         "concept_cards": len(PLATFORM_ENGINEERING_CONCEPT_DECK),
         "lab_cards": len(PLATFORM_ENGINEERING_LAB_DECK),
@@ -160,13 +196,13 @@ def run() -> None:
         result = seed_platform_deck(session)
 
     print(
-        "FlashQuest’s Platform Engineering deck ready: "
+        "FlashQuest’s featured Platform Engineering deck ready: "
         f"{result['deck_size']} cards "
         f"({result['concept_cards']} concepts + {result['lab_cards']} labs; "
         f"{result['inserted_cards']} inserted, "
         f"{result['updated_cards']} metadata repaired, "
         f"{result['existing_cards']} already present, "
-        f"{result['created_progress']} progress rows created)."
+        f"{result['created_progress']} demo progress rows created)."
     )
 
 

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,17 +1,16 @@
 # fly.toml app configuration file generated on 2025-08-19T14:38:34-04:00
 #
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
+# See https://fly.io/docs/reference/configuration/ for information on this file.
 
 app = 'flashcards-tobias'
 primary_region = 'atl'
 
 [build]
-  # Using your Dockerfile in /backend
   dockerfile = "./Dockerfile"
 
 [deploy]
-  release_command = "alembic -c /app/alembic.ini upgrade head"
+  # Schema first, then idempotently repair/seed the built-in curriculum.
+  release_command = "sh -c 'alembic -c /app/alembic.ini upgrade head && python -m app.seed'"
 
 [env]
   PORT = "8080"
@@ -38,7 +37,7 @@ primary_region = 'atl'
   grace_period = "10s"
   interval = "10s"
   method = "GET"
-  path = "/health"
+  path = "/health/ready"
   timeout = "2s"
 
 [mounts]

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -9,11 +9,14 @@ primary_region = 'atl'
   dockerfile = "./Dockerfile"
 
 [deploy]
-  # Schema first, then idempotently repair/seed the built-in curriculum.
+  # Schema first, then idempotently repair/seed the featured curriculum.
   release_command = "sh -c 'alembic -c /app/alembic.ini upgrade head && python -m app.seed'"
 
 [env]
   PORT = "8080"
+  APP_ENV = "production"
+  FRONTEND_URL = "https://flashcards-tobias.netlify.app"
+  EMAIL_DELIVERY_MODE = "resend"
 
 [[vm]]
   memory = "256mb"

--- a/backend/tests/test_api_admin.py
+++ b/backend/tests/test_api_admin.py
@@ -1,47 +1,134 @@
-"""Admin endpoint tests: create/list/search/update/delete and stats."""
+"""Admin endpoint tests: reusable custom cards plus protected demo content."""
 
 from sqlmodel import Session
 
+from app.config import settings
+from app.models import Card, UserCard
+
 
 def test_admin_create_list_update_delete(client, sqlite_session: Session):
-    """Full CRUD lifecycle via /cards endpoints."""
-    # Create
-    r = client.post("/cards", json={"word": "delta", "definition": "d"})
+    """Custom cards can be created, customized, listed, and deleted."""
+    r = client.post(
+        "/cards",
+        json={
+            "word": "What is a VPC?",
+            "definition": "A logically isolated virtual network.",
+            "topic": "AWS",
+            "domain": "Networking",
+            "kind": "concept",
+        },
+    )
     assert r.status_code == 200
     card = r.json()
     cid = card["id"]
+    assert card["topic"] == "AWS"
+    assert card["is_builtin"] is False
 
-    # Admin list should include status fields
-    r = client.get("/cards/admin")
-    items = r.json()
-    assert any(x["id"] == cid and "bin" in x and "status" in x for x in items)
+    items = client.get("/cards/admin").json()
+    assert any(
+        x["id"] == cid
+        and x["topic"] == "AWS"
+        and x["domain"] == "Networking"
+        and "bin" in x
+        for x in items
+    )
 
-    # Update
-    r = client.put(f"/cards/{cid}", json={"definition": "delta-def"})
-    assert r.status_code == 200 and r.json()["definition"] == "delta-def"
+    r = client.patch(
+        f"/cards/{cid}",
+        json={"topic": "AWS SAA", "kind": "lab", "definition": "Updated answer"},
+    )
+    assert r.status_code == 200
+    assert r.json()["topic"] == "AWS SAA"
+    assert r.json()["kind"] == "lab"
 
-    # Delete
     r = client.delete(f"/cards/{cid}")
     assert r.status_code == 200 and r.json()["ok"] is True
-
-    # Verify gone
     assert client.get("/cards").json() == []
 
 
-def test_admin_search_and_stats(client, sqlite_session: Session):
-    """Search filters by q; stats returns counts and by_bin with expected keys."""
-    client.post("/cards", json={"word": "eager", "definition": "keen"})
-    client.post("/cards", json={"word": "earnest", "definition": "serious"})
+def test_built_in_card_requires_demo_password_to_delete(
+    client, sqlite_session: Session, monkeypatch
+):
+    """Seeded/demo content cannot be wiped by an anonymous visitor."""
+    card = Card(
+        word="Built-in question",
+        definition="Built-in answer",
+        topic="Platform Engineering",
+        domain="Linux & OS",
+        kind="concept",
+        is_builtin=True,
+    )
+    sqlite_session.add(card)
+    sqlite_session.commit()
+    sqlite_session.refresh(card)
+    sqlite_session.add(UserCard(card_id=card.id, user_id=1))
+    sqlite_session.commit()
 
-    # search
-    r = client.get("/cards/admin", params={"q": "ear"})
-    items = r.json()
+    assert client.delete(f"/cards/{card.id}").status_code == 503
+
+    monkeypatch.setattr(settings, "DEMO_DELETE_PASSWORD", "demo-secret")
+    assert (
+        client.delete(
+            f"/cards/{card.id}",
+            headers={"X-Demo-Admin-Password": "wrong"},
+        ).status_code
+        == 403
+    )
+    assert (
+        client.delete(
+            f"/cards/{card.id}",
+            headers={"X-Demo-Admin-Password": "demo-secret"},
+        ).status_code
+        == 200
+    )
+
+
+def test_built_in_card_is_read_only(client, sqlite_session: Session):
+    card = Card(
+        word="Protected",
+        definition="Keep me stable",
+        topic="Platform Engineering",
+        domain="Security",
+        kind="concept",
+        is_builtin=True,
+    )
+    sqlite_session.add(card)
+    sqlite_session.commit()
+    sqlite_session.refresh(card)
+
+    response = client.patch(f"/cards/{card.id}", json={"definition": "defaced"})
+    assert response.status_code == 403
+
+
+def test_admin_search_and_stats(client, sqlite_session: Session):
+    """Search includes metadata; stats still expose every spaced-repetition bin."""
+    client.post(
+        "/cards",
+        json={
+            "word": "eager",
+            "definition": "keen",
+            "topic": "English",
+            "domain": "Vocabulary",
+        },
+    )
+    client.post(
+        "/cards",
+        json={
+            "word": "earnest",
+            "definition": "serious",
+            "topic": "English",
+            "domain": "Vocabulary",
+        },
+    )
+
+    items = client.get("/cards/admin", params={"q": "ear"}).json()
     words = {x["word"] for x in items}
     assert "earnest" in words and "eager" not in words
 
-    # stats
-    r = client.get("/cards/stats")
-    stats = r.json()
+    topic_items = client.get("/cards/admin", params={"q": "English"}).json()
+    assert len(topic_items) == 2
+
+    stats = client.get("/cards/stats").json()
     assert {"total_cards", "active", "never", "hard_to_remember", "by_bin"} <= set(
         stats.keys()
     )

--- a/backend/tests/test_api_admin.py
+++ b/backend/tests/test_api_admin.py
@@ -1,56 +1,123 @@
-"""Admin endpoint tests: reusable custom cards plus protected demo content."""
+"""Card/deck API tests for ownership and protected featured content."""
 
 from sqlmodel import Session
 
 from app.config import settings
-from app.models import Card, UserCard
+from app.models import Card, Deck, User
+from app.security import create_auth_session, hash_password
 
 
-def test_admin_create_list_update_delete(client, sqlite_session: Session):
-    """Custom cards can be created, customized, listed, and deleted."""
-    r = client.post(
+def _verified_user(session: Session, email: str = "tee@example.com") -> tuple[User, dict[str, str]]:
+    user = User(
+        email=email,
+        display_name="Tee",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    token = create_auth_session(session, int(user.id or 0))
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+def _create_deck(client, headers: dict[str, str], title: str = "AWS") -> int:
+    response = client.post(
+        "/decks",
+        headers=headers,
+        json={"title": title, "description": "Custom study deck"},
+    )
+    assert response.status_code == 201
+    return int(response.json()["id"])
+
+
+def test_owned_card_create_list_update_delete(client, sqlite_session: Session):
+    """Verified users can manage cards only inside their own decks."""
+    _user, headers = _verified_user(sqlite_session)
+    deck_id = _create_deck(client, headers)
+
+    response = client.post(
         "/cards",
+        headers=headers,
         json={
+            "deck_id": deck_id,
             "word": "What is a VPC?",
             "definition": "A logically isolated virtual network.",
-            "topic": "AWS",
             "domain": "Networking",
             "kind": "concept",
         },
     )
-    assert r.status_code == 200
-    card = r.json()
-    cid = card["id"]
+    assert response.status_code == 201
+    card = response.json()
+    card_id = int(card["id"])
     assert card["topic"] == "AWS"
+    assert card["deck_id"] == deck_id
     assert card["is_builtin"] is False
 
-    items = client.get("/cards/admin").json()
+    items = client.get(
+        "/cards/admin", headers=headers, params={"deck_id": deck_id}
+    ).json()
     assert any(
-        x["id"] == cid
-        and x["topic"] == "AWS"
-        and x["domain"] == "Networking"
-        and "bin" in x
-        for x in items
+        item["id"] == card_id
+        and item["domain"] == "Networking"
+        and item["bin"] == 0
+        for item in items
     )
 
-    r = client.patch(
-        f"/cards/{cid}",
-        json={"topic": "AWS SAA", "kind": "lab", "definition": "Updated answer"},
+    response = client.patch(
+        f"/cards/{card_id}",
+        headers=headers,
+        json={"kind": "lab", "definition": "Updated recovery path"},
     )
-    assert r.status_code == 200
-    assert r.json()["topic"] == "AWS SAA"
-    assert r.json()["kind"] == "lab"
+    assert response.status_code == 200
+    assert response.json()["kind"] == "lab"
+    assert response.json()["definition"] == "Updated recovery path"
 
-    r = client.delete(f"/cards/{cid}")
-    assert r.status_code == 200 and r.json()["ok"] is True
-    assert client.get("/cards").json() == []
+    response = client.delete(f"/cards/{card_id}", headers=headers)
+    assert response.status_code == 200 and response.json()["ok"] is True
+    assert client.get("/cards", headers=headers, params={"deck_id": deck_id}).json() == []
+
+
+def test_user_cannot_edit_another_users_card(client, sqlite_session: Session):
+    """Ownership is enforced at the API boundary."""
+    _owner, owner_headers = _verified_user(sqlite_session, "owner@example.com")
+    deck_id = _create_deck(client, owner_headers, "Owner Deck")
+    card_id = client.post(
+        "/cards",
+        headers=owner_headers,
+        json={
+            "deck_id": deck_id,
+            "word": "Private question",
+            "definition": "Private answer",
+            "domain": "General",
+            "kind": "concept",
+        },
+    ).json()["id"]
+
+    _other, other_headers = _verified_user(sqlite_session, "other@example.com")
+    response = client.patch(
+        f"/cards/{card_id}",
+        headers=other_headers,
+        json={"definition": "Nope"},
+    )
+    assert response.status_code == 403
 
 
 def test_built_in_card_requires_demo_password_to_delete(
     client, sqlite_session: Session, monkeypatch
 ):
-    """Seeded/demo content cannot be wiped by an anonymous visitor."""
+    """Anonymous visitors cannot wipe the featured starter content."""
+    deck = Deck(
+        owner_id=None,
+        title="Platform Engineering",
+        slug="platform-engineering",
+        description="Starter",
+        is_builtin=True,
+    )
+    sqlite_session.add(deck)
+    sqlite_session.flush()
     card = Card(
+        deck_id=deck.id,
         word="Built-in question",
         definition="Built-in answer",
         topic="Platform Engineering",
@@ -61,30 +128,32 @@ def test_built_in_card_requires_demo_password_to_delete(
     sqlite_session.add(card)
     sqlite_session.commit()
     sqlite_session.refresh(card)
-    sqlite_session.add(UserCard(card_id=card.id, user_id=1))
-    sqlite_session.commit()
 
     assert client.delete(f"/cards/{card.id}").status_code == 503
 
     monkeypatch.setattr(settings, "DEMO_DELETE_PASSWORD", "demo-secret")
-    assert (
-        client.delete(
-            f"/cards/{card.id}",
-            headers={"X-Demo-Admin-Password": "wrong"},
-        ).status_code
-        == 403
-    )
-    assert (
-        client.delete(
-            f"/cards/{card.id}",
-            headers={"X-Demo-Admin-Password": "demo-secret"},
-        ).status_code
-        == 200
-    )
+    assert client.delete(
+        f"/cards/{card.id}", headers={"X-Demo-Admin-Password": "wrong"}
+    ).status_code == 403
+    assert client.delete(
+        f"/cards/{card.id}",
+        headers={"X-Demo-Admin-Password": "demo-secret"},
+    ).status_code == 200
 
 
-def test_built_in_card_is_read_only(client, sqlite_session: Session):
+def test_built_in_card_is_read_only_for_signed_in_users(client, sqlite_session: Session):
+    _user, headers = _verified_user(sqlite_session)
+    deck = Deck(
+        owner_id=None,
+        title="Platform Engineering",
+        slug="platform-engineering",
+        description="Starter",
+        is_builtin=True,
+    )
+    sqlite_session.add(deck)
+    sqlite_session.flush()
     card = Card(
+        deck_id=deck.id,
         word="Protected",
         definition="Keep me stable",
         topic="Platform Engineering",
@@ -96,40 +165,39 @@ def test_built_in_card_is_read_only(client, sqlite_session: Session):
     sqlite_session.commit()
     sqlite_session.refresh(card)
 
-    response = client.patch(f"/cards/{card.id}", json={"definition": "defaced"})
+    response = client.patch(
+        f"/cards/{card.id}", headers=headers, json={"definition": "defaced"}
+    )
     assert response.status_code == 403
 
 
-def test_admin_search_and_stats(client, sqlite_session: Session):
-    """Search includes metadata; stats still expose every spaced-repetition bin."""
-    client.post(
-        "/cards",
-        json={
-            "word": "eager",
-            "definition": "keen",
-            "topic": "English",
-            "domain": "Vocabulary",
-        },
-    )
-    client.post(
-        "/cards",
-        json={
-            "word": "earnest",
-            "definition": "serious",
-            "topic": "English",
-            "domain": "Vocabulary",
-        },
-    )
+def test_search_and_stats_are_scoped_to_owned_deck(client, sqlite_session: Session):
+    _user, headers = _verified_user(sqlite_session)
+    deck_id = _create_deck(client, headers, "English")
+    for word, definition in [("eager", "keen"), ("earnest", "serious")]:
+        response = client.post(
+            "/cards",
+            headers=headers,
+            json={
+                "deck_id": deck_id,
+                "word": word,
+                "definition": definition,
+                "domain": "Vocabulary",
+                "kind": "concept",
+            },
+        )
+        assert response.status_code == 201
 
-    items = client.get("/cards/admin", params={"q": "ear"}).json()
-    words = {x["word"] for x in items}
+    items = client.get(
+        "/cards/admin",
+        headers=headers,
+        params={"q": "ear", "deck_id": deck_id},
+    ).json()
+    words = {item["word"] for item in items}
     assert "earnest" in words and "eager" not in words
 
-    topic_items = client.get("/cards/admin", params={"q": "English"}).json()
-    assert len(topic_items) == 2
-
-    stats = client.get("/cards/stats").json()
-    assert {"total_cards", "active", "never", "hard_to_remember", "by_bin"} <= set(
-        stats.keys()
-    )
+    stats = client.get(
+        "/cards/stats", headers=headers, params={"deck_id": deck_id}
+    ).json()
+    assert stats["total_cards"] == 2
     assert set(map(int, stats["by_bin"].keys())) == set(range(12))

--- a/backend/tests/test_api_study.py
+++ b/backend/tests/test_api_study.py
@@ -1,13 +1,4 @@
-# Here’s the updated **`tests/test_api_study.py`** with a helper that normalizes datetimes to **aware UTC** before comparison,
-# plus clear docstrings/comments:
-
-
-"""Endpoint tests for study flow: /study/next and /study/answer.
-
-These tests exercise the selection logic (next card) and the bin/spacing updates
-when answering correct or wrong. SQLite may strip tzinfo on datetime columns, so
-we normalize DB datetimes to *aware UTC* before comparing to `datetime.now(UTC)`.
-"""
+"""Endpoint tests for featured-deck study flow."""
 
 from __future__ import annotations
 
@@ -17,104 +8,114 @@ from typing import Any, cast
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.models import Card, UserCard
+from app.models import Card, Deck, UserCard
+from app.security import DEMO_USER_ID
 
 
 def _as_aware_utc(dt: datetime) -> datetime:
-    """Normalize a datetime to timezone-aware UTC.
-
-    Args:
-        dt: A datetime that may be naive (no tzinfo) or offset-aware.
-
-    Returns:
-        datetime: A timezone-aware UTC datetime suitable for comparisons.
-    """
     if dt.tzinfo is None:
-        # SQLite often returns naive datetimes; assume they are UTC in tests.
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
 
 
-def _mk_card(s: Session, word: str = "alpha", definition: str = "a") -> Card:
-    """Insert a Card and its initial UserCard row (bin 0).
+def _featured_deck(session: Session) -> Deck:
+    deck = session.exec(select(Deck).where(Deck.slug == "platform-engineering")).first()
+    if deck is None:
+        deck = Deck(
+            owner_id=None,
+            title="Platform Engineering",
+            slug="platform-engineering",
+            description="Test featured deck",
+            is_builtin=True,
+        )
+        session.add(deck)
+        session.commit()
+        session.refresh(deck)
+    return deck
 
-    Args:
-        s: Open SQLModel session.
-        word: The vocabulary word.
-        definition: The word's definition.
 
-    Returns:
-        The created Card (refreshed with its ID).
-    """
-    c = Card(word=word, definition=definition)
-    s.add(c)
-    s.commit()
-    s.refresh(c)
-    s.add(UserCard(card_id=c.id, bin=0))
-    s.commit()
-    return c
+def _mk_card(
+    session: Session, word: str = "alpha", definition: str = "a", kind: str = "concept"
+) -> Card:
+    deck = _featured_deck(session)
+    card = Card(
+        deck_id=deck.id,
+        word=word,
+        definition=definition,
+        topic=deck.title,
+        domain="Testing",
+        kind=kind,
+        is_builtin=True,
+    )
+    session.add(card)
+    session.commit()
+    session.refresh(card)
+    session.add(UserCard(user_id=DEMO_USER_ID, card_id=int(card.id or 0), bin=0))
+    session.commit()
+    return card
 
 
 def test_next_returns_new_when_nothing_due(
     client: TestClient, sqlite_session: Session
 ) -> None:
-    """When no due cards exist, /study/next should return a bin-0 card."""
     _mk_card(sqlite_session, "alpha", "a")
-    r = client.get("/study/next")
-    data = r.json()
+    response = client.get("/study/next")
+    data = response.json()
+    assert response.status_code == 200
     assert data["status"] == "ok"
     assert data["card"]["word"] == "alpha"
+    assert data["deck"]["title"] == "Platform Engineering"
+
+
+def test_track_filter_can_select_lab(client: TestClient, sqlite_session: Session) -> None:
+    _mk_card(sqlite_session, "Concept", "c", "concept")
+    _mk_card(sqlite_session, "Lab challenge", "l", "lab")
+    response = client.get("/study/next", params={"track": "lab"})
+    assert response.status_code == 200
+    assert response.json()["card"]["kind"] == "lab"
 
 
 def test_answer_correct_moves_up_and_sets_timer(
     client: TestClient, sqlite_session: Session
 ) -> None:
-    """Answering 'correct' should increase bin and set a positive next_review_at."""
-    c = _mk_card(sqlite_session, "bravo", "b")
-
-    # First get the card
+    card = _mk_card(sqlite_session, "bravo", "b")
     assert client.get("/study/next").json()["status"] == "ok"
 
-    # Correct answer -> bin 1 (5s)
-    r = client.post(f"/study/answer?card_id={c.id}&result=correct")
-    payload = r.json()
-    assert (
-        payload["ok"] is True
-        and payload["to_bin"] == 1
-        and payload["status"] == "active"
+    response = client.post(
+        "/study/answer", params={"card_id": card.id, "result": "correct"}
     )
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["to_bin"] == 1
+    assert payload["status"] == "active"
 
-    # Verify next_review_at is in the future (~5s)
-    uc_stmt = select(UserCard).where(cast(Any, UserCard.card_id) == c.id)
-    uc = sqlite_session.exec(uc_stmt).first()
+    uc = sqlite_session.exec(
+        select(UserCard).where(cast(Any, UserCard.card_id) == card.id)
+    ).first()
     assert uc is not None
     assert uc.bin == 1
     assert uc.next_review_at is not None
-
-    # Normalize possible naive DB datetime to aware UTC before comparing
     assert _as_aware_utc(uc.next_review_at) > datetime.now(timezone.utc)
 
 
 def test_answer_wrong_resets_bin_and_increments_wrong_count(
     client: TestClient, sqlite_session: Session
 ) -> None:
-    """Answering 'wrong' should set bin=1 and increment wrong_count."""
-    c = _mk_card(sqlite_session, "charlie", "c")
-
-    # Fetch the actual UserCard instance
-    uc_stmt = select(UserCard).where(cast(Any, UserCard.card_id) == c.id)
-    uc = sqlite_session.exec(uc_stmt).first()
+    card = _mk_card(sqlite_session, "charlie", "c")
+    uc = sqlite_session.exec(
+        select(UserCard).where(cast(Any, UserCard.card_id) == card.id)
+    ).first()
     assert uc is not None
 
-    # Make it due in a higher bin to simulate real flow
     uc.bin = 3
     uc.next_review_at = datetime.now(timezone.utc) - timedelta(seconds=1)
     sqlite_session.add(uc)
     sqlite_session.commit()
 
-    # Wrong answer
     before = uc.wrong_count
-    payload = client.post(f"/study/answer?card_id={c.id}&result=wrong").json()
+    payload = client.post(
+        "/study/answer", params={"card_id": card.id, "result": "wrong"}
+    ).json()
     assert payload["ok"] is True and payload["to_bin"] == 1
 
     sqlite_session.refresh(uc)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,94 @@
+"""Authentication and email-verification regression tests."""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session, select
+
+from app.models import EmailVerificationToken, User
+from app.security import create_auth_session, hash_password, hash_token
+
+
+def test_signup_creates_unverified_account(client, sqlite_session: Session):
+    response = client.post(
+        "/auth/signup",
+        json={
+            "display_name": "Tee",
+            "email": "TEE@example.com",
+            "password": "strong-pass-123",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["email"] == "tee@example.com"
+
+    user = sqlite_session.exec(select(User).where(User.email == "tee@example.com")).first()
+    assert user is not None
+    assert user.is_verified is False
+    assert user.password_hash != "strong-pass-123"
+
+    login = client.post(
+        "/auth/login",
+        json={"email": "tee@example.com", "password": "strong-pass-123"},
+    )
+    assert login.status_code == 403
+
+
+def test_verify_login_me_and_logout(client, sqlite_session: Session):
+    user = User(
+        email="verified@example.com",
+        display_name="Verified User",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=False,
+    )
+    sqlite_session.add(user)
+    sqlite_session.commit()
+    sqlite_session.refresh(user)
+
+    raw = "verification-token-for-test"
+    sqlite_session.add(
+        EmailVerificationToken(
+            user_id=int(user.id or 0),
+            token_hash=hash_token(raw),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+        )
+    )
+    sqlite_session.commit()
+
+    verify = client.post("/auth/verify", json={"token": raw})
+    assert verify.status_code == 200
+    sqlite_session.refresh(user)
+    assert user.is_verified is True
+
+    login = client.post(
+        "/auth/login",
+        json={"email": user.email, "password": "strong-pass-123"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    me = client.get("/auth/me", headers=headers)
+    assert me.status_code == 200
+    assert me.json()["email"] == user.email
+
+    assert client.post("/auth/logout", headers=headers).status_code == 200
+    assert client.get("/auth/me", headers=headers).status_code == 401
+
+
+def test_unverified_session_cannot_create_deck(client, sqlite_session: Session):
+    user = User(
+        email="waiting@example.com",
+        display_name="Waiting",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=False,
+    )
+    sqlite_session.add(user)
+    sqlite_session.commit()
+    sqlite_session.refresh(user)
+    token = create_auth_session(sqlite_session, int(user.id or 0))
+
+    response = client.post(
+        "/decks",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "Private deck", "description": "Should wait"},
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_never.py
+++ b/backend/tests/test_never.py
@@ -1,27 +1,56 @@
-"""Ensure never/hard_to_remember cards are excluded from selection."""
+"""Ensure never/hard_to_remember cards are excluded from featured selection."""
 
 from sqlmodel import Session
-from app.models import Card, UserCard
+
+from app.models import Card, Deck, UserCard
+from app.security import DEMO_USER_ID
 
 
 def test_never_and_hard_excluded_from_selection(client, sqlite_session: Session):
-    """Cards with status 'never' or 'hard_to_remember' should not be returned by /study/next."""
-    # never
-    c1 = Card(word="final", definition="x")
+    deck = Deck(
+        owner_id=None,
+        title="Platform Engineering",
+        slug="platform-engineering",
+        description="Test starter",
+        is_builtin=True,
+    )
+    sqlite_session.add(deck)
+    sqlite_session.commit()
+    sqlite_session.refresh(deck)
+
+    c1 = Card(
+        deck_id=deck.id,
+        word="final",
+        definition="x",
+        topic=deck.title,
+        is_builtin=True,
+    )
     sqlite_session.add(c1)
     sqlite_session.commit()
     sqlite_session.refresh(c1)
-    sqlite_session.add(UserCard(card_id=c1.id, bin=11, status="never"))
-    sqlite_session.commit()
+    sqlite_session.add(
+        UserCard(user_id=DEMO_USER_ID, card_id=int(c1.id or 0), bin=11, status="never")
+    )
 
-    # hard_to_remember
-    c2 = Card(word="stuck", definition="y")
+    c2 = Card(
+        deck_id=deck.id,
+        word="stuck",
+        definition="y",
+        topic=deck.title,
+        is_builtin=True,
+    )
     sqlite_session.add(c2)
     sqlite_session.commit()
     sqlite_session.refresh(c2)
-    sqlite_session.add(UserCard(card_id=c2.id, bin=1, status="hard_to_remember"))
+    sqlite_session.add(
+        UserCard(
+            user_id=DEMO_USER_ID,
+            card_id=int(c2.id or 0),
+            bin=1,
+            status="hard_to_remember",
+        )
+    )
     sqlite_session.commit()
 
-    # no active/new cards -> temporarily_done
     data = client.get("/study/next").json()
     assert data["status"] in {"temporarily_done", "permanently_done"}

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -41,7 +41,7 @@ def test_lab_cards_are_scenario_driven():
     )
 
 
-def test_seed_platform_deck_is_idempotent(sqlite_session):
+def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     first = seed_platform_deck(sqlite_session)
     assert first["deck_size"] == 216
     assert first["concept_cards"] == 144
@@ -49,12 +49,19 @@ def test_seed_platform_deck_is_idempotent(sqlite_session):
     assert first["inserted_cards"] == 216
     assert first["created_progress"] == 216
 
-    assert len(sqlite_session.exec(select(Card)).all()) == 216
+    cards = sqlite_session.exec(select(Card)).all()
+    assert len(cards) == 216
     assert len(sqlite_session.exec(select(UserCard)).all()) == 216
+    assert all(card.topic == "Platform Engineering" for card in cards)
+    assert all(card.is_builtin for card in cards)
+    assert sum(card.kind == "concept" for card in cards) == 144
+    assert sum(card.kind == "lab" for card in cards) == 72
+    assert len({card.domain for card in cards}) >= 12
 
     second = seed_platform_deck(sqlite_session)
     assert second["inserted_cards"] == 0
     assert second["existing_cards"] == 216
+    assert second["updated_cards"] == 0
     assert second["created_progress"] == 0
 
     assert len(sqlite_session.exec(select(Card)).all()) == 216

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,9 +1,10 @@
-"""Tests for the built-in Platform Engineering concept and lab decks."""
+"""Tests for the built-in Platform Engineering concept and lab deck."""
 
 from sqlmodel import select
 
-from app.models import Card, UserCard
+from app.models import Card, Deck, UserCard
 from app.seed import (
+    DEMO_USER_ID,
     PLATFORM_ENGINEERING_CONCEPT_DECK,
     PLATFORM_ENGINEERING_DECK,
     PLATFORM_ENGINEERING_DECK_BY_DOMAIN,
@@ -49,9 +50,19 @@ def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     assert first["inserted_cards"] == 216
     assert first["created_progress"] == 216
 
+    decks = sqlite_session.exec(select(Deck)).all()
+    assert len(decks) == 1
+    assert decks[0].title == "Platform Engineering"
+    assert decks[0].slug == "platform-engineering"
+    assert decks[0].is_builtin is True
+    assert decks[0].owner_id is None
+
     cards = sqlite_session.exec(select(Card)).all()
+    progress = sqlite_session.exec(select(UserCard)).all()
     assert len(cards) == 216
-    assert len(sqlite_session.exec(select(UserCard)).all()) == 216
+    assert len(progress) == 216
+    assert all(row.user_id == DEMO_USER_ID for row in progress)
+    assert all(card.deck_id == decks[0].id for card in cards)
     assert all(card.topic == "Platform Engineering" for card in cards)
     assert all(card.is_builtin for card in cards)
     assert sum(card.kind == "concept" for card in cards) == 144
@@ -64,5 +75,6 @@ def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     assert second["updated_cards"] == 0
     assert second["created_progress"] == 0
 
+    assert len(sqlite_session.exec(select(Deck)).all()) == 1
     assert len(sqlite_session.exec(select(Card)).all()) == 216
     assert len(sqlite_session.exec(select(UserCard)).all()) == 216

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,124 @@
+# Accounts & email verification 🔐📬
+
+FlashQuest’s keeps the public featured deck easy to try while requiring a verified account before a user can create private decks.
+
+## User journey
+
+```text
+Visitor
+  │
+  ├── Try featured Platform Engineering deck
+  │
+  └── Sign up
+       │
+       ▼
+Unverified account
+       │ verification email
+       ▼
+Verified account
+       │
+       ├── Sign in
+       ├── Create private decks
+       ├── Copy starter decks
+       └── Keep per-user study progress
+```
+
+## Password storage
+
+Passwords are never stored directly.
+
+FlashQuest’s uses salted **PBKDF2-HMAC-SHA256** password hashes. Each password receives a random salt, a high iteration count, and constant-time digest comparison during login.
+
+## Login sessions
+
+The API returns a high-entropy opaque bearer token after a successful verified login.
+
+Only a SHA-256 hash of that token is stored in PostgreSQL. Sessions have an expiration time and can be explicitly revoked on logout.
+
+The V1 React client stores the bearer token in browser local storage so sessions survive navigation/reloads. For a higher-assurance production environment, an HttpOnly secure-cookie architecture would be a reasonable hardening step.
+
+## Email verification
+
+Verification links are also opaque random tokens.
+
+The database stores only the token hash plus:
+
+- user id;
+- creation time;
+- expiration time;
+- one-time `used_at` state.
+
+Creating a new verification link invalidates older unused links for that user.
+
+The default expiration is **60 minutes** and is configurable with `VERIFICATION_TOKEN_MINUTES`.
+
+## Email delivery
+
+Two delivery modes are supported:
+
+### Local / CI
+
+```text
+EMAIL_DELIVERY_MODE=console
+```
+
+The verification URL is printed to the API log. This is useful for local development and automated tests.
+
+### Hosted
+
+```text
+EMAIL_DELIVERY_MODE=resend
+RESEND_API_KEY=<secret>
+EMAIL_FROM=FlashQuest <verified-sender@example.com>
+FRONTEND_URL=https://flashcards-tobias.netlify.app
+```
+
+Hosted verification uses the Resend HTTP API. The API key must be stored as a deployment secret, never committed to the repository.
+
+For Fly.io, a typical secret setup is:
+
+```bash
+fly secrets set \
+  RESEND_API_KEY='...' \
+  DEMO_DELETE_PASSWORD='...' \
+  -a flashcards-tobias
+```
+
+Non-secret environment configuration such as `FRONTEND_URL` can live in deployment configuration.
+
+## Demo protection
+
+The featured Platform Engineering deck is public to study but protected from normal editing/deletion.
+
+- Visitors cannot edit built-in cards.
+- Signed-in users can copy the featured deck and edit their private copy.
+- Built-in destructive operations require `DEMO_DELETE_PASSWORD` on the server.
+- The demo password is entered only when the owner performs maintenance; it is not embedded in the frontend bundle.
+
+## Privacy boundary
+
+Public API calls expose built-in starter content only. Authenticated card/deck listing is scoped to:
+
+1. built-in public decks; and
+2. decks owned by the signed-in user.
+
+A user cannot update or delete another user’s custom deck/cards through the normal API routes.
+
+## Important production configuration
+
+Before enabling public signup, configure:
+
+```text
+APP_ENV=production
+FRONTEND_URL=https://flashcards-tobias.netlify.app
+EMAIL_DELIVERY_MODE=resend
+RESEND_API_KEY=<secret>
+EMAIL_FROM=<verified sender>
+DEMO_DELETE_PASSWORD=<strong secret>
+```
+
+!!! warning "Email delivery is a deployment dependency"
+    If hosted email delivery is configured as `resend` without a valid API key, account creation may succeed but verification delivery will return a service error. The user can use **Resend verification** once the provider is configured.
+
+[Build a custom deck →](MAKE_YOUR_OWN_DECK.md){ .md-button .md-button--primary }
+[Operations & deployment →](OPERATIONS.md){ .md-button }

--- a/docs/MAKE_YOUR_OWN_DECK.md
+++ b/docs/MAKE_YOUR_OWN_DECK.md
@@ -1,0 +1,73 @@
+# Make your own deck ✨🗂️
+
+FlashQuest’s is a reusable study engine. **Platform Engineering is the featured starter deck**, not a hard-coded limit on what the product can teach.
+
+A visitor can play the public Platform Engineering deck without an account. A verified account unlocks private, user-owned decks.
+
+## The simple version
+
+1. **Try the demo** — play the featured Platform Engineering deck.
+2. **Create an account** — name, email, password.
+3. **Verify your email** — click the one-time link FlashQuest sends.
+4. **Create a deck** — give it a name such as `AWS Solutions Architect`, `Spanish`, or `Biology Chapter 4`.
+5. **Add cards** — choose a question, answer, category/domain, and card type.
+6. **Study it** — the same XP, streak, mastery, and spaced-repetition engine now works on your topic.
+
+## Concepts vs labs
+
+Every custom card can be one of two types:
+
+- **Concept** — learn or explain an idea.
+- **Lab** — pretend something is broken or needs to be built, then explain the troubleshooting or implementation path.
+
+That means a security deck can mix definitions with incident scenarios, a programming deck can mix language concepts with debugging exercises, and a school deck can mix facts with worked problems.
+
+## Deck ownership
+
+Custom decks belong to the signed-in account that created them.
+
+- Other users cannot list or edit them.
+- Custom cards can be edited or deleted by their owner.
+- Deleting a custom deck also removes its cards, study progress, and review history.
+- A featured deck can be copied into your account so you can customize the copy without changing the public demo.
+
+## Featured Platform Engineering deck
+
+The first starter pack contains **216 cards**:
+
+- 144 concepts;
+- 72 break/fix labs;
+- 12 domains;
+- 12 mastery levels.
+
+The public copy is protected from normal editing. Server-side demo-owner authentication is required for destructive maintenance such as deleting built-in cards or resetting shared demo progress.
+
+## Adding future starter packs
+
+The product model is:
+
+```text
+User
+  └── Deck
+       └── Card
+            ├── domain / category
+            └── kind: concept | lab
+```
+
+Built-in starter packs are simply decks with `is_builtin=true` and no owner. New starter packs can therefore reuse the same deck/card/study engine rather than requiring a new application.
+
+Good future examples include:
+
+- AWS
+- Azure
+- Linux+
+- Security+
+- Python
+- SQL / database engineering
+- networking certifications
+- interview preparation
+- school subjects
+- language learning
+
+[Read how accounts are protected →](AUTHENTICATION.md){ .md-button .md-button--primary }
+[Open FlashQuest’s →](https://flashcards-tobias.netlify.app/){ .md-button }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations & deployment ⚙️
 
-This page is the runbook for operating FlashQuest’s locally and understanding its deployment boundaries.
+This is the runbook for operating FlashQuest’s locally and understanding the production boundaries between the React app, FastAPI, PostgreSQL, email verification, Netlify, and Fly.io.
 
 ## Runtime topology
 
@@ -8,20 +8,25 @@ This page is the runbook for operating FlashQuest’s locally and understanding 
 browser
   │
   ▼
-web (React/Nginx)
+React / Netlify
+  │ HTTPS + bearer session
+  ▼
+FastAPI / Fly.io
+  │
+  ├── Resend API (verification email)
   │
   ▼
-api (FastAPI/Uvicorn)
-  │
-  ▼
-db (PostgreSQL 16)
+PostgreSQL
 ```
 
-Docker Compose enforces dependency-aware startup:
+The data plane stores:
 
-1. PostgreSQL starts and passes `pg_isready`.
-2. The API starts only after the database is healthy.
-3. The web container starts only after the API passes `/health/ready`.
+- accounts and verification state;
+- hashed opaque auth sessions;
+- featured and user-owned decks;
+- cards;
+- per-user mastery state;
+- review history.
 
 ---
 
@@ -34,20 +39,20 @@ cd FlashQuest
 docker compose up --build -d
 ```
 
-Apply the schema explicitly:
+Apply the schema:
 
 ```bash
 docker compose exec api \
   alembic -c /app/alembic.ini upgrade head
 ```
 
-Seed the built-in curriculum:
+Seed the featured Platform Engineering deck:
 
 ```bash
 docker compose exec api python -m app.seed
 ```
 
-Verify all three services:
+Verify:
 
 ```bash
 docker compose ps
@@ -55,226 +60,309 @@ curl http://localhost:8080/health/live
 curl http://localhost:8080/health/ready
 ```
 
-Open the application at `http://localhost:5173`.
+Open:
+
+- app: `http://localhost:5173`
+- API docs: `http://localhost:8080/docs`
 
 !!! important "Migrate before seeding"
-    FlashQuest’s does not silently mutate the schema on API startup. On a fresh database, run Alembic before the curriculum seeder.
+    The API does not silently create tables at process startup. Alembic owns schema lifecycle; the curriculum seeder owns featured starter data.
+
+---
+
+## Featured seed lifecycle
+
+The seeder is **idempotent**. Running it repeatedly:
+
+1. creates or repairs the built-in `Platform Engineering` deck;
+2. inserts missing cards;
+3. repairs built-in metadata and deck membership;
+4. creates missing anonymous-demo progress rows;
+5. does not duplicate existing content.
+
+The featured deck contains **216 cards: 144 concepts + 72 labs**.
+
+Fly’s release command is configured to run:
+
+```text
+alembic upgrade head && python -m app.seed
+```
+
+That means a backend release applies the schema before repairing the featured content.
 
 ---
 
 ## Health semantics
 
-| Endpoint | Meaning | Database required? |
+| Endpoint | Meaning | PostgreSQL required? |
 | --- | --- | --- |
-| `GET /health` | lightweight backwards-compatible health response | No |
-| `GET /health/live` | process/service is alive; includes service metadata | No |
-| `GET /health/ready` | API can serve traffic including critical DB access | **Yes** |
+| `GET /health` | lightweight backwards-compatible process health | No |
+| `GET /health/live` | process is alive + service metadata | No |
+| `GET /health/ready` | API can execute a database query | **Yes** |
 
-A process can be alive while the service is not ready. This distinction lets an orchestrator avoid sending traffic to an API that cannot reach PostgreSQL without treating every dependency outage as a crashed process.
-
-### Quick diagnosis
+A live process can still be unready when PostgreSQL is unavailable.
 
 ```bash
 curl -i http://localhost:8080/health/live
 curl -i http://localhost:8080/health/ready
 ```
 
-If liveness succeeds but readiness returns `503`, investigate PostgreSQL connectivity before restarting the API blindly.
+If liveness succeeds but readiness returns `503`, investigate the database/network path before restarting the API blindly.
 
 ---
 
-## Request diagnostics
+## Runtime configuration
 
-Every API response includes:
+| Variable | Purpose | Secret? |
+| --- | --- | --- |
+| `DATABASE_URL` | PostgreSQL / SQLAlchemy connection string | Usually |
+| `APP_ENV` | runtime environment label | No |
+| `APP_VERSION` | API version metadata | No |
+| `LOG_LEVEL` | logging configuration | No |
+| `ALLOWED_ORIGINS` | extra CORS browser origins | No |
+| `ACCESS_TOKEN_MINUTES` | opaque bearer-session lifetime | No |
+| `FRONTEND_URL` | base URL used in verification links | No |
+| `EMAIL_DELIVERY_MODE` | `console` locally or `resend` hosted | No |
+| `RESEND_API_KEY` | Resend API credential | **Yes** |
+| `EMAIL_FROM` | verification sender identity | No |
+| `VERIFICATION_TOKEN_MINUTES` | email-link lifetime | No |
+| `DEMO_DELETE_PASSWORD` | owner-only built-in deletion/reset guard | **Yes** |
+| `VITE_API_URL` | FastAPI URL compiled into React | No |
+
+Do not commit production credentials to the repository.
+
+### Hosted email verification
+
+Fly is configured for:
 
 ```text
-X-Request-ID
-X-Response-Time-Ms
+EMAIL_DELIVERY_MODE=resend
+FRONTEND_URL=https://flashcards-tobias.netlify.app
 ```
 
-If a client sends `X-Request-ID`, the API propagates it. Otherwise FlashQuest’s generates one.
-
-Use that ID to correlate a user-facing failure with API or proxy logs.
+Before enabling public signup, configure the provider secret and demo-owner secret:
 
 ```bash
-curl -i \
-  -H 'X-Request-ID: lab-incident-001' \
-  http://localhost:8080/health/live
+fly secrets set \
+  RESEND_API_KEY='...' \
+  DEMO_DELETE_PASSWORD='...' \
+  -a flashcards-tobias
 ```
+
+You should also configure `EMAIL_FROM` to a sender/domain accepted by your Resend account.
+
+!!! warning "Signup depends on email delivery"
+    If the hosted API is in `resend` mode without a working `RESEND_API_KEY`, the account row can be created but delivery returns a service error. Once the provider is configured, the user can request **Resend verification**.
 
 ---
 
-## Useful Docker commands
+## Authentication diagnostics
 
-### Service state
+### User cannot sign in
 
-```bash
-docker compose ps
+Check:
+
+1. the account exists;
+2. email is verified;
+3. the password matches;
+4. bearer session has not expired/revoked;
+5. browser requests contain `Authorization: Bearer ...`.
+
+### Verification email never arrives
+
+Check:
+
+1. `EMAIL_DELIVERY_MODE`;
+2. `RESEND_API_KEY` is present in Fly secrets;
+3. `EMAIL_FROM` is allowed by the provider;
+4. `FRONTEND_URL` points at the current app URL;
+5. Fly/API logs for provider HTTP errors.
+
+Local mode intentionally prints the verification URL to the API logs:
+
+```text
+EMAIL_DELIVERY_MODE=console
 ```
 
-### API logs
+### Verification link expired
 
-```bash
-docker compose logs --tail=200 api
-```
+Links are one-time tokens and expire. Use the **Resend verification** flow to create a fresh token; older unused links are invalidated.
 
-### PostgreSQL logs
+---
 
-```bash
-docker compose logs --tail=200 db
-```
+## Deck ownership and demo protection
 
-### Follow logs
+The built-in Platform Engineering deck is public to read/study. Custom decks belong to their verified creator.
 
-```bash
-docker compose logs -f api db
-```
+API boundaries enforce:
 
-### Restart one service
+- anonymous users see built-in content only;
+- signed-in users see built-ins + their own decks;
+- users can mutate only their own custom decks/cards;
+- featured content is read-only through normal user routes;
+- destructive maintenance on built-ins requires the server-side demo password.
 
-```bash
-docker compose restart api
-```
-
-### Stop the stack
-
-```bash
-docker compose down
-```
-
-### Destroy the local database volume
-
-```bash
-docker compose down -v
-```
-
-!!! warning "`down -v` deletes local database state"
-    Use it only when you intentionally want a clean local PostgreSQL volume. Afterward repeat **start → migrate → seed → verify**.
+The demo password is never compiled into the React bundle.
 
 ---
 
 ## Database lifecycle
 
-### Current migration
+Inspect migration state:
 
 ```bash
 docker compose exec api \
   alembic -c /app/alembic.ini current
 ```
 
-### Upgrade to head
+Upgrade:
 
 ```bash
 docker compose exec api \
   alembic -c /app/alembic.ini upgrade head
 ```
 
-### Create a migration after model changes
+Create a migration after changing persistent models:
 
 ```bash
 docker compose exec api \
   alembic -c /app/alembic.ini revision --autogenerate -m "describe change"
 ```
 
-CI provisions a clean PostgreSQL 16 service and upgrades it to Alembic `head`, catching migrations that only work against a developer’s existing database.
+CI provisions clean PostgreSQL 16 and runs `alembic upgrade head` so migration failures are caught before merge.
 
 ---
 
-## Runtime configuration
+## Request diagnostics
 
-| Variable | Purpose |
-| --- | --- |
-| `DATABASE_URL` | PostgreSQL / SQLAlchemy connection string |
-| `APP_ENV` | runtime environment label |
-| `APP_VERSION` | service version returned by operational metadata |
-| `LOG_LEVEL` | application logging level/configuration input |
-| `ALLOWED_ORIGINS` | browser origins allowed through CORS |
-| `VITE_API_URL` | API base URL compiled into the React frontend |
-
-Keep environment-specific credentials and secrets outside the repository.
-
----
-
-## CI gates
-
-The application pipeline validates:
-
-- backend compilation and tests on Python 3.11 and 3.12;
-- Ruff correctness checks;
-- Black formatting checks for upgraded platform code;
-- frontend ESLint + TypeScript/Vite build;
-- Alembic migration against clean PostgreSQL 16;
-- Docker Compose configuration;
-- API and web container builds.
-
-The docs pipeline separately builds MkDocs + TypeDoc, keeping documentation failures isolated from application CI while still blocking broken docs changes in pull requests.
-
----
-
-## Netlify docs deployment
-
-The **root `netlify.toml` is the documentation deployment**, not the React application deployment.
-
-Its docs build:
-
-1. creates a Python virtual environment;
-2. installs MkDocs Material and mkdocstrings;
-3. installs backend requirements so Python API references can import;
-4. runs the frontend TypeDoc generation;
-5. runs `mkdocs build --strict`;
-6. publishes the generated `site/` directory.
-
-The config also uses a content-change filter. A Netlify deploy may be **canceled intentionally** when none of these paths changed:
+API responses include:
 
 ```text
-mkdocs.yml
-docs/
-frontend/
-backend/
-.github/workflows/
+X-Request-ID
+X-Response-Time-Ms
 ```
 
-That “canceled due to no content change” result is an optimization, not a build failure.
+Send a known request id when reproducing a problem:
 
-### React application deployment
+```bash
+curl -i \
+  -H 'X-Request-ID: debug-001' \
+  http://localhost:8080/health/live
+```
 
-Treat the React application as a separate web deployment concern. For a Netlify site that hosts the app itself:
+Use the same id to correlate client symptoms with API/proxy logs.
+
+---
+
+## Docker commands
+
+```bash
+# state
+docker compose ps
+
+# API logs
+docker compose logs --tail=200 api
+
+# DB logs
+docker compose logs --tail=200 db
+
+# follow both
+docker compose logs -f api db
+
+# stop
+docker compose down
+```
+
+Destroy the local database only when you intentionally want a clean environment:
+
+```bash
+docker compose down -v
+```
+
+Then repeat **start → migrate → seed → verify**.
+
+---
+
+## Netlify deployments
+
+FlashQuest’s has two separate Netlify concerns:
+
+### React application
 
 ```text
+Site: flashcards-tobias
 Base directory: frontend
 Build command: npm run build
 Publish directory: dist
+VITE_API_URL: https://flashcards-tobias.fly.dev
 ```
 
-Set `VITE_API_URL` to the deployed FastAPI base URL for that application site.
+### MkDocs documentation
 
-!!! note "Docs and app are intentionally separate"
-    The root Netlify config publishes MkDocs to `site/`. Do not repurpose it as the React app deployment by changing its publish directory to `frontend/dist`; that would collapse two different deployment concerns into one config.
+```text
+Site: flashquest-docs
+URL: https://flashquest-docs.netlify.app/
+Publish directory: site
+```
+
+The root `netlify.toml` belongs to **MkDocs**, not the React application.
+
+A docs deploy may be intentionally skipped/canceled when no docs-relevant paths changed. That optimization is not itself a build failure.
 
 ---
 
-## Failure triage cheatsheet
+## Fly deployment boundary
+
+Netlify deploying the React bundle **does not migrate PostgreSQL**.
+
+The account/deck schema and featured seed become production-ready only after the corresponding backend commit is deployed to Fly. Fly then executes the configured release command before starting the new app version.
+
+For this V1, production rollout order is:
+
+1. configure required Fly secrets;
+2. deploy FastAPI/Fly commit;
+3. confirm migration + seed release command succeeded;
+4. verify `/health/ready`;
+5. deploy/confirm React frontend;
+6. test signup → verification → login → create deck;
+7. confirm MkDocs deployment.
+
+---
+
+## CI quality gates
+
+Application CI validates:
+
+- Python 3.11/3.12 tests;
+- Ruff correctness checks;
+- Black checks for upgraded backend code;
+- frontend ESLint + production Vite build;
+- clean PostgreSQL migration to Alembic `head`;
+- Compose configuration;
+- API/web container builds.
+
+Documentation CI separately runs MkDocs + TypeDoc with strict build checking.
+
+---
+
+## Failure triage
 
 | Symptom | First checks |
 | --- | --- |
-| Web page unavailable | `docker compose ps`, web logs, frontend build/deploy status |
-| API returns connection errors | `/health/live`, `/health/ready`, API logs, `DATABASE_URL` |
-| API live but not ready | PostgreSQL health/logs, network/DNS between API and DB |
-| Fresh DB has missing tables | Alembic `current`, then `upgrade head` |
-| No study cards | run `python -m app.seed`, inspect seed output |
-| Netlify docs deploy skipped | check whether docs-relevant paths actually changed |
-| Docs build fails | run `mkdocs build --strict`; inspect TypeDoc/MkDocs import errors |
-| Container image build fails | reproduce the failing Docker build and inspect the first failed layer |
+| Play shows `Network Error` | `VITE_API_URL`, Fly health, CORS, browser network tab |
+| API live but not ready | PostgreSQL health/network/`DATABASE_URL` |
+| Featured deck empty | migration state, release seed output, `python -m app.seed` |
+| Signup 503 after account creation | Resend key/sender/provider logs |
+| Login 403 | email verification state |
+| Custom deck invisible | bearer session + ownership scope |
+| User cannot modify a card | deck ownership / built-in protection |
+| Docs old after merge | Netlify `flashquest-docs` production deploy status |
+| Migration fails | first failing Alembic revision on clean PostgreSQL |
 
----
-
-## Operational principle
-
-The safest recovery loop is:
+The operational loop remains:
 
 **observe → narrow → mitigate → verify → prevent**
 
-Restarting can be a mitigation, but it should not replace understanding the failure signal.
-
-[Architecture decisions →](PLATFORM_ENGINEERING.md){ .md-button }
-[Practice break/fix scenarios →](LABS.md){ .md-button .md-button--primary }
+[Account model →](AUTHENTICATION.md){ .md-button }
+[Custom decks →](MAKE_YOUR_OWN_DECK.md){ .md-button }
+[Architecture →](PLATFORM_ENGINEERING.md){ .md-button .md-button--primary }

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,63 +4,145 @@
 
 ## Learn it. Break it. Fix it. Remember it.
 
-**FlashQuest’s** is a game-like Platform Engineering study and troubleshooting environment built with React, FastAPI, PostgreSQL, Alembic, Docker, and GitHub Actions.
+**FlashQuest’s** is a reusable, game-like study engine built with React, FastAPI, PostgreSQL, Alembic, and Docker.
 
-It combines a **216-card curriculum** with hands-on break/fix scenarios and a real full-stack application you can inspect while you study.
+Start instantly with the featured **216-card Platform Engineering deck**. Then create a verified account and build private decks for **anything you want to learn**.
+
+[Open FlashQuest’s →](https://flashcards-tobias.netlify.app/){ .md-button .md-button--primary }
+[Make your own deck →](MAKE_YOUR_OWN_DECK.md){ .md-button }
 
 </div>
 
 <div class="fq-grid" markdown>
 
 <div class="fq-card" markdown>
-**144 concept cards**
+**Try before signing up**
 
-Interview-style questions covering the systems Platform Engineers work with.
+The featured Platform Engineering deck is public, so visitors can understand the study loop immediately.
 </div>
 
 <div class="fq-card" markdown>
-**72 break/fix labs**
+**Verify once, build anything**
 
-Operational scenarios: diagnose the symptoms, choose the next signal, and recover safely.
+Sign up, verify your email, then create private decks with concept cards and break/fix labs.
 </div>
 
 <div class="fq-card" markdown>
-**12 domains**
+**216-card starter pack**
 
-Linux through incident response, with 18 challenges in every domain.
+144 Platform Engineering concepts + 72 practical troubleshooting labs across 12 domains.
 </div>
 
 <div class="fq-card" markdown>
 **12 mastery levels**
 
-PostgreSQL-backed spaced repetition tracks durable progress while session XP keeps studying fun.
+Spaced repetition stores durable progress in PostgreSQL while XP and streaks make each session feel like a game.
 </div>
 
 </div>
 
-## 🧭 Pick your path
+## 🧭 How the product works
 
-=== "Study"
+```text
+Visitor
+  │
+  ├── Play featured Platform Engineering deck
+  │
+  └── Sign up
+       │
+       ▼
+Verify email
+       │
+       ▼
+Sign in
+       │
+       ├── Create private deck
+       ├── Copy + customize featured deck
+       ├── Add concept / lab cards
+       └── Study with personal progress
+```
 
-    Start with the [Platform Engineering curriculum](CURRICULUM.md), then use the [Break/Fix Labs](LABS.md) to practice applying the concepts under pressure.
+### The UI explains the loop in five tiny steps
 
-=== "Build"
+1. **Pick a deck.**
+2. **Read the question and think first.**
+3. **Reveal the answer.**
+4. **Choose Missed it or Got it.**
+5. **Keep going — weaker cards return sooner.**
 
-    Read the [Platform Engineering architecture](PLATFORM_ENGINEERING.md) to see how FlashQuest’s handles health checks, migrations, configuration, containers, and CI quality gates.
-
-=== "Operate"
-
-    Use the [Operations & Deployment guide](OPERATIONS.md) for startup order, diagnostics, database lifecycle, Docker commands, and deployment boundaries.
-
-=== "Inspect the code"
-
-    Jump into the generated [Backend API](backend/api.md) or [Frontend reference](frontend/modules.md).
+For a **lab** card, pretend the system is broken, say what you would inspect first, then reveal the suggested recovery path.
 
 ---
 
-## ⚡ Quick start
+## ✨ Make your own deck
 
-A fresh environment should come up in this order:
+Platform Engineering is the first built-in pack, not the limit of the product.
+
+A verified user can create decks for topics such as:
+
+- AWS, Azure, Linux, Kubernetes, Security+, or Terraform;
+- Python, SQL, coding interviews, and database engineering;
+- school subjects;
+- language learning;
+- certifications;
+- personal study notes.
+
+Each card belongs to a **Deck** and carries a category/domain plus a type:
+
+```text
+User
+  └── Deck
+       └── Card
+            ├── domain / category
+            └── kind: concept | lab
+```
+
+The same study engine works for every deck.
+
+[See the custom-deck flow →](MAKE_YOUR_OWN_DECK.md){ .md-button .md-button--primary }
+[Read the account security model →](AUTHENTICATION.md){ .md-button }
+
+---
+
+## ⭐ Featured Platform Engineering deck
+
+The starter deck includes **216 challenges**:
+
+| Content | Count |
+| --- | ---: |
+| Concept / interview cards | 144 |
+| Break/Fix labs | 72 |
+| Domains | 12 |
+| **Total cards** | **216** |
+
+The built-in content covers Linux, networking, containers, Kubernetes, CI/CD, cloud, Terraform/IaC, observability, databases, security, SRE/reliability, and incident response.
+
+[Explore the curriculum →](CURRICULUM.md){ .md-button }
+[See the lab format →](LABS.md){ .md-button }
+
+---
+
+## 🔐 Accounts and email verification
+
+Custom deck creation is unlocked after email verification.
+
+FlashQuest’s uses:
+
+- salted PBKDF2-HMAC-SHA256 password hashes;
+- high-entropy opaque bearer sessions stored only as hashes;
+- one-time, expiring email-verification tokens stored only as hashes;
+- owner-scoped deck/card APIs;
+- server-side password protection for destructive maintenance on the public demo deck.
+
+Hosted verification emails are designed to use **Resend**. Local development can print verification URLs to the API log instead.
+
+[Accounts & email verification →](AUTHENTICATION.md){ .md-button .md-button--primary }
+
+---
+
+## ⚡ Local quick start
+
+A fresh environment comes up in this order:
 
 **start → migrate → seed → verify**
 
@@ -83,47 +165,14 @@ curl http://localhost:8080/health/live
 curl http://localhost:8080/health/ready
 ```
 
-Then open:
+Open:
 
-- **FlashQuest’s game UI:** `http://localhost:5173`
+- **React app:** `http://localhost:5173`
 - **FastAPI / OpenAPI:** `http://localhost:8080/docs`
-- **Readiness endpoint:** `http://localhost:8080/health/ready`
+- **Readiness:** `http://localhost:8080/health/ready`
 
-!!! tip "Seeding is safe to repeat"
-    The built-in curriculum seeder is idempotent. Existing prompts are reused, new curriculum cards are inserted, and missing default-user progress rows are repaired without duplicating the deck.
-
----
-
-## 📚 What you study
-
-Every domain contains **12 concept cards + 6 practical lab scenarios**.
-
-| Domain | Concepts | Labs | Total |
-| --- | ---: | ---: | ---: |
-| Linux & OS | 12 | 6 | 18 |
-| Networking | 12 | 6 | 18 |
-| Containers | 12 | 6 | 18 |
-| Kubernetes | 12 | 6 | 18 |
-| CI/CD | 12 | 6 | 18 |
-| Cloud | 12 | 6 | 18 |
-| IaC & Terraform | 12 | 6 | 18 |
-| Observability | 12 | 6 | 18 |
-| Databases | 12 | 6 | 18 |
-| Security | 12 | 6 | 18 |
-| SRE & Reliability | 12 | 6 | 18 |
-| Incident Response | 12 | 6 | 18 |
-| **Total** | **144** | **72** | **216** |
-
-The curriculum itself is versioned under:
-
-```text
-backend/app/data/
-├── platform_engineering_cards.json
-└── platform_engineering_labs.json
-```
-
-[Explore the full curriculum →](CURRICULUM.md){ .md-button .md-button--primary }
-[Try the lab format →](LABS.md){ .md-button }
+!!! tip "The featured seed is idempotent"
+    Re-running the seeder repairs the built-in Platform Engineering deck, its 216 cards, metadata, and missing anonymous-demo progress without duplicating content.
 
 ---
 
@@ -134,7 +183,7 @@ Browser
   │
   ▼
 React / TypeScript SPA
-  │ HTTP / JSON
+  │ HTTP / JSON + bearer session
   ▼
 FastAPI
   │ SQLModel / SQLAlchemy
@@ -145,20 +194,22 @@ PostgreSQL 16
 Alembic
 ```
 
-FlashQuest’s deliberately separates **application liveness** from **dependency readiness**, validates migrations in CI, runs the API container as a non-root user, and keeps durable study state in PostgreSQL while browser-session game feedback remains ephemeral.
+The application separates liveness from database-backed readiness, validates migrations in CI, runs its API container as a non-root user, and keeps durable accounts/decks/cards/progress in PostgreSQL.
 
-[Read the architecture decisions →](PLATFORM_ENGINEERING.md){ .md-button }
+[Architecture decisions →](PLATFORM_ENGINEERING.md){ .md-button }
+[Operations & deployment →](OPERATIONS.md){ .md-button }
 
 ---
 
 ## ✅ Quality gates
 
-Changes are validated across the same boundaries the application depends on:
+Pull requests validate:
 
-1. **Backend** — Python 3.11/3.12, compile, pytest, Ruff correctness, Black formatting.
-2. **Frontend** — clean install, ESLint, TypeScript, Vite production build.
-3. **Database** — clean PostgreSQL 16 + Alembic upgrade to `head`.
-4. **Containers** — Compose validation plus API and web image builds.
-5. **Documentation** — MkDocs + TypeDoc build checks.
+1. backend tests on Python 3.11 and 3.12;
+2. Ruff correctness and Black formatting checks;
+3. frontend ESLint + TypeScript/Vite production build;
+4. Alembic against clean PostgreSQL 16;
+5. Docker Compose + API/web image builds;
+6. strict MkDocs + TypeDoc documentation builds.
 
-That gives FlashQuest’s two jobs at once: **help you study Platform Engineering and give you a Platform Engineering project to talk about.**
+FlashQuest’s is therefore both **a study product** and **a portfolio project demonstrating platform-minded software delivery**.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,10 +1,27 @@
 :root {
-  --fq-glow: 0 0 32px rgba(34, 211, 238, 0.12);
+  --fq-ink: #03071e;
+  --fq-bordeaux: #370617;
+  --fq-cherry: #6a040f;
+  --fq-ember: #d00000;
+  --fq-cayenne: #e85d04;
+  --fq-orange: #faa307;
+  --fq-amber: #ffba08;
+  --fq-glow: 0 0 34px rgba(250, 163, 7, 0.13);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #03071e;
+  --md-default-bg-color--light: #090818;
+  --md-primary-fg-color: #03071e;
+  --md-accent-fg-color: #faa307;
+  --md-typeset-a-color: #ffba08;
+  --md-code-bg-color: rgba(55, 6, 23, 0.62);
 }
 
 .md-header,
 .md-tabs {
   backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(250, 163, 7, 0.12);
 }
 
 .md-main__inner {
@@ -22,10 +39,12 @@
 }
 
 .md-typeset .fq-hero {
-  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 28%, transparent);
+  border: 1px solid rgba(250, 163, 7, 0.24);
   border-radius: 1rem;
   padding: 1.25rem 1.4rem;
-  background: linear-gradient(135deg, rgba(124, 58, 237, 0.13), rgba(34, 211, 238, 0.08));
+  background:
+    radial-gradient(circle at 90% 0%, rgba(232, 93, 4, 0.15), transparent 18rem),
+    linear-gradient(135deg, rgba(106, 4, 15, 0.38), rgba(3, 7, 30, 0.1));
   box-shadow: var(--fq-glow);
 }
 
@@ -37,16 +56,24 @@
 }
 
 .md-typeset .fq-card {
-  border: 1px solid var(--md-default-fg-color--lightest);
+  border: 1px solid color-mix(in srgb, var(--fq-orange) 18%, transparent);
   border-radius: 0.85rem;
   padding: 0.95rem 1rem;
-  background: var(--md-code-bg-color);
+  background: color-mix(in srgb, var(--md-code-bg-color) 92%, transparent);
 }
 
 .md-typeset .fq-card strong {
   display: block;
   margin-bottom: 0.25rem;
   font-size: 1.05rem;
+  color: var(--fq-amber);
+}
+
+.md-typeset .md-button--primary {
+  background: linear-gradient(90deg, var(--fq-cayenne), var(--fq-orange));
+  border-color: var(--fq-orange);
+  color: var(--fq-ink);
+  font-weight: 800;
 }
 
 .md-typeset code {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,100 +1,83 @@
 import { BrowserRouter, Navigate, NavLink, Route, Routes } from "react-router-dom";
+import { AuthProvider, useAuth } from "./auth";
 import Admin from "./pages/Admin";
-import Study from "./pages/Study";
+import Landing from "./pages/Landing";
+import Login from "./pages/Login";
+import MyDecks from "./pages/MyDecks";
+import Signup from "./pages/Signup";
 import Status from "./pages/Status";
-
-const navItems = [
-  { to: "/study", icon: "⚡", label: "Play" },
-  { to: "/admin", icon: "🧪", label: "Deck Lab" },
-  { to: "/status", icon: "🗺️", label: "Deck Map" },
-];
+import Study from "./pages/Study";
+import VerifyEmail from "./pages/VerifyEmail";
 
 const DOCS_URL = "https://flashquest-docs.netlify.app/";
 
-export default function App() {
+function Shell() {
+  const { user, signOut } = useAuth();
+  const navItems = [
+    { to: "/study", icon: "⚡", label: "Play" },
+    { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
+    ...(user ? [{ to: "/decks", icon: "🗂️", label: "My Decks" }] : []),
+    { to: "/status", icon: "🗺️", label: "Deck Map" },
+  ];
+
   return (
-    <BrowserRouter>
-      <div className="game-shell min-h-screen text-slate-100">
-        <div className="game-grid" aria-hidden="true" />
+    <div className="game-shell min-h-screen text-slate-100">
+      <div className="game-grid" aria-hidden="true" />
 
-        <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
-          <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-            <NavLink to="/study" className="group flex items-center gap-3">
-              <div className="grid h-11 w-11 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">
-                🧠
-              </div>
-              <div>
-                <div className="flex items-center gap-2">
-                  <span className="text-lg font-black tracking-tight text-white">FlashQuest’s</span>
-                  <span className="rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-[#ffba08]">
-                    Quest Mode
-                  </span>
-                </div>
-                <p className="text-xs font-medium text-slate-400">Any topic. One memory engine.</p>
-              </div>
-            </NavLink>
-
-            <div className="flex flex-wrap items-center gap-2">
-              <nav className="flex gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
-                {navItems.map((item) => (
-                  <NavLink
-                    key={item.to}
-                    to={item.to}
-                    className={({ isActive }) =>
-                      [
-                        "flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition",
-                        isActive
-                          ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20"
-                          : "text-slate-300 hover:bg-white/10 hover:text-white",
-                      ].join(" ")
-                    }
-                  >
-                    <span aria-hidden="true">{item.icon}</span>
-                    <span>{item.label}</span>
-                  </NavLink>
-                ))}
-              </nav>
-              <a
-                href={DOCS_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] hover:bg-[#6a040f]/65"
-              >
-                📖 Docs
-              </a>
+      <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 lg:flex-row lg:items-center lg:justify-between sm:px-6">
+          <NavLink to="/" className="group flex items-center gap-3">
+            <div className="grid h-11 w-11 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">🧠</div>
+            <div>
+              <div className="flex items-center gap-2"><span className="text-lg font-black tracking-tight text-white">FlashQuest’s</span><span className="rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-[#ffba08]">Quest Mode</span></div>
+              <p className="text-xs font-medium text-slate-400">Any topic. One memory engine.</p>
             </div>
+          </NavLink>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <nav className="flex flex-wrap gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
+              {navItems.map((item) => (
+                <NavLink key={item.to} to={item.to} className={({ isActive }) => ["flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
+                  <span aria-hidden="true">{item.icon}</span><span>{item.label}</span>
+                </NavLink>
+              ))}
+            </nav>
+            <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
+            {user ? (
+              <div className="flex items-center gap-2">
+                <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 sm:inline">👋 {user.display_name}</span>
+                <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
+              </div>
+            ) : (
+              <div className="flex gap-2"><NavLink className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" to="/login">Sign in</NavLink><NavLink className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]" to="/signup">Make a deck</NavLink></div>
+            )}
           </div>
-        </header>
+        </div>
+      </header>
 
-        <main className="relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
-          <Routes>
-            <Route path="/" element={<Navigate to="/study" replace />} />
-            <Route path="/study" element={<Study />} />
-            <Route path="/admin" element={<Admin />} />
-            <Route path="/status" element={<Status />} />
-            <Route
-              path="*"
-              element={
-                <div className="game-panel mx-auto max-w-lg p-8 text-center">
-                  <div className="text-5xl">🌀</div>
-                  <h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1>
-                  <p className="mt-2 text-slate-400">That route slipped into another dimension.</p>
-                  <NavLink to="/study" className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">
-                    Return to the quest
-                  </NavLink>
-                </div>
-              }
-            />
-          </Routes>
-        </main>
+      <main className="relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/study" element={<Study />} />
+          <Route path="/deck-lab" element={<Admin />} />
+          <Route path="/admin" element={<Navigate to="/deck-lab" replace />} />
+          <Route path="/decks" element={<MyDecks />} />
+          <Route path="/status" element={<Status />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/verify-email" element={<VerifyEmail />} />
+          <Route path="*" element={<div className="game-panel mx-auto max-w-lg p-8 text-center"><div className="text-5xl">🌀</div><h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1><p className="mt-2 text-slate-400">That route slipped into another dimension.</p><NavLink to="/" className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">Back home</NavLink></div>} />
+        </Routes>
+      </main>
 
-        <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-          <span>Reusable topics · concepts + labs · 12 mastery levels</span>
-          <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">
-            FastAPI · React · PostgreSQL · Docker · Docs ↗
-          </a>
-        </footer>
-      </div>
-    </BrowserRouter>
+      <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
+        <span>Featured Platform Engineering · make your own decks · 12 mastery levels</span>
+        <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>
+      </footer>
+    </div>
   );
+}
+
+export default function App() {
+  return <BrowserRouter><AuthProvider><Shell /></AuthProvider></BrowserRouter>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,48 +9,60 @@ const navItems = [
   { to: "/status", icon: "🗺️", label: "Deck Map" },
 ];
 
+const DOCS_URL = "https://flashquest-docs.netlify.app/";
+
 export default function App() {
   return (
     <BrowserRouter>
       <div className="game-shell min-h-screen text-slate-100">
         <div className="game-grid" aria-hidden="true" />
 
-        <header className="relative z-20 border-b border-white/10 bg-slate-950/75 backdrop-blur-xl">
+        <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
           <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
             <NavLink to="/study" className="group flex items-center gap-3">
-              <div className="grid h-11 w-11 place-items-center rounded-2xl border border-violet-300/30 bg-violet-500/20 text-2xl shadow-lg shadow-violet-950/40 transition group-hover:-rotate-6 group-hover:scale-105">
+              <div className="grid h-11 w-11 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">
                 🧠
               </div>
               <div>
                 <div className="flex items-center gap-2">
                   <span className="text-lg font-black tracking-tight text-white">FlashQuest’s</span>
-                  <span className="rounded-full border border-amber-300/30 bg-amber-300/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-amber-200">
+                  <span className="rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-[#ffba08]">
                     Quest Mode
                   </span>
                 </div>
-                <p className="text-xs font-medium text-slate-400">Level up what you remember.</p>
+                <p className="text-xs font-medium text-slate-400">Any topic. One memory engine.</p>
               </div>
             </NavLink>
 
-            <nav className="flex gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-1.5" aria-label="Primary navigation">
-              {navItems.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  className={({ isActive }) =>
-                    [
-                      "flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition",
-                      isActive
-                        ? "bg-white text-slate-950 shadow-lg shadow-black/20"
-                        : "text-slate-300 hover:bg-white/10 hover:text-white",
-                    ].join(" ")
-                  }
-                >
-                  <span aria-hidden="true">{item.icon}</span>
-                  <span>{item.label}</span>
-                </NavLink>
-              ))}
-            </nav>
+            <div className="flex flex-wrap items-center gap-2">
+              <nav className="flex gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
+                {navItems.map((item) => (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    className={({ isActive }) =>
+                      [
+                        "flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition",
+                        isActive
+                          ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20"
+                          : "text-slate-300 hover:bg-white/10 hover:text-white",
+                      ].join(" ")
+                    }
+                  >
+                    <span aria-hidden="true">{item.icon}</span>
+                    <span>{item.label}</span>
+                  </NavLink>
+                ))}
+              </nav>
+              <a
+                href={DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] hover:bg-[#6a040f]/65"
+              >
+                📖 Docs
+              </a>
+            </div>
           </div>
         </header>
 
@@ -67,10 +79,7 @@ export default function App() {
                   <div className="text-5xl">🌀</div>
                   <h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1>
                   <p className="mt-2 text-slate-400">That route slipped into another dimension.</p>
-                  <NavLink
-                    to="/study"
-                    className="mt-6 inline-flex rounded-xl bg-violet-400 px-4 py-2 font-black text-violet-950 transition hover:bg-violet-300"
-                  >
+                  <NavLink to="/study" className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">
                     Return to the quest
                   </NavLink>
                 </div>
@@ -80,8 +89,10 @@ export default function App() {
         </main>
 
         <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-          <span>12 mastery levels · spaced repetition engine</span>
-          <span>FastAPI · React · PostgreSQL · Docker</span>
+          <span>Reusable topics · concepts + labs · 12 mastery levels</span>
+          <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">
+            FastAPI · React · PostgreSQL · Docker · Docs ↗
+          </a>
         </footer>
       </div>
     </BrowserRouter>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,12 +4,17 @@ import type {
   CardAdminRead,
   CardRead,
   CreateCardPayload,
+  DeckRead,
+  LoginPayload,
+  LoginResponse,
+  SignupPayload,
   StudyNext,
-  StudyTopicSummary,
   UpdateCardPayload,
+  UserRead,
 } from "./types";
 
 export type StudyTrack = "mixed" | "concept" | "lab";
+const TOKEN_KEY = "flashquest-access-token";
 
 export const BIN_DELAYS: Record<number, number> = {
   0: 0,
@@ -46,12 +51,19 @@ export function formatDelay(ms: number): string {
 export function apiBaseURL(): string {
   const configured = import.meta.env.VITE_API_URL?.trim();
   if (configured) return configured.replace(/\/$/, "");
-
   if (typeof window !== "undefined" && window.location.hostname.endsWith("netlify.app")) {
     return "https://flashcards-tobias.fly.dev";
   }
-
   return "http://localhost:8080";
+}
+
+export function getAccessToken(): string | null {
+  return window.localStorage.getItem(TOKEN_KEY);
+}
+
+export function setAccessToken(token: string | null): void {
+  if (token) window.localStorage.setItem(TOKEN_KEY, token);
+  else window.localStorage.removeItem(TOKEN_KEY);
 }
 
 export const api = axios.create({
@@ -59,6 +71,12 @@ export const api = axios.create({
   timeout: 12_000,
   headers: { Accept: "application/json", "Content-Type": "application/json" },
   responseType: "json",
+});
+
+api.interceptors.request.use((config) => {
+  const token = typeof window !== "undefined" ? getAccessToken() : null;
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
 });
 
 api.interceptors.response.use(
@@ -97,10 +115,99 @@ export async function checkApi(): Promise<boolean> {
   }
 }
 
-export async function getStudyTopics(): Promise<StudyTopicSummary[]> {
+export async function signup(payload: SignupPayload): Promise<{ message: string; email: string }> {
   try {
-    const { data } = await api.get<StudyTopicSummary[]>("/study/topics");
+    const { data } = await api.post<{ message: string; email: string }>("/auth/signup", payload);
     return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function verifyEmail(token: string): Promise<string> {
+  try {
+    const { data } = await api.post<{ message: string }>("/auth/verify", { token });
+    return data.message;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function resendVerification(email: string): Promise<string> {
+  try {
+    const { data } = await api.post<{ message: string }>("/auth/resend-verification", { email });
+    return data.message;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  try {
+    const { data } = await api.post<LoginResponse>("/auth/login", payload);
+    setAccessToken(data.access_token);
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function getMe(): Promise<UserRead> {
+  try {
+    const { data } = await api.get<UserRead>("/auth/me");
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await api.post("/auth/logout");
+  } finally {
+    setAccessToken(null);
+  }
+}
+
+export async function getFeaturedDecks(): Promise<DeckRead[]> {
+  try {
+    const { data } = await api.get<DeckRead[]>("/decks/featured");
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function getMyDecks(): Promise<DeckRead[]> {
+  try {
+    const { data } = await api.get<DeckRead[]>("/decks/mine");
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function createDeck(title: string, description = ""): Promise<DeckRead> {
+  try {
+    const { data } = await api.post<DeckRead>("/decks", { title, description });
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function copyFeaturedDeck(deckId: number): Promise<DeckRead> {
+  try {
+    const { data } = await api.post<DeckRead>(`/decks/${deckId}/copy`);
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function deleteDeck(deckId: number): Promise<void> {
+  try {
+    await api.delete(`/decks/${deckId}`);
   } catch (e) {
     throw normalizeError(e);
   }
@@ -108,11 +215,11 @@ export async function getStudyTopics(): Promise<StudyTopicSummary[]> {
 
 export async function getStudyNext(
   track: StudyTrack = "mixed",
-  topic?: string
+  deckId?: number
 ): Promise<StudyNext> {
   try {
     const { data } = await api.get<StudyNext>("/study/next", {
-      params: { track, topic: topic || undefined },
+      params: { track, deck_id: deckId },
     });
     return data;
   } catch (e) {
@@ -145,10 +252,7 @@ export async function createCard(payload: CreateCardPayload): Promise<CardRead> 
   }
 }
 
-export async function updateCard(
-  id: number,
-  payload: UpdateCardPayload
-): Promise<CardRead> {
+export async function updateCard(id: number, payload: UpdateCardPayload): Promise<CardRead> {
   try {
     const { data } = await api.patch<CardRead>(`/cards/${id}`, payload);
     return data;
@@ -157,10 +261,10 @@ export async function updateCard(
   }
 }
 
-export async function listAdminCards(q?: string): Promise<CardAdminRead[]> {
+export async function listAdminCards(q?: string, deckId?: number): Promise<CardAdminRead[]> {
   try {
     const { data } = await api.get<CardAdminRead[]>("/cards/admin", {
-      params: q ? { q } : undefined,
+      params: { q: q || undefined, deck_id: deckId },
     });
     return data;
   } catch (e) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
 // frontend/src/api.ts
 /**
  * Minimal API client using axios with friendly errors + health check.
- * Base URL comes from Vite env (VITE_API_URL) or defaults to localhost.
+ * Base URL comes from Vite env, then a production-safe fallback, then localhost.
  *
  * Also exports spaced-repetition helpers to display bin timers in the UI.
  */
@@ -14,33 +14,31 @@ import type {
   CreateCardPayload,
 } from "./types";
 
+export type StudyTrack = "mixed" | "concept" | "lab";
+
 /** Map of bin -> delay in milliseconds (must mirror backend schedule). */
 export const BIN_DELAYS: Record<number, number> = {
-  0: 0, // new
-  1: 5_000, // 5s
-  2: 30_000, // 30s
-  3: 5 * 60_000, // 5m
-  4: 30 * 60_000, // 30m
-  5: 2 * 60 * 60_000, // 2h
-  6: 6 * 60 * 60_000, // 6h
-  7: 24 * 60 * 60_000, // 1d
-  8: 2 * 24 * 60 * 60_000, // 2d
-  9: 4 * 24 * 60 * 60_000, // 4d
-  10: 7 * 24 * 60 * 60_000, // 7d (~1w)
-  11: 14 * 24 * 60 * 60_000, // 14d
+  0: 0,
+  1: 5_000,
+  2: 25_000,
+  3: 2 * 60_000,
+  4: 10 * 60_000,
+  5: 60 * 60_000,
+  6: 5 * 60 * 60_000,
+  7: 24 * 60 * 60_000,
+  8: 5 * 24 * 60 * 60_000,
+  9: 25 * 24 * 60 * 60_000,
+  10: 120 * 24 * 60 * 60_000,
+  11: 0,
 };
 
-/**
- * Human-friendly label for a bin’s delay (e.g., "5s", "30m", "2h", "1d").
- * Falls back to "~1m" if bin is unknown.
- */
 export function binLabel(bin: number): string {
+  if (bin === 11) return "mastered";
   const ms = BIN_DELAYS[bin];
   if (ms == null) return "~1m";
   return formatDelay(ms);
 }
 
-/** Format milliseconds into a short relative label (s/m/h/d). */
 export function formatDelay(ms: number): string {
   const s = Math.round(ms / 1000);
   if (s < 60) return `${s}s`;
@@ -52,12 +50,18 @@ export function formatDelay(ms: number): string {
   return `${d}d`;
 }
 
-/** Resolve API base URL for diagnostics. */
+/** Resolve API base URL for diagnostics and production. */
 export function apiBaseURL(): string {
-  return import.meta.env.VITE_API_URL ?? "http://localhost:8080";
+  const configured = import.meta.env.VITE_API_URL?.trim();
+  if (configured) return configured.replace(/\/$/, "");
+
+  if (typeof window !== "undefined" && window.location.hostname.endsWith("netlify.app")) {
+    return "https://flashcards-tobias.fly.dev";
+  }
+
+  return "http://localhost:8080";
 }
 
-/** Axios instance with sane timeout and JSON defaults. */
 export const api = axios.create({
   baseURL: apiBaseURL(),
   timeout: 12_000,
@@ -65,11 +69,9 @@ export const api = axios.create({
   responseType: "json",
 });
 
-/** Log useful info on API failures to help debug quickly in the console. */
 api.interceptors.response.use(
   (r) => r,
   (err) => {
-    // Avoid noisy logs for cancellations
     if (axios.isCancel?.(err)) return Promise.reject(err);
 
     console.error("API error:", {
@@ -84,14 +86,11 @@ api.interceptors.response.use(
   }
 );
 
-/** Convert Axios/Network errors to readable messages for the UI. */
 function normalizeError(err: unknown): Error {
   if (axios.isAxiosError(err)) {
     const status = err.response?.status;
-    const detail =
-      (err.response?.data as any)?.detail ??
-      err.response?.statusText ??
-      err.message;
+    const responseData = err.response?.data as { detail?: unknown } | undefined;
+    const detail = responseData?.detail ?? err.response?.statusText ?? err.message;
     return new Error(
       status ? `HTTP ${status}: ${String(detail)}` : `Network: ${String(detail)}`
     );
@@ -99,10 +98,6 @@ function normalizeError(err: unknown): Error {
   return err instanceof Error ? err : new Error("Unknown error");
 }
 
-/**
- * Check API health.
- * @returns `true` if `/health` responds `{ ok: true }`, otherwise `false`.
- */
 export async function checkApi(): Promise<boolean> {
   try {
     const { data } = await api.get<{ ok: boolean }>("/health");
@@ -112,29 +107,19 @@ export async function checkApi(): Promise<boolean> {
   }
 }
 
-/**
- * Get the next study item or a status if none are due.
- * @returns Discriminated union with `status: "ok" | "temporarily_done" | "permanently_done"`.
- */
-export async function getStudyNext(): Promise<StudyNext> {
+export async function getStudyNext(track: StudyTrack = "mixed"): Promise<StudyNext> {
   try {
-    const { data } = await api.get<StudyNext>("/study/next");
+    const { data } = await api.get<StudyNext>("/study/next", {
+      params: { track },
+    });
     return data;
   } catch (e) {
     throw normalizeError(e);
   }
 }
 
-/** Response shape for /study/answer. */
 export type AnswerResponse = { ok: boolean; to_bin: number; status: string };
 
-/**
- * Submit an answer for a card.
- *
- * Overloads:
- * - `postStudyAnswer(123, "correct")`
- * - `postStudyAnswer({ cardId: 123, result: "correct" })`
- */
 export function postStudyAnswer(
   cardId: number,
   result: "correct" | "wrong"
@@ -164,10 +149,6 @@ export async function postStudyAnswer(
   }
 }
 
-/**
- * Create a new card (word + definition).
- * @param payload - The card data.
- */
 export async function createCard(payload: CreateCardPayload): Promise<CardRead> {
   try {
     const { data } = await api.post<CardRead>("/cards", payload);
@@ -177,10 +158,6 @@ export async function createCard(payload: CreateCardPayload): Promise<CardRead> 
   }
 }
 
-/**
- * List admin cards (with bin/status). Optional search query.
- * @param q - Case-insensitive match on word/definition.
- */
 export async function listAdminCards(q?: string): Promise<CardAdminRead[]> {
   try {
     const { data } = await api.get<CardAdminRead[]>("/cards/admin", {
@@ -192,13 +169,6 @@ export async function listAdminCards(q?: string): Promise<CardAdminRead[]> {
   }
 }
 
-/**
- * Reset ALL progress for the default user on the backend.
- * - Ensures a UserCard exists for every Card
- * - Deletes all Review rows
- * - Resets bin/wrong_count/next_review_at/status on UserCard
- * @returns counts of affected rows
- */
 export async function adminReset(): Promise<{
   ok: boolean;
   inserted_usercards: number;
@@ -218,11 +188,6 @@ export async function adminReset(): Promise<{
   }
 }
 
-/**
- * Delete a card by ID.
- * Also removes associated per-user progress/reviews if your backend cascades.
- * @throws Error with readable message when the API rejects the request.
- */
 export async function deleteCard(id: number): Promise<void> {
   try {
     await api.delete(`/cards/${id}`);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,22 +1,16 @@
 // frontend/src/api.ts
-/**
- * Minimal API client using axios with friendly errors + health check.
- * Base URL comes from Vite env, then a production-safe fallback, then localhost.
- *
- * Also exports spaced-repetition helpers to display bin timers in the UI.
- */
-
 import axios from "axios";
 import type {
-  CardRead,
   CardAdminRead,
-  StudyNext,
+  CardRead,
   CreateCardPayload,
+  StudyNext,
+  StudyTopicSummary,
+  UpdateCardPayload,
 } from "./types";
 
 export type StudyTrack = "mixed" | "concept" | "lab";
 
-/** Map of bin -> delay in milliseconds (must mirror backend schedule). */
 export const BIN_DELAYS: Record<number, number> = {
   0: 0,
   1: 5_000,
@@ -46,11 +40,9 @@ export function formatDelay(ms: number): string {
   if (m < 60) return `${m}m`;
   const h = Math.round(m / 60);
   if (h < 24) return `${h}h`;
-  const d = Math.round(h / 24);
-  return `${d}d`;
+  return `${Math.round(h / 24)}d`;
 }
 
-/** Resolve API base URL for diagnostics and production. */
 export function apiBaseURL(): string {
   const configured = import.meta.env.VITE_API_URL?.trim();
   if (configured) return configured.replace(/\/$/, "");
@@ -73,12 +65,10 @@ api.interceptors.response.use(
   (r) => r,
   (err) => {
     if (axios.isCancel?.(err)) return Promise.reject(err);
-
     console.error("API error:", {
       url: err?.config?.url,
       method: err?.config?.method,
       status: err?.response?.status,
-      headers: err?.response?.headers,
       data: err?.response?.data,
       message: err?.message,
     });
@@ -107,10 +97,22 @@ export async function checkApi(): Promise<boolean> {
   }
 }
 
-export async function getStudyNext(track: StudyTrack = "mixed"): Promise<StudyNext> {
+export async function getStudyTopics(): Promise<StudyTopicSummary[]> {
+  try {
+    const { data } = await api.get<StudyTopicSummary[]>("/study/topics");
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function getStudyNext(
+  track: StudyTrack = "mixed",
+  topic?: string
+): Promise<StudyNext> {
   try {
     const { data } = await api.get<StudyNext>("/study/next", {
-      params: { track },
+      params: { track, topic: topic || undefined },
     });
     return data;
   } catch (e) {
@@ -120,26 +122,11 @@ export async function getStudyNext(track: StudyTrack = "mixed"): Promise<StudyNe
 
 export type AnswerResponse = { ok: boolean; to_bin: number; status: string };
 
-export function postStudyAnswer(
+export async function postStudyAnswer(
   cardId: number,
   result: "correct" | "wrong"
-): Promise<AnswerResponse>;
-export function postStudyAnswer(args: {
-  cardId: number;
-  result: "correct" | "wrong";
-}): Promise<AnswerResponse>;
-export async function postStudyAnswer(
-  a:
-    | number
-    | {
-        cardId: number;
-        result: "correct" | "wrong";
-      },
-  b?: "correct" | "wrong"
 ): Promise<AnswerResponse> {
   try {
-    const cardId = typeof a === "number" ? a : a.cardId;
-    const result = typeof a === "number" ? (b as "correct" | "wrong") : a.result;
     const { data } = await api.post<AnswerResponse>("/study/answer", null, {
       params: { card_id: cardId, result },
     });
@@ -158,6 +145,18 @@ export async function createCard(payload: CreateCardPayload): Promise<CardRead> 
   }
 }
 
+export async function updateCard(
+  id: number,
+  payload: UpdateCardPayload
+): Promise<CardRead> {
+  try {
+    const { data } = await api.patch<CardRead>(`/cards/${id}`, payload);
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
 export async function listAdminCards(q?: string): Promise<CardAdminRead[]> {
   try {
     const { data } = await api.get<CardAdminRead[]>("/cards/admin", {
@@ -169,28 +168,27 @@ export async function listAdminCards(q?: string): Promise<CardAdminRead[]> {
   }
 }
 
-export async function adminReset(): Promise<{
+export async function adminReset(password: string): Promise<{
   ok: boolean;
   inserted_usercards: number;
   deleted_reviews: number;
   updated_usercards: number;
 }> {
   try {
-    const { data } = await api.post("/cards/admin/reset");
-    return data as {
-      ok: boolean;
-      inserted_usercards: number;
-      deleted_reviews: number;
-      updated_usercards: number;
-    };
+    const { data } = await api.post("/cards/admin/reset", null, {
+      headers: { "X-Demo-Admin-Password": password },
+    });
+    return data;
   } catch (e) {
     throw normalizeError(e);
   }
 }
 
-export async function deleteCard(id: number): Promise<void> {
+export async function deleteCard(id: number, password?: string): Promise<void> {
   try {
-    await api.delete(`/cards/${id}`);
+    await api.delete(`/cards/${id}`, {
+      headers: password ? { "X-Demo-Admin-Password": password } : undefined,
+    });
   } catch (e) {
     throw normalizeError(e);
   }

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { getAccessToken, getMe, login as apiLogin, logout as apiLogout } from "./api";
 import type { LoginPayload, UserRead } from "./types";
 
@@ -16,7 +24,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<UserRead | null>(null);
   const [loading, setLoading] = useState(true);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     if (!getAccessToken()) {
       setUser(null);
       setLoading(false);
@@ -29,26 +37,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
   useEffect(() => {
     void refresh();
-  }, []);
+  }, [refresh]);
 
-  async function signIn(payload: LoginPayload): Promise<UserRead> {
+  const signIn = useCallback(async (payload: LoginPayload): Promise<UserRead> => {
     const response = await apiLogin(payload);
     setUser(response.user);
     return response.user;
-  }
+  }, []);
 
-  async function signOut() {
+  const signOut = useCallback(async () => {
     await apiLogout();
     setUser(null);
-  }
+  }, []);
 
   const value = useMemo(
     () => ({ user, loading, signIn, signOut, refresh }),
-    [user, loading]
+    [user, loading, signIn, signOut, refresh]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { getAccessToken, getMe, login as apiLogin, logout as apiLogout } from "./api";
+import type { LoginPayload, UserRead } from "./types";
+
+type AuthValue = {
+  user: UserRead | null;
+  loading: boolean;
+  signIn: (payload: LoginPayload) => Promise<UserRead>;
+  signOut: () => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<UserRead | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  async function refresh() {
+    if (!getAccessToken()) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+    try {
+      setUser(await getMe());
+    } catch {
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function signIn(payload: LoginPayload): Promise<UserRead> {
+    const response = await apiLogin(payload);
+    setUser(response.user);
+    return response.user;
+  }
+
+  async function signOut() {
+    await apiLogout();
+    setUser(null);
+  }
+
+  const value = useMemo(
+    () => ({ user, loading, signIn, signOut, refresh }),
+    [user, loading]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthValue {
+  const value = useContext(AuthContext);
+  if (!value) throw new Error("useAuth must be used inside AuthProvider");
+  return value;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,111 +1,149 @@
 @import "tailwindcss";
 
 :root {
+  --ink-black: #03071e;
+  --night-bordeaux: #370617;
+  --black-cherry: #6a040f;
+  --oxblood: #9d0208;
+  --brick-ember: #d00000;
+  --red-ochre: #dc2f02;
+  --cayenne-red: #e85d04;
+  --deep-saffron: #f48c06;
+  --orange: #faa307;
+  --amber-flame: #ffba08;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #e2e8f0;
-  background: #090d18;
+  color: #f8fafc;
+  background: var(--ink-black);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
 
 * { box-sizing: border-box; }
-html { min-width: 320px; background: #090d18; }
-body { margin: 0; min-width: 320px; min-height: 100vh; background: #090d18; }
+html { min-width: 320px; background: var(--ink-black); }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--ink-black); }
 button, input, textarea, select { font: inherit; }
 button { cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: .55; }
 a { color: inherit; text-decoration: none; }
 table { border-collapse: collapse; }
-::selection { background: rgba(196, 181, 253, .35); color: white; }
+::selection { background: rgba(255, 186, 8, .33); color: white; }
 
 .game-shell {
   position: relative;
   overflow-x: hidden;
   background:
-    radial-gradient(circle at 12% 12%, rgba(124, 58, 237, .24), transparent 32rem),
-    radial-gradient(circle at 88% 22%, rgba(14, 165, 233, .16), transparent 28rem),
-    radial-gradient(circle at 50% 100%, rgba(245, 158, 11, .09), transparent 30rem),
-    linear-gradient(180deg, #080c17 0%, #0d1324 48%, #090d18 100%);
+    radial-gradient(circle at 8% 10%, rgba(106, 4, 15, .52), transparent 31rem),
+    radial-gradient(circle at 92% 18%, rgba(232, 93, 4, .14), transparent 29rem),
+    radial-gradient(circle at 52% 105%, rgba(250, 163, 7, .08), transparent 34rem),
+    linear-gradient(180deg, #03071e 0%, #090818 48%, #050610 100%);
 }
 
 .game-grid {
   pointer-events: none;
   position: fixed;
   inset: 0;
-  opacity: .13;
+  opacity: .09;
   background-image:
-    linear-gradient(rgba(255,255,255,.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,.08) 1px, transparent 1px);
-  background-size: 42px 42px;
+    linear-gradient(rgba(255, 186, 8, .08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 186, 8, .08) 1px, transparent 1px);
+  background-size: 44px 44px;
   mask-image: linear-gradient(to bottom, black, transparent 78%);
 }
 
 .game-panel {
-  border: 1px solid rgba(255,255,255,.1);
-  border-radius: 1.5rem;
-  background: linear-gradient(180deg, rgba(30,41,59,.9), rgba(15,23,42,.82));
-  box-shadow: 0 24px 70px rgba(0,0,0,.3), inset 0 1px 0 rgba(255,255,255,.05);
+  border: 1px solid rgba(255, 255, 255, .085);
+  border-radius: 1.45rem;
+  background:
+    linear-gradient(145deg, rgba(55, 6, 23, .42), rgba(3, 7, 30, .82)),
+    rgba(3, 7, 30, .72);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, .34), inset 0 1px 0 rgba(255, 255, 255, .04);
   backdrop-filter: blur(18px);
 }
 
 .quest-card {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(196,181,253,.22);
+  border: 1px solid rgba(250, 163, 7, .22);
   border-radius: 2rem;
   background:
-    radial-gradient(circle at 90% 0%, rgba(139,92,246,.22), transparent 18rem),
-    linear-gradient(145deg, rgba(30,41,59,.97), rgba(15,23,42,.98));
-  box-shadow: 0 34px 85px rgba(2,6,23,.48), inset 0 1px 0 rgba(255,255,255,.06);
+    radial-gradient(circle at 88% -5%, rgba(232, 93, 4, .18), transparent 20rem),
+    radial-gradient(circle at 5% 100%, rgba(106, 4, 15, .28), transparent 19rem),
+    linear-gradient(145deg, rgba(55, 6, 23, .8), rgba(3, 7, 30, .96));
+  box-shadow: 0 34px 85px rgba(0, 0, 0, .46), inset 0 1px 0 rgba(255, 255, 255, .05);
 }
 
 .quest-card::after {
   content: "";
   position: absolute;
-  width: 9rem;
-  height: 9rem;
-  right: -3rem;
-  bottom: -4rem;
+  width: 10rem;
+  height: 10rem;
+  right: -4rem;
+  bottom: -5rem;
   border-radius: 999px;
-  background: rgba(56,189,248,.08);
-  filter: blur(8px);
+  background: rgba(255, 186, 8, .07);
+  filter: blur(10px);
 }
 
 .xp-track {
   height: .65rem;
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid rgba(255, 255, 255, .07);
   border-radius: 999px;
-  background: rgba(15,23,42,.8);
+  background: rgba(3, 7, 30, .9);
 }
 
 .xp-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, #a78bfa, #22d3ee, #fbbf24);
-  box-shadow: 0 0 20px rgba(34,211,238,.32);
-  transition: width .45s cubic-bezier(.2,.8,.2,1);
+  background: linear-gradient(90deg, var(--red-ochre), var(--deep-saffron), var(--amber-flame));
+  box-shadow: 0 0 22px rgba(250, 163, 7, .28);
+  transition: width .45s cubic-bezier(.2, .8, .2, 1);
 }
 
 .game-chip {
-  border: 1px solid rgba(255,255,255,.09);
+  border: 1px solid rgba(255, 255, 255, .085);
   border-radius: 999px;
-  background: rgba(255,255,255,.055);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.04);
+  background: rgba(255, 255, 255, .045);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .03);
 }
 
 .game-button {
-  border-radius: 1rem;
+  border-radius: .95rem;
   font-weight: 900;
   transition: transform .16s ease, filter .16s ease, box-shadow .16s ease;
 }
-.game-button:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.07); }
-.game-button:active:not(:disabled) { transform: translateY(0) scale(.98); }
+.game-button:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.06); }
+.game-button:active:not(:disabled) { transform: translateY(0) scale(.985); }
 
-.answer-pop { animation: answer-pop .36s cubic-bezier(.2,.9,.3,1); }
+.deck-input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, .11);
+  border-radius: .9rem;
+  background: rgba(3, 7, 30, .78);
+  color: #f8fafc;
+  padding: .72rem .85rem;
+  outline: none;
+  transition: border-color .16s ease, box-shadow .16s ease, background .16s ease;
+}
+.deck-input::placeholder { color: #64748b; }
+.deck-input:focus {
+  border-color: rgba(250, 163, 7, .62);
+  box-shadow: 0 0 0 3px rgba(250, 163, 7, .1);
+  background: rgba(3, 7, 30, .94);
+}
+
+.metric-label {
+  color: var(--amber-flame);
+  font-size: .68rem;
+  font-weight: 900;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+
+.answer-pop { animation: answer-pop .36s cubic-bezier(.2, .9, .3, 1); }
 .wrong-shake { animation: wrong-shake .35s ease; }
 .floaty { animation: floaty 4s ease-in-out infinite; }
-.reward-pop { animation: reward-pop .42s cubic-bezier(.2,.9,.3,1); }
+.reward-pop { animation: reward-pop .42s cubic-bezier(.2, .9, .3, 1); }
 
 @keyframes answer-pop {
   0% { transform: scale(.98); opacity: .72; }
@@ -132,5 +170,10 @@ table { border-collapse: collapse; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,6 +100,14 @@ table { border-collapse: collapse; }
   transition: width .45s cubic-bezier(.2, .8, .2, 1);
 }
 
+.ember-text {
+  color: var(--amber-flame);
+  background: linear-gradient(90deg, var(--cayenne-red), var(--orange), var(--amber-flame));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .game-chip {
   border: 1px solid rgba(255, 255, 255, .085);
   border-radius: 999px;
@@ -115,6 +123,7 @@ table { border-collapse: collapse; }
 .game-button:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.06); }
 .game-button:active:not(:disabled) { transform: translateY(0) scale(.985); }
 
+.game-input,
 .deck-input {
   width: 100%;
   border: 1px solid rgba(255, 255, 255, .11);
@@ -125,12 +134,15 @@ table { border-collapse: collapse; }
   outline: none;
   transition: border-color .16s ease, box-shadow .16s ease, background .16s ease;
 }
+.game-input::placeholder,
 .deck-input::placeholder { color: #64748b; }
+.game-input:focus,
 .deck-input:focus {
   border-color: rgba(250, 163, 7, .62);
   box-shadow: 0 0 0 3px rgba(250, 163, 7, .1);
   background: rgba(3, 7, 30, .94);
 }
+select.game-input option { background: var(--ink-black); color: white; }
 
 .metric-label {
   color: var(--amber-flame);

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,47 +1,91 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
   adminReset,
+  copyFeaturedDeck,
   createCard,
   deleteCard,
+  getFeaturedDecks,
+  getMyDecks,
   listAdminCards,
   updateCard,
 } from "../api";
-import type { CardAdminRead, CardKind, CreateCardPayload } from "../types";
+import { useAuth } from "../auth";
+import type { CardAdminRead, CardKind, DeckRead } from "../types";
 
-function errorMessage(error: unknown, fallback: string): string {
+function message(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
 export default function Admin() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const requestedDeckId = Number(params.get("deck") || 0) || null;
+
+  const [decks, setDecks] = useState<DeckRead[]>([]);
+  const [selectedDeckId, setSelectedDeckId] = useState<number | null>(requestedDeckId);
   const [cards, setCards] = useState<CardAdminRead[]>([]);
   const [q, setQ] = useState("");
-  const [topicFilter, setTopicFilter] = useState("all");
   const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
-  const [demoPassword, setDemoPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   const [word, setWord] = useState("");
   const [definition, setDefinition] = useState("");
-  const [topic, setTopic] = useState("My Topic");
   const [domain, setDomain] = useState("General");
   const [kind, setKind] = useState<CardKind>("concept");
 
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editWord, setEditWord] = useState("");
   const [editDefinition, setEditDefinition] = useState("");
-  const [editTopic, setEditTopic] = useState("");
   const [editDomain, setEditDomain] = useState("");
   const [editKind, setEditKind] = useState<CardKind>("concept");
-  const createRef = useRef<HTMLDivElement | null>(null);
+
+  const [demoPassword, setDemoPassword] = useState("");
+
+  const selectedDeck = useMemo(
+    () => decks.find((deck) => deck.id === selectedDeckId) ?? null,
+    [decks, selectedDeckId]
+  );
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return cards;
+    return cards.filter((card) =>
+      [card.word, card.definition, card.domain, card.kind]
+        .join(" ")
+        .toLowerCase()
+        .includes(needle)
+    );
+  }, [cards, q]);
+
+  async function loadDecks() {
+    const featured = await getFeaturedDecks();
+    const mine = user ? await getMyDecks() : [];
+    const all = [...featured, ...mine];
+    setDecks(all);
+    setSelectedDeckId((current) => {
+      if (requestedDeckId && all.some((deck) => deck.id === requestedDeckId)) return requestedDeckId;
+      if (current && all.some((deck) => deck.id === current)) return current;
+      return mine[0]?.id ?? featured[0]?.id ?? null;
+    });
+  }
+
+  async function loadCards(deckId: number | null) {
+    if (!deckId) {
+      setCards([]);
+      return;
+    }
+    setCards(await listAdminCards(undefined, deckId));
+  }
 
   async function refresh() {
     setLoading(true);
-    setErr(null);
+    setError(null);
     try {
-      setCards(await listAdminCards());
-    } catch (error) {
-      setErr(errorMessage(error, "Could not load cards"));
+      await loadDecks();
+    } catch (e) {
+      setError(message(e, "Could not load decks"));
     } finally {
       setLoading(false);
     }
@@ -49,317 +93,227 @@ export default function Admin() {
 
   useEffect(() => {
     void refresh();
-  }, []);
+  }, [user]);
 
-  const topics = useMemo(
-    () => Array.from(new Set(cards.map((card) => card.topic))).sort(),
-    [cards]
-  );
+  useEffect(() => {
+    void loadCards(selectedDeckId).catch((e: unknown) => setError(message(e, "Could not load cards")));
+  }, [selectedDeckId, user]);
 
-  const filtered = useMemo(() => {
-    const query = q.trim().toLowerCase();
-    return cards.filter((card) => {
-      if (topicFilter !== "all" && card.topic !== topicFilter) return false;
-      if (!query) return true;
-      return [card.word, card.definition, card.topic, card.domain, card.kind]
-        .join(" ")
-        .toLowerCase()
-        .includes(query);
-    });
-  }, [cards, q, topicFilter]);
-
-  const builtInCount = cards.filter((card) => card.is_builtin).length;
-  const customCount = cards.length - builtInCount;
-
-  async function onCreate(event: FormEvent) {
+  async function addCard(event: React.FormEvent) {
     event.preventDefault();
-    if (!word.trim() || !definition.trim()) return;
+    if (!selectedDeck || selectedDeck.is_builtin) return;
     setLoading(true);
-    setErr(null);
-    setNotice(null);
+    setError(null);
     try {
-      const payload: CreateCardPayload = {
-        word: word.trim(),
-        definition: definition.trim(),
-        topic: topic.trim() || "My Topic",
-        domain: domain.trim() || "General",
+      await createCard({
+        deck_id: selectedDeck.id,
+        word,
+        definition,
+        domain,
         kind,
-      };
-      await createCard(payload);
+      });
       setWord("");
       setDefinition("");
-      setNotice("Card added. It is ready to study in Play.");
-      await refresh();
-    } catch (error) {
-      setErr(errorMessage(error, "Could not create card"));
+      setDomain("General");
+      setKind("concept");
+      await loadCards(selectedDeck.id);
+      await loadDecks();
+    } catch (e) {
+      setError(message(e, "Could not add card"));
     } finally {
       setLoading(false);
     }
   }
 
-  function startEdit(card: CardAdminRead) {
-    if (card.is_builtin) return;
+  function beginEdit(card: CardAdminRead) {
     setEditingId(card.id);
     setEditWord(card.word);
     setEditDefinition(card.definition);
-    setEditTopic(card.topic);
     setEditDomain(card.domain);
     setEditKind(card.kind === "lab" ? "lab" : "concept");
-    setErr(null);
   }
 
   async function saveEdit(cardId: number) {
     setLoading(true);
-    setErr(null);
-    setNotice(null);
+    setError(null);
     try {
       await updateCard(cardId, {
-        word: editWord.trim(),
-        definition: editDefinition.trim(),
-        topic: editTopic.trim() || "My Topic",
-        domain: editDomain.trim() || "General",
+        word: editWord,
+        definition: editDefinition,
+        domain: editDomain,
         kind: editKind,
       });
       setEditingId(null);
-      setNotice("Custom card updated.");
-      await refresh();
-    } catch (error) {
-      setErr(errorMessage(error, "Could not update card"));
+      await loadCards(selectedDeckId);
+    } catch (e) {
+      setError(message(e, "Could not update card"));
     } finally {
       setLoading(false);
     }
   }
 
-  function copyToCustom(card: CardAdminRead) {
-    setWord(card.word.replace(/^LAB ·\s*/, ""));
-    setDefinition(card.definition);
-    setTopic(`My ${card.topic}`);
-    setDomain(card.domain.replace(/ Labs$/, ""));
-    setKind(card.kind === "lab" ? "lab" : "concept");
-    setNotice("Copied into the new-card form. Change anything you want, then save it.");
-    requestAnimationFrame(() => createRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }));
-  }
-
-  async function onDelete(card: CardAdminRead) {
-    if (card.is_builtin && !demoPassword) {
-      setErr("Built-in demo cards are protected. Enter the demo admin password first.");
-      return;
-    }
-    const warning = card.is_builtin
-      ? "Delete this protected built-in demo card? The admin password will be checked."
-      : "Delete this custom card and its study progress?";
-    if (!window.confirm(warning)) return;
-
+  async function removeCard(card: CardAdminRead) {
+    if (!confirm(`Delete “${card.word}”?`)) return;
     setLoading(true);
-    setErr(null);
+    setError(null);
     try {
       await deleteCard(card.id, card.is_builtin ? demoPassword : undefined);
-      setNotice(card.is_builtin ? "Built-in card deleted." : "Custom card deleted.");
-      await refresh();
-    } catch (error) {
-      setErr(errorMessage(error, "Could not delete card"));
+      await loadCards(selectedDeckId);
+      await loadDecks();
+    } catch (e) {
+      setError(message(e, "Could not delete card"));
     } finally {
       setLoading(false);
     }
   }
 
-  async function onResetProgress() {
-    if (!demoPassword) {
-      setErr("Enter the demo admin password before resetting shared demo progress.");
+  async function copyStarter() {
+    if (!user || !selectedDeck?.is_builtin) {
+      navigate("/signup");
       return;
     }
-    if (!window.confirm("Reset progress for every card in the shared demo?")) return;
     setLoading(true);
-    setErr(null);
+    setError(null);
+    try {
+      const copy = await copyFeaturedDeck(selectedDeck.id);
+      navigate(`/deck-lab?deck=${copy.id}`);
+      await refresh();
+    } catch (e) {
+      setError(message(e, "Could not copy the starter deck"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function resetDemo() {
+    if (!demoPassword) return;
+    if (!confirm("Reset the public Platform Engineering demo progress?")) return;
+    setLoading(true);
+    setError(null);
     try {
       await adminReset(demoPassword);
-      setNotice("Shared demo progress reset to level 0.");
-      await refresh();
-    } catch (error) {
-      setErr(errorMessage(error, "Could not reset progress"));
+      await loadCards(selectedDeckId);
+    } catch (e) {
+      setError(message(e, "Could not reset demo progress"));
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <div className="mx-auto grid max-w-6xl gap-6">
+    <div className="grid gap-6">
       <section className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-[#ffba08]">🧪 Deck Lab</p>
-          <h1 className="mt-2 text-3xl font-black text-white sm:text-4xl">Build your own study deck.</h1>
+          <p className="metric-label">Deck Lab</p>
+          <h1 className="mt-2 text-4xl font-black text-white">Build the cards you want to remember.</h1>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-            Platform Engineering is the demo pack. Add any topic you want and FlashQuest’s will use the same memory engine for it.
+            The Platform Engineering starter deck is protected. Sign in to create your own decks, or copy the starter and remix all 216 cards.
           </p>
         </div>
-        <div className="flex gap-2 text-xs font-bold">
-          <span className="game-chip px-3 py-2 text-slate-200">{cards.length} total</span>
-          <span className="game-chip px-3 py-2 text-[#ffba08]">{builtInCount} built-in</span>
-          <span className="game-chip px-3 py-2 text-[#faa307]">{customCount} custom</span>
-        </div>
-      </section>
-
-      <section className="game-panel p-5 sm:p-6">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">How Deck Lab works</p>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {[
-            ["➕", "Make a card", "Type a question and answer."],
-            ["🏷️", "Name the topic", "AWS, Spanish, math — anything."],
-            ["📚", "Pick a type", "Concept = learn it. Lab = fix it."],
-            ["⚡", "Go to Play", "Your new topic appears automatically."],
-          ].map(([icon, title, detail]) => (
-            <div key={title} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-              <span className="text-2xl">{icon}</span>
-              <p className="mt-3 font-black text-white">{title}</p>
-              <p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {err && <div className="rounded-2xl border border-[#d00000]/50 bg-[#6a040f]/55 p-4 text-sm font-semibold text-white">⚠️ {err}</div>}
-      {notice && <div className="rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 p-4 text-sm font-semibold text-[#ffba08]">✨ {notice}</div>}
-
-      <section ref={createRef} className="game-panel p-5 sm:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">Create a custom card</p>
-            <h2 className="mt-1 text-xl font-black text-white">What do you want to remember?</h2>
-          </div>
-          <span className="game-chip px-3 py-1.5 text-xs text-slate-400">Custom cards never need the demo password to delete.</span>
-        </div>
-        <form onSubmit={onCreate} className="mt-5 grid gap-4">
-          <div className="grid gap-4 lg:grid-cols-2">
-            <label className="grid gap-2 text-sm font-bold text-slate-200">
-              Question
-              <textarea className="deck-input min-h-28" value={word} onChange={(e) => setWord(e.target.value)} placeholder="What is a Kubernetes readiness probe?" required />
-            </label>
-            <label className="grid gap-2 text-sm font-bold text-slate-200">
-              Answer
-              <textarea className="deck-input min-h-28" value={definition} onChange={(e) => setDefinition(e.target.value)} placeholder="It tells the platform when a workload is ready to receive traffic..." required />
-            </label>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-3">
-            <label className="grid gap-2 text-sm font-bold text-slate-200">
-              Topic
-              <input className="deck-input" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="My AWS Study" />
-            </label>
-            <label className="grid gap-2 text-sm font-bold text-slate-200">
-              Domain
-              <input className="deck-input" value={domain} onChange={(e) => setDomain(e.target.value)} placeholder="Networking" />
-            </label>
-            <label className="grid gap-2 text-sm font-bold text-slate-200">
-              Type
-              <select className="deck-input" value={kind} onChange={(e) => setKind(e.target.value as CardKind)}>
-                <option value="concept">📚 Concept</option>
-                <option value="lab">🔧 Break/Fix Lab</option>
-              </select>
-            </label>
-          </div>
-          <div>
-            <button className="game-button bg-gradient-to-r from-[#dc2f02] via-[#f48c06] to-[#ffba08] px-5 py-3 text-sm text-[#370617]" type="submit" disabled={loading}>
-              ➕ Add card to FlashQuest’s
-            </button>
-          </div>
-        </form>
-      </section>
-
-      <section className="game-panel p-5 sm:p-6">
-        <div className="grid gap-3 lg:grid-cols-[1fr_240px]">
-          <input className="deck-input" placeholder="Search question, answer, topic, domain…" value={q} onChange={(e) => setQ(e.target.value)} />
-          <select className="deck-input" value={topicFilter} onChange={(e) => setTopicFilter(e.target.value)}>
-            <option value="all">All topics</option>
-            {topics.map((item) => <option key={item} value={item}>{item}</option>)}
-          </select>
-        </div>
-        <p className="mt-3 text-xs text-slate-500">Showing {filtered.length} of {cards.length} cards.</p>
-      </section>
-
-      <section className="grid gap-3">
-        {filtered.map((card) => {
-          const editing = editingId === card.id;
-          return (
-            <article key={card.id} className="game-panel p-5">
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="game-chip px-2.5 py-1 text-[11px] font-black text-[#ffba08]">{card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span>
-                    <span className="game-chip px-2.5 py-1 text-[11px] font-bold text-slate-300">{card.topic}</span>
-                    <span className="game-chip px-2.5 py-1 text-[11px] font-bold text-slate-400">{card.domain}</span>
-                    {card.is_builtin && <span className="game-chip px-2.5 py-1 text-[11px] font-black text-[#faa307]">🔒 BUILT-IN</span>}
-                    <span className="text-[11px] font-bold text-slate-600">Mastery {card.bin}/11 · {card.status}</span>
-                  </div>
-
-                  {editing ? (
-                    <div className="mt-4 grid gap-3">
-                      <textarea className="deck-input min-h-24" value={editWord} onChange={(e) => setEditWord(e.target.value)} />
-                      <textarea className="deck-input min-h-28" value={editDefinition} onChange={(e) => setEditDefinition(e.target.value)} />
-                      <div className="grid gap-2 sm:grid-cols-3">
-                        <input className="deck-input" value={editTopic} onChange={(e) => setEditTopic(e.target.value)} />
-                        <input className="deck-input" value={editDomain} onChange={(e) => setEditDomain(e.target.value)} />
-                        <select className="deck-input" value={editKind} onChange={(e) => setEditKind(e.target.value as CardKind)}>
-                          <option value="concept">Concept</option>
-                          <option value="lab">Lab</option>
-                        </select>
-                      </div>
-                      <div className="flex gap-2">
-                        <button className="game-button bg-[#faa307] px-4 py-2 text-sm text-[#370617]" onClick={() => void saveEdit(card.id)}>Save</button>
-                        <button className="game-button border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-slate-200" onClick={() => setEditingId(null)}>Cancel</button>
-                      </div>
-                    </div>
-                  ) : (
-                    <>
-                      <h2 className="mt-4 text-lg font-black leading-7 text-white">{card.word}</h2>
-                      <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-300">{card.definition}</p>
-                    </>
-                  )}
-                </div>
-
-                {!editing && (
-                  <div className="flex shrink-0 flex-wrap gap-2">
-                    {card.is_builtin ? (
-                      <button className="game-button border border-[#faa307]/25 bg-[#faa307]/10 px-3 py-2 text-xs text-[#ffba08]" onClick={() => copyToCustom(card)}>
-                        ✨ Customize a copy
-                      </button>
-                    ) : (
-                      <button className="game-button border border-white/10 bg-white/[0.06] px-3 py-2 text-xs text-slate-200" onClick={() => startEdit(card)}>
-                        ✏️ Edit
-                      </button>
-                    )}
-                    <button className="game-button border border-[#d00000]/35 bg-[#6a040f]/45 px-3 py-2 text-xs text-[#ffba08]" onClick={() => void onDelete(card)} disabled={loading}>
-                      🗑️ Delete
-                    </button>
-                  </div>
-                )}
-              </div>
-            </article>
-          );
-        })}
-        {!loading && filtered.length === 0 && (
-          <div className="game-panel p-8 text-center text-slate-400">No cards match this view.</div>
+        {user ? (
+          <Link className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]" to="/decks">+ New deck</Link>
+        ) : (
+          <Link className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]" to="/signup">Sign up to create</Link>
         )}
       </section>
 
-      <section className="game-panel border-[#d00000]/25 p-5 sm:p-6">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">🔐 Demo admin controls</p>
-        <h2 className="mt-1 text-xl font-black text-white">Protect the built-in demo.</h2>
-        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-          Built-in Platform Engineering cards are read-only. The server-side password is required to delete one or reset the shared demo progress. The password is never saved in the browser.
-        </p>
-        <div className="mt-4 flex max-w-xl flex-col gap-2 sm:flex-row">
-          <input
-            className="deck-input flex-1"
-            type="password"
-            autoComplete="off"
-            value={demoPassword}
-            onChange={(e) => setDemoPassword(e.target.value)}
-            placeholder="Demo admin password"
-          />
-          <button className="game-button border border-[#d00000]/40 bg-[#9d0208]/55 px-4 py-2 text-sm text-white" onClick={() => void onResetProgress()} disabled={loading}>
-            Reset shared progress
-          </button>
+      {error && <div className="rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-4 text-sm text-rose-200">{error}</div>}
+
+      <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[.75fr_1.25fr]">
+        <div>
+          <label className="metric-label" htmlFor="deck-picker">Choose a deck</label>
+          <select
+            id="deck-picker"
+            className="game-input mt-2"
+            value={selectedDeckId ?? ""}
+            onChange={(e) => setSelectedDeckId(Number(e.target.value))}
+          >
+            {decks.map((deck) => (
+              <option key={deck.id} value={deck.id}>{deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count} cards</option>
+            ))}
+          </select>
+          {selectedDeck?.is_builtin && (
+            <div className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-4">
+              <p className="font-black text-white">⭐ Featured starter deck</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">Read-only for visitors. Copy it to your account to edit freely.</p>
+              <button className="game-button mt-3 bg-[#ffba08] px-4 py-2 text-xs font-black text-[#370617]" onClick={() => void copyStarter()}>{user ? "Copy + customize" : "Sign up + copy"}</button>
+            </div>
+          )}
+        </div>
+        <div>
+          <label className="metric-label" htmlFor="card-search">Find a card</label>
+          <input id="card-search" className="game-input mt-2" value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search question, answer, domain, or type…" />
+          <div className="mt-3 flex flex-wrap gap-2 text-xs font-bold text-slate-500">
+            <span>{filtered.length} shown</span><span>•</span><span>{cards.length} total</span>
+            {selectedDeck && <><span>•</span><span>{selectedDeck.title}</span></>}
+          </div>
         </div>
       </section>
+
+      {selectedDeck && !selectedDeck.is_builtin && user && (
+        <form onSubmit={addCard} className="game-panel p-5 sm:p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div><p className="metric-label">Add a card</p><h2 className="mt-1 text-2xl font-black text-white">Concept or hands-on lab?</h2></div>
+            <div className="flex rounded-xl border border-white/10 bg-black/20 p-1">
+              {(["concept", "lab"] as CardKind[]).map((value) => (
+                <button key={value} type="button" className={`rounded-lg px-3 py-2 text-xs font-black ${kind === value ? "bg-[#faa307] text-[#370617]" : "text-slate-400"}`} onClick={() => setKind(value)}>{value === "concept" ? "📚 Concept" : "🔧 Lab"}</button>
+              ))}
+            </div>
+          </div>
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            <label className="grid gap-1.5 text-sm font-bold text-slate-200">Question / challenge<textarea className="game-input min-h-28 resize-y" value={word} onChange={(e) => setWord(e.target.value)} required /></label>
+            <label className="grid gap-1.5 text-sm font-bold text-slate-200">Answer / recovery path<textarea className="game-input min-h-28 resize-y" value={definition} onChange={(e) => setDefinition(e.target.value)} required /></label>
+          </div>
+          <div className="mt-4 flex flex-wrap items-end gap-3">
+            <label className="grid min-w-56 flex-1 gap-1.5 text-sm font-bold text-slate-200">Domain / category<input className="game-input" value={domain} onChange={(e) => setDomain(e.target.value)} placeholder="Networking, Chapter 4, Verbs…" /></label>
+            <button className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>Add to deck</button>
+          </div>
+        </form>
+      )}
+
+      <section className="grid gap-3">
+        {filtered.map((card) => (
+          <article key={card.id} className="game-panel p-5">
+            {editingId === card.id ? (
+              <div className="grid gap-3">
+                <textarea className="game-input min-h-20" value={editWord} onChange={(e) => setEditWord(e.target.value)} />
+                <textarea className="game-input min-h-24" value={editDefinition} onChange={(e) => setEditDefinition(e.target.value)} />
+                <div className="flex flex-wrap gap-3">
+                  <input className="game-input min-w-52 flex-1" value={editDomain} onChange={(e) => setEditDomain(e.target.value)} />
+                  <select className="game-input max-w-40" value={editKind} onChange={(e) => setEditKind(e.target.value as CardKind)}><option value="concept">Concept</option><option value="lab">Lab</option></select>
+                  <button className="game-button bg-[#ffba08] px-4 py-2 text-xs font-black text-[#370617]" onClick={() => void saveEdit(card.id)}>Save</button>
+                  <button className="game-button border border-white/10 px-4 py-2 text-xs font-black text-white" onClick={() => setEditingId(null)}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap gap-2 text-[11px] font-black uppercase tracking-[0.12em]"><span className="game-chip px-2 py-1 text-[#ffba08]">{card.kind === "lab" ? "🔧 Lab" : "📚 Concept"}</span><span className="game-chip px-2 py-1 text-slate-400">{card.domain}</span><span className="game-chip px-2 py-1 text-slate-500">Mastery {card.bin}/11</span></div>
+                  <h2 className="mt-3 text-lg font-black text-white">{card.word}</h2>
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-400">{card.definition}</p>
+                </div>
+                <div className="flex gap-2">
+                  {!card.is_builtin && <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => beginEdit(card)}>Edit</button>}
+                  <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/40 px-3 py-2 text-xs font-black text-rose-200" onClick={() => void removeCard(card)}>{card.is_builtin ? "Admin delete" : "Delete"}</button>
+                </div>
+              </div>
+            )}
+          </article>
+        ))}
+        {!loading && filtered.length === 0 && <div className="game-panel p-8 text-center text-sm text-slate-400">No cards match this view yet.</div>}
+      </section>
+
+      {selectedDeck?.is_builtin && (
+        <section className="game-panel border-[#9d0208]/40 p-5 sm:p-6">
+          <p className="metric-label">Demo owner controls</p>
+          <h2 className="mt-2 text-xl font-black text-white">Protected destructive actions</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-400">Built-in Platform Engineering cards and the public demo reset require the server-side demo password. The password is never embedded in React.</p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <input className="game-input min-w-64 flex-1" type="password" value={demoPassword} onChange={(e) => setDemoPassword(e.target.value)} placeholder="Demo admin password" />
+            <button className="game-button border border-[#d00000]/50 bg-[#6a040f]/50 px-4 py-2 text-sm font-black text-rose-200" onClick={() => void resetDemo()} disabled={!demoPassword || loading}>Reset demo progress</button>
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,739 +1,365 @@
-// frontend/src/pages/Admin.tsx
-/**
- * Admin view:
- * - Create new cards
- * - List cards with bin/status (joins user state on backend)
- * - Client-side search across word/definition
- * - Reset all progress (per default user)
- * - Export current cards to CSV (ALL rows or VISIBLE/filtered)
- * - Import cards from CSV (word,definition) — at the very bottom
- * - Delete a single card (trashcan icon on far-left)
- */
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  adminReset,
+  createCard,
+  deleteCard,
+  listAdminCards,
+  updateCard,
+} from "../api";
+import type { CardAdminRead, CardKind, CreateCardPayload } from "../types";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { createCard, listAdminCards, adminReset, deleteCard } from "../api";
-import type { CardAdminRead, CreateCardPayload } from "../types";
-
-/** Row parsed from CSV. */
-type CsvRow = { word: string; definition: string };
-
-/**
- * Detect a likely CSV delimiter from the first line.
- * @param s Raw CSV text
- * @returns the detected delimiter character (default ",")
- */
-function detectDelimiter(s: string): string {
-  const firstLine = (s.split(/\r?\n/)[0] ?? "").replace(/^\uFEFF/, "");
-  const candidates = [",", ";", "\t", "|"];
-  let best = ",";
-  let bestCount = -1;
-  for (const d of candidates) {
-    const c = (firstLine.match(new RegExp(`\\${d}`, "g")) || []).length;
-    if (c > bestCount) {
-      bestCount = c;
-      best = d;
-    }
-  }
-  return best;
-}
-
-/**
- * Parse CSV text into a grid of cells.
- * Handles quoted fields, escaped quotes, commas in quotes, mixed newlines, BOM.
- * @param text CSV content as a string
- * @param delimiter Optional forced delimiter; auto-detected when omitted
- */
-function parseCSV(text: string, delimiter?: string): string[][] {
-  const rows: string[][] = [];
-  let cur = "";
-  let row: string[] = [];
-  let inQuotes = false;
-  let i = 0;
-
-  const s0 = text.replace(/^\uFEFF/, "");
-  const d = delimiter ?? detectDelimiter(s0);
-  const s = s0.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-
-  while (i < s.length) {
-    const ch = s[i];
-    if (inQuotes) {
-      if (ch === '"') {
-        if (s[i + 1] === '"') {
-          cur += '"';
-          i += 2;
-          continue;
-        } else {
-          inQuotes = false;
-          i += 1;
-          continue;
-        }
-      } else {
-        cur += ch;
-        i += 1;
-        continue;
-      }
-    } else {
-      if (ch === '"') {
-        inQuotes = true;
-        i += 1;
-        continue;
-      }
-      if (ch === d) {
-        row.push(cur);
-        cur = "";
-        i += 1;
-        continue;
-      }
-      if (ch === "\n") {
-        row.push(cur);
-        rows.push(row);
-        row = [];
-        cur = "";
-        i += 1;
-        continue;
-      }
-      cur += ch;
-      i += 1;
-    }
-  }
-  row.push(cur);
-  rows.push(row);
-  return rows.filter((r) => !(r.length === 1 && r[0] === ""));
-}
-
-/**
- * Convert a cell grid into CsvRow objects.
- * Detects header (word/definition), falls back to first two columns.
- */
-function gridToRows(grid: string[][]): CsvRow[] {
-  if (grid.length === 0) return [];
-  const header = grid[0].map((h) => h.trim().toLowerCase());
-  const hasHeader =
-    header.includes("word") && header.includes("definition") && grid.length > 1;
-
-  const rows = hasHeader ? grid.slice(1) : grid;
-  let wordIdx = 0;
-  let defIdx = 1;
-
-  if (hasHeader) {
-    wordIdx = header.indexOf("word");
-    defIdx = header.indexOf("definition");
-  }
-
-  const out: CsvRow[] = [];
-  for (const r of rows) {
-    const word = (r[wordIdx] ?? "").trim();
-    const definition = (r[defIdx] ?? "").trim();
-    if (word && definition) out.push({ word, definition });
-  }
-  return out;
-}
-
-/**
- * Concurrency-limited async mapper.
- * @template T Input item type
- * @template R Result type
- * @param items Items to process
- * @param limit Max concurrency
- * @param worker Async worker function
- */
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  worker: (item: T, index: number) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let next = 0;
-  let active = 0;
-
-  return new Promise((resolve, reject) => {
-    const launch = () => {
-      while (active < limit && next < items.length) {
-        const i = next++;
-        active++;
-        worker(items[i], i)
-          .then((res) => (results[i] = res))
-          .catch(reject)
-          .finally(() => {
-            active--;
-            if (next === items.length && active === 0) resolve(results);
-            else launch();
-          });
-      }
-    };
-    launch();
-  });
-}
-
-/**
- * Escape a value for safe CSV serialization.
- * @param v Any value
- */
-function csvEscape(v: unknown): string {
-  const s = v == null ? "" : String(v);
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-}
-
-/** Simple timestamp for filenames (YYYY-MM-DD-HH-MM-SS). */
-function stamp(): string {
-  return new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
-}
-
-/**
- * Download arbitrary rows as CSV with given columns.
- * Includes UTF-8 BOM for Excel.
- * @param filenameBase Base filename without extension
- * @param rows Array of row objects
- * @param columns Column keys to export (order respected)
- */
-function downloadCsv(
-  filenameBase: string,
-  rows: Array<Record<string, unknown>>,
-  columns: string[]
-) {
-  const header = columns.map(csvEscape).join(",");
-  const body = rows
-    .map((r) => columns.map((c) => csvEscape(r[c])).join(","))
-    .join("\r\n");
-  const csv = `\uFEFF${header}\r\n${body}\r\n`;
-  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `${filenameBase}_${rows.length}_${stamp()}.csv`;
-  a.click();
-  URL.revokeObjectURL(url);
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }
 
 export default function Admin() {
-  // ===== Basic state =====
+  const [cards, setCards] = useState<CardAdminRead[]>([]);
   const [q, setQ] = useState("");
-  const [list, setList] = useState<CardAdminRead[]>([]);
-  const [word, setWord] = useState("");
-  const [definition, setDefinition] = useState("");
+  const [topicFilter, setTopicFilter] = useState("all");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [demoPassword, setDemoPassword] = useState("");
 
-  // Track which rows are being deleted (per-row disabled/spinner)
-  const [deleting, setDeleting] = useState<Set<number>>(new Set());
+  const [word, setWord] = useState("");
+  const [definition, setDefinition] = useState("");
+  const [topic, setTopic] = useState("My Topic");
+  const [domain, setDomain] = useState("General");
+  const [kind, setKind] = useState<CardKind>("concept");
 
-  // ===== CSV state (import section lives at the bottom) =====
-  const [csvName, setCsvName] = useState<string | null>(null);
-  const [csvRows, setCsvRows] = useState<CsvRow[]>([]);
-  const [csvError, setCsvError] = useState<string | null>(null);
-  const [importing, setImporting] = useState(0); // 0 or progress percent
-  const [importProgress, setImportProgress] = useState(0);
-  const [importSummary, setImportSummary] = useState<{
-    created: number;
-    skipped: number;
-    failed: number;
-  } | null>(null);
-  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editWord, setEditWord] = useState("");
+  const [editDefinition, setEditDefinition] = useState("");
+  const [editTopic, setEditTopic] = useState("");
+  const [editDomain, setEditDomain] = useState("");
+  const [editKind, setEditKind] = useState<CardKind>("concept");
+  const createRef = useRef<HTMLDivElement | null>(null);
 
-  // ===== Dropdown menu state for the Import/Export menu =====
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    function onDocClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, []);
-
-  /** Fetch the full list (no server-side filtering). */
-  async function refreshAll() {
-    setErr(null);
+  async function refresh() {
     setLoading(true);
+    setErr(null);
     try {
-      const rows = await listAdminCards();
-      setList(rows);
-    } catch (e: any) {
-      setErr(e?.message ?? "Failed to load cards");
+      setCards(await listAdminCards());
+    } catch (error) {
+      setErr(errorMessage(error, "Could not load cards"));
     } finally {
       setLoading(false);
     }
   }
 
-  // Client-side filtering so imports/exports/resets see everything by default
-  const filtered = useMemo(() => {
-    const s = q.trim().toLowerCase();
-    if (!s) return list;
-    return list.filter(
-      (c) =>
-        c.word.toLowerCase().includes(s) ||
-        c.definition.toLowerCase().includes(s)
-    );
-  }, [q, list]);
-
-  // Initial load
   useEffect(() => {
-    void refreshAll();
+    void refresh();
   }, []);
 
-  /** Create a card, then refresh full list. */
-  async function onCreate(e: React.FormEvent) {
-    e.preventDefault();
+  const topics = useMemo(
+    () => Array.from(new Set(cards.map((card) => card.topic))).sort(),
+    [cards]
+  );
+
+  const filtered = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    return cards.filter((card) => {
+      if (topicFilter !== "all" && card.topic !== topicFilter) return false;
+      if (!query) return true;
+      return [card.word, card.definition, card.topic, card.domain, card.kind]
+        .join(" ")
+        .toLowerCase()
+        .includes(query);
+    });
+  }, [cards, q, topicFilter]);
+
+  const builtInCount = cards.filter((card) => card.is_builtin).length;
+  const customCount = cards.length - builtInCount;
+
+  async function onCreate(event: FormEvent) {
+    event.preventDefault();
     if (!word.trim() || !definition.trim()) return;
-    setErr(null);
     setLoading(true);
+    setErr(null);
+    setNotice(null);
     try {
-      await createCard({ word: word.trim(), definition: definition.trim() });
+      const payload: CreateCardPayload = {
+        word: word.trim(),
+        definition: definition.trim(),
+        topic: topic.trim() || "My Topic",
+        domain: domain.trim() || "General",
+        kind,
+      };
+      await createCard(payload);
       setWord("");
       setDefinition("");
-      setQ(""); // show new item even if user had a filter
-      await refreshAll();
-    } catch (e: any) {
-      setErr(e?.message ?? "Failed to create card");
+      setNotice("Card added. It is ready to study in Play.");
+      await refresh();
+    } catch (error) {
+      setErr(errorMessage(error, "Could not create card"));
     } finally {
       setLoading(false);
     }
   }
 
-  /** Confirm + reset progress; then hard refresh. */
-  async function onResetProgress() {
-    if (!confirm("Reset ALL progress for the default user? This cannot be undone.")) return;
+  function startEdit(card: CardAdminRead) {
+    if (card.is_builtin) return;
+    setEditingId(card.id);
+    setEditWord(card.word);
+    setEditDefinition(card.definition);
+    setEditTopic(card.topic);
+    setEditDomain(card.domain);
+    setEditKind(card.kind === "lab" ? "lab" : "concept");
+    setErr(null);
+  }
+
+  async function saveEdit(cardId: number) {
+    setLoading(true);
+    setErr(null);
+    setNotice(null);
+    try {
+      await updateCard(cardId, {
+        word: editWord.trim(),
+        definition: editDefinition.trim(),
+        topic: editTopic.trim() || "My Topic",
+        domain: editDomain.trim() || "General",
+        kind: editKind,
+      });
+      setEditingId(null);
+      setNotice("Custom card updated.");
+      await refresh();
+    } catch (error) {
+      setErr(errorMessage(error, "Could not update card"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function copyToCustom(card: CardAdminRead) {
+    setWord(card.word.replace(/^LAB ·\s*/, ""));
+    setDefinition(card.definition);
+    setTopic(`My ${card.topic}`);
+    setDomain(card.domain.replace(/ Labs$/, ""));
+    setKind(card.kind === "lab" ? "lab" : "concept");
+    setNotice("Copied into the new-card form. Change anything you want, then save it.");
+    requestAnimationFrame(() => createRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }));
+  }
+
+  async function onDelete(card: CardAdminRead) {
+    if (card.is_builtin && !demoPassword) {
+      setErr("Built-in demo cards are protected. Enter the demo admin password first.");
+      return;
+    }
+    const warning = card.is_builtin
+      ? "Delete this protected built-in demo card? The admin password will be checked."
+      : "Delete this custom card and its study progress?";
+    if (!window.confirm(warning)) return;
+
     setLoading(true);
     setErr(null);
     try {
-      await adminReset();
-      setQ("");
-      await refreshAll();
-    } catch (e: any) {
-      setErr(e?.message ?? "Failed to reset progress");
+      await deleteCard(card.id, card.is_builtin ? demoPassword : undefined);
+      setNotice(card.is_builtin ? "Built-in card deleted." : "Custom card deleted.");
+      await refresh();
+    } catch (error) {
+      setErr(errorMessage(error, "Could not delete card"));
     } finally {
       setLoading(false);
     }
   }
 
-  /** Delete a card (red trashcan on far-left). */
-  async function onDelete(id: number) {
-    if (!confirm("Delete this card? This removes the card and its progress.")) return;
-    setDeleting((s) => new Set(s).add(id));
+  async function onResetProgress() {
+    if (!demoPassword) {
+      setErr("Enter the demo admin password before resetting shared demo progress.");
+      return;
+    }
+    if (!window.confirm("Reset progress for every card in the shared demo?")) return;
+    setLoading(true);
+    setErr(null);
     try {
-      // Optimistic removal
-      setList((prev) => prev.filter((c) => c.id !== id));
-      await deleteCard(id);
-      // If you prefer authoritative list, call: await refreshAll();
-    } catch (e: any) {
-      // Revert by reloading the list on failure
-      await refreshAll();
-      setErr(e?.message ?? "Failed to delete card");
+      await adminReset(demoPassword);
+      setNotice("Shared demo progress reset to level 0.");
+      await refresh();
+    } catch (error) {
+      setErr(errorMessage(error, "Could not reset progress"));
     } finally {
-      setDeleting((s) => {
-        const next = new Set(s);
-        next.delete(id);
-        return next;
-      });
+      setLoading(false);
     }
-  }
-
-  // ===== CSV import helpers (bottom section UI) =====
-
-  /** Handle file selection and parse into CsvRow[] */
-  async function onPickCsv(file: File) {
-    try {
-      setCsvError(null);
-      setCsvName(file.name);
-      const text = await file.text();
-      const grid = parseCSV(text); // auto-detects delimiter + handles BOM
-      let rows = gridToRows(grid);
-
-      // Dedup within-file by word (case-insensitive)
-      const seen = new Set<string>();
-      rows = rows.filter((r) => {
-        const k = r.word.toLowerCase();
-        if (seen.has(k)) return false;
-        seen.add(k);
-        return true;
-      });
-
-      setCsvRows(rows);
-      setImportSummary(null);
-      setImportProgress(0);
-    } catch (e) {
-      setCsvError(e instanceof Error ? e.message : "Failed to parse CSV");
-      setCsvRows([]);
-      setCsvName(null);
-    }
-  }
-
-  /** Begin importing parsed CSV rows using limited concurrency. */
-  async function startImport() {
-    if (csvRows.length === 0) return;
-    setImporting(1);
-    setImportSummary(null);
-    setImportProgress(0);
-
-    let created = 0;
-    let failed = 0;
-    const TOTAL = csvRows.length;
-    let done = 0;
-
-    try {
-      await mapWithConcurrency<CreateCardPayload, void>(
-        csvRows.map((r) => ({ word: r.word, definition: r.definition })),
-        5,
-        async (payload) => {
-          try {
-            await createCard(payload);
-            created += 1;
-          } catch {
-            failed += 1;
-          } finally {
-            done += 1;
-            setImportProgress(Math.round((done / TOTAL) * 100));
-          }
-        }
-      );
-      const skipped = 0;
-      setImportSummary({ created, failed, skipped });
-      setQ("");
-      await refreshAll();
-    } finally {
-      setImporting(0);
-    }
-  }
-
-  // ===== Export helpers =====
-  function exportWordsDefsAll() {
-    const rows = list.map((c) => ({ word: c.word, definition: c.definition }));
-    downloadCsv("flashcards_export_words_defs_ALL", rows, ["word", "definition"]);
-  }
-  function exportWordsDefsVisible() {
-    const rows = filtered.map((c) => ({ word: c.word, definition: c.definition }));
-    downloadCsv("flashcards_export_words_defs_VISIBLE", rows, ["word", "definition"]);
-  }
-  function exportFullAll() {
-    const rows = list.map((c) => ({
-      id: c.id,
-      word: c.word,
-      definition: c.definition,
-      bin: c.bin,
-      status: c.status,
-      created_at: c.created_at ?? "",
-    }));
-    downloadCsv(
-      "flashcards_export_full_ALL",
-      rows,
-      ["id", "word", "definition", "bin", "status", "created_at"]
-    );
   }
 
   return (
-    <div className="max-w-3xl mx-auto p-4 space-y-6">
-      {/* Title */}
-      <div className="flex items-end justify-between gap-2">
-        <h1 className="text-2xl font-semibold">Admin</h1>
-      </div>
-
-      {err && <div className="border border-red-300 bg-red-50 p-2">{err}</div>}
-
-      {/* Explainer card: what columns mean */}
-      <div className="rounded-2xl border border-black/10 bg-white p-4">
-        <h2 className="text-lg font-semibold text-black">What the columns mean</h2>
-        <dl className="mt-3 grid grid-cols-1 gap-3 text-sm text-neutral-800 sm:grid-cols-2">
-          <div>
-            <dt className="font-medium text-black">ID</dt>
-            <dd>Internal numeric identifier for the card.</dd>
-          </div>
-          <div>
-            <dt className="font-medium text-black">Word</dt>
-            <dd>The vocabulary term you’re learning.</dd>
-          </div>
-          <div>
-            <dt className="font-medium text-black">Definition</dt>
-            <dd>Short explanation of the word.</dd>
-          </div>
-          <div>
-            <dt className="font-medium text-black">Bin</dt>
-            <dd>Spaced-repetition level (0–11). Higher bins appear less often.</dd>
-          </div>
-          <div>
-            <dt className="font-medium text-black">Status</dt>
-            <dd>
-              <b>active</b> = in rotation; <b>hard_to_remember</b> = many wrong answers;{" "}
-              <b>never</b> = maxed out at bin 11.
-            </dd>
-          </div>
-          <div>
-            <dt className="font-medium text-black">Created</dt>
-            <dd>When the card was added.</dd>
-          </div>
-        </dl>
-      </div>
-
-      {/* Create form */}
-      <form onSubmit={onCreate} className="border rounded p-3 flex gap-2 items-end bg-white">
-        <div className="flex-1">
-          <label className="block text-sm mb-1">Word</label>
-          <input
-            className="w-full border rounded px-2 py-1"
-            value={word}
-            onChange={(e) => setWord(e.target.value)}
-            placeholder="abate"
-          />
+    <div className="mx-auto grid max-w-6xl gap-6">
+      <section className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-[#ffba08]">🧪 Deck Lab</p>
+          <h1 className="mt-2 text-3xl font-black text-white sm:text-4xl">Build your own study deck.</h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+            Platform Engineering is the demo pack. Add any topic you want and FlashQuest’s will use the same memory engine for it.
+          </p>
         </div>
-        <div className="flex-[2]">
-          <label className="block text-sm mb-1">Definition</label>
-          <input
-            className="w-full border rounded px-2 py-1"
-            value={definition}
-            onChange={(e) => setDefinition(e.target.value)}
-            placeholder="to become less intense or widespread"
-          />
+        <div className="flex gap-2 text-xs font-bold">
+          <span className="game-chip px-3 py-2 text-slate-200">{cards.length} total</span>
+          <span className="game-chip px-3 py-2 text-[#ffba08]">{builtInCount} built-in</span>
+          <span className="game-chip px-3 py-2 text-[#faa307]">{customCount} custom</span>
         </div>
-        <button className="px-3 py-2 rounded bg-black text-white" type="submit" disabled={loading}>
-          Add
-        </button>
-      </form>
+      </section>
 
-      {/* Search + counts */}
-      <div className="flex items-end justify-between gap-2">
-        <div className="flex gap-2 flex-1">
+      <section className="game-panel p-5 sm:p-6">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">How Deck Lab works</p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[
+            ["➕", "Make a card", "Type a question and answer."],
+            ["🏷️", "Name the topic", "AWS, Spanish, math — anything."],
+            ["📚", "Pick a type", "Concept = learn it. Lab = fix it."],
+            ["⚡", "Go to Play", "Your new topic appears automatically."],
+          ].map(([icon, title, detail]) => (
+            <div key={title} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span className="text-2xl">{icon}</span>
+              <p className="mt-3 font-black text-white">{title}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {err && <div className="rounded-2xl border border-[#d00000]/50 bg-[#6a040f]/55 p-4 text-sm font-semibold text-white">⚠️ {err}</div>}
+      {notice && <div className="rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 p-4 text-sm font-semibold text-[#ffba08]">✨ {notice}</div>}
+
+      <section ref={createRef} className="game-panel p-5 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">Create a custom card</p>
+            <h2 className="mt-1 text-xl font-black text-white">What do you want to remember?</h2>
+          </div>
+          <span className="game-chip px-3 py-1.5 text-xs text-slate-400">Custom cards never need the demo password to delete.</span>
+        </div>
+        <form onSubmit={onCreate} className="mt-5 grid gap-4">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <label className="grid gap-2 text-sm font-bold text-slate-200">
+              Question
+              <textarea className="deck-input min-h-28" value={word} onChange={(e) => setWord(e.target.value)} placeholder="What is a Kubernetes readiness probe?" required />
+            </label>
+            <label className="grid gap-2 text-sm font-bold text-slate-200">
+              Answer
+              <textarea className="deck-input min-h-28" value={definition} onChange={(e) => setDefinition(e.target.value)} placeholder="It tells the platform when a workload is ready to receive traffic..." required />
+            </label>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <label className="grid gap-2 text-sm font-bold text-slate-200">
+              Topic
+              <input className="deck-input" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="My AWS Study" />
+            </label>
+            <label className="grid gap-2 text-sm font-bold text-slate-200">
+              Domain
+              <input className="deck-input" value={domain} onChange={(e) => setDomain(e.target.value)} placeholder="Networking" />
+            </label>
+            <label className="grid gap-2 text-sm font-bold text-slate-200">
+              Type
+              <select className="deck-input" value={kind} onChange={(e) => setKind(e.target.value as CardKind)}>
+                <option value="concept">📚 Concept</option>
+                <option value="lab">🔧 Break/Fix Lab</option>
+              </select>
+            </label>
+          </div>
+          <div>
+            <button className="game-button bg-gradient-to-r from-[#dc2f02] via-[#f48c06] to-[#ffba08] px-5 py-3 text-sm text-[#370617]" type="submit" disabled={loading}>
+              ➕ Add card to FlashQuest’s
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="game-panel p-5 sm:p-6">
+        <div className="grid gap-3 lg:grid-cols-[1fr_240px]">
+          <input className="deck-input" placeholder="Search question, answer, topic, domain…" value={q} onChange={(e) => setQ(e.target.value)} />
+          <select className="deck-input" value={topicFilter} onChange={(e) => setTopicFilter(e.target.value)}>
+            <option value="all">All topics</option>
+            {topics.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </div>
+        <p className="mt-3 text-xs text-slate-500">Showing {filtered.length} of {cards.length} cards.</p>
+      </section>
+
+      <section className="grid gap-3">
+        {filtered.map((card) => {
+          const editing = editingId === card.id;
+          return (
+            <article key={card.id} className="game-panel p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="game-chip px-2.5 py-1 text-[11px] font-black text-[#ffba08]">{card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span>
+                    <span className="game-chip px-2.5 py-1 text-[11px] font-bold text-slate-300">{card.topic}</span>
+                    <span className="game-chip px-2.5 py-1 text-[11px] font-bold text-slate-400">{card.domain}</span>
+                    {card.is_builtin && <span className="game-chip px-2.5 py-1 text-[11px] font-black text-[#faa307]">🔒 BUILT-IN</span>}
+                    <span className="text-[11px] font-bold text-slate-600">Mastery {card.bin}/11 · {card.status}</span>
+                  </div>
+
+                  {editing ? (
+                    <div className="mt-4 grid gap-3">
+                      <textarea className="deck-input min-h-24" value={editWord} onChange={(e) => setEditWord(e.target.value)} />
+                      <textarea className="deck-input min-h-28" value={editDefinition} onChange={(e) => setEditDefinition(e.target.value)} />
+                      <div className="grid gap-2 sm:grid-cols-3">
+                        <input className="deck-input" value={editTopic} onChange={(e) => setEditTopic(e.target.value)} />
+                        <input className="deck-input" value={editDomain} onChange={(e) => setEditDomain(e.target.value)} />
+                        <select className="deck-input" value={editKind} onChange={(e) => setEditKind(e.target.value as CardKind)}>
+                          <option value="concept">Concept</option>
+                          <option value="lab">Lab</option>
+                        </select>
+                      </div>
+                      <div className="flex gap-2">
+                        <button className="game-button bg-[#faa307] px-4 py-2 text-sm text-[#370617]" onClick={() => void saveEdit(card.id)}>Save</button>
+                        <button className="game-button border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-slate-200" onClick={() => setEditingId(null)}>Cancel</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <h2 className="mt-4 text-lg font-black leading-7 text-white">{card.word}</h2>
+                      <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-300">{card.definition}</p>
+                    </>
+                  )}
+                </div>
+
+                {!editing && (
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    {card.is_builtin ? (
+                      <button className="game-button border border-[#faa307]/25 bg-[#faa307]/10 px-3 py-2 text-xs text-[#ffba08]" onClick={() => copyToCustom(card)}>
+                        ✨ Customize a copy
+                      </button>
+                    ) : (
+                      <button className="game-button border border-white/10 bg-white/[0.06] px-3 py-2 text-xs text-slate-200" onClick={() => startEdit(card)}>
+                        ✏️ Edit
+                      </button>
+                    )}
+                    <button className="game-button border border-[#d00000]/35 bg-[#6a040f]/45 px-3 py-2 text-xs text-[#ffba08]" onClick={() => void onDelete(card)} disabled={loading}>
+                      🗑️ Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            </article>
+          );
+        })}
+        {!loading && filtered.length === 0 && (
+          <div className="game-panel p-8 text-center text-slate-400">No cards match this view.</div>
+        )}
+      </section>
+
+      <section className="game-panel border-[#d00000]/25 p-5 sm:p-6">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">🔐 Demo admin controls</p>
+        <h2 className="mt-1 text-xl font-black text-white">Protect the built-in demo.</h2>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+          Built-in Platform Engineering cards are read-only. The server-side password is required to delete one or reset the shared demo progress. The password is never saved in the browser.
+        </p>
+        <div className="mt-4 flex max-w-xl flex-col gap-2 sm:flex-row">
           <input
-            className="border rounded px-2 py-1 flex-1"
-            placeholder="Search (word/definition)…"
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
+            className="deck-input flex-1"
+            type="password"
+            autoComplete="off"
+            value={demoPassword}
+            onChange={(e) => setDemoPassword(e.target.value)}
+            placeholder="Demo admin password"
           />
-          <button
-            className="px-3 py-2 rounded bg-gray-200"
-            onClick={() => setQ("")}
-            disabled={loading || q === ""}
-          >
-            Clear
+          <button className="game-button border border-[#d00000]/40 bg-[#9d0208]/55 px-4 py-2 text-sm text-white" onClick={() => void onResetProgress()} disabled={loading}>
+            Reset shared progress
           </button>
         </div>
-        <div className="text-sm text-neutral-700">
-          Showing <b>{filtered.length}</b> of <b>{list.length}</b>
-        </div>
-      </div>
-
-      {loading && <div className="opacity-70">Loading…</div>}
-
-      {/* Results table */}
-      <div className="overflow-auto border rounded">
-        <table className="w-full text-left text-sm">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="p-2 w-[36px]" title="Delete" aria-label="Delete column">{/* Trash */}</th>
-              <th className="p-2">ID</th>
-              <th className="p-2">Word</th>
-              <th className="p-2">Definition</th>
-              <th className="p-2">Bin</th>
-              <th className="p-2">Status</th>
-              <th className="p-2">Created</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((c) => {
-              const isDeleting = deleting.has(c.id);
-              return (
-                <tr key={c.id} className="border-t align-top">
-                  {/* Red trashcan on far-left */}
-                  <td className="p-2">
-                    <button
-                      className="rounded p-1 hover:bg-red-50 transition disabled:opacity-50"
-                      title="Delete card"
-                      aria-label={`Delete ${c.word}`}
-                      onClick={() => void onDelete(c.id)}
-                      disabled={isDeleting}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                        className={`h-4 w-4 ${isDeleting ? "text-red-400" : "text-red-600 hover:text-red-700"}`}
-                      >
-                        <path d="M9 3a1 1 0 0 0-1 1v1H5.5a1 1 0 1 0 0 2H6v11a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V7h.5a1 1 0 1 0 0-2H16V4a1 1 0 0 0-1-1H9zm2 2h2v1h-2V5zM8 7h8v11a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V7zm2.75 3a.75.75 0 0 0-.75.75v6.5a.75.75 0 1 0 1.5 0v-6.5a.75.75 0 0 0-.75-.75zm4.5 0a.75.75 0 0 0-.75.75v6.5a.75.75 0 1 0 1.5 0v-6.5a.75.75 0 0 0-.75-.75z" />
-                      </svg>
-                    </button>
-                  </td>
-
-                  <td className="p-2">{c.id}</td>
-                  <td className="p-2 font-medium text-black">{c.word}</td>
-                  <td className="p-2 whitespace-pre-wrap break-words text-neutral-900">{c.definition}</td>
-                  <td className="p-2">{c.bin}</td>
-                  <td className="p-2">{c.status}</td>
-                  <td className="p-2">
-                    {c.created_at ? new Date(c.created_at).toLocaleString() : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-            {!loading && filtered.length === 0 && (
-              <tr>
-                <td className="p-2 text-gray-500" colSpan={7}>
-                  No cards yet.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* === CSV Import (last section) === */}
-      <div className="rounded-2xl border border-black/10 bg-white p-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-black">Import from CSV</h2>
-
-          <div className="flex gap-2 items-center">
-            {/* Dropdown menu with exports + reset */}
-            <div className="relative" ref={menuRef}>
-              <button
-                type="button"
-                onClick={() => setMenuOpen((v) => !v)}
-                className="rounded-lg border border-black/10 px-3 py-1 text-sm text-neutral-800 hover:bg-neutral-50 transition"
-                aria-haspopup="menu"
-                aria-expanded={menuOpen}
-              >
-                Download template
-                <span className="ml-1 align-middle">▾</span>
-              </button>
-
-              {menuOpen && (
-                <div
-                  role="menu"
-                  className="absolute right-0 z-10 mt-1 w-64 overflow-hidden rounded-xl border border-black/10 bg-white shadow-lg"
-                >
-                  <button
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      exportWordsDefsAll();
-                    }}
-                    className="block w-full px-3 py-2 text-left text-sm hover:bg-neutral-50"
-                  >
-                    Export words+defs (ALL {list.length})
-                  </button>
-                  <button
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      exportWordsDefsVisible();
-                    }}
-                    className="block w-full px-3 py-2 text-left text-sm hover:bg-neutral-50 disabled:opacity-50"
-                    disabled={filtered.length === 0}
-                  >
-                    Export words+defs (VISIBLE {filtered.length})
-                  </button>
-                  <button
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      exportFullAll();
-                    }}
-                    className="block w-full px-3 py-2 text-left text-sm hover:bg-neutral-50 disabled:opacity-50"
-                    disabled={list.length === 0}
-                  >
-                    Export full (ALL {list.length})
-                  </button>
-
-                  <div className="my-1 h-px bg-neutral-200" />
-
-                  <button
-                    role="menuitem"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      onResetProgress();
-                    }}
-                    className="block w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50"
-                  >
-                    Reset all progress
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Choose file */}
-            <button
-              type="button"
-              onClick={() => fileRef.current?.click()}
-              className="rounded-lg border border-black px-3 py-1 text-sm text-black hover:bg-black hover:text-white transition"
-            >
-              Choose file
-            </button>
-            <input
-              ref={fileRef}
-              type="file"
-              accept=".csv,text/csv"
-              className="hidden"
-              onChange={(e) => {
-                const f = e.target.files?.[0];
-                if (f) void onPickCsv(f);
-              }}
-            />
-          </div>
-        </div>
-
-        <p className="mt-2 text-sm text-neutral-700">
-          CSV should contain <code>word</code> and <code>definition</code> columns (header
-          optional). Quotes, commas, and UTF-8 BOM are supported.
-        </p>
-
-        {csvError && <p className="mt-2 text-sm text-red-700">Error: {csvError}</p>}
-
-        {csvRows.length > 0 && (
-          <div className="mt-3 space-y-3">
-            <div className="text-sm text-neutral-800">
-              File: <b>{csvName}</b> — Parsed rows: <b>{csvRows.length}</b>
-            </div>
-
-            <div className="overflow-auto border rounded">
-              <table className="w-full text-left text-sm">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="p-2">Word</th>
-                    <th className="p-2">Definition</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {csvRows.map((r, i) => (
-                    <tr key={i} className="border-t align-top">
-                      <td className="p-2 font-medium text-black">{r.word}</td>
-                      <td className="p-2 whitespace-pre-wrap break-words text-neutral-900">
-                        {r.definition}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                onClick={startImport}
-                disabled={!!importing}
-                className="rounded-xl border border-black bg-black px-4 py-2 text-white hover:bg-white hover:text-black transition"
-              >
-                {importing ? "Importing…" : "Import"}
-              </button>
-              {!!importing && (
-                <div className="flex items-center gap-2 text-sm text-neutral-700">
-                  <div className="h-2 w-40 overflow-hidden rounded bg-neutral-200">
-                    <div
-                      className="h-2 bg-black transition-all"
-                      style={{ width: `${importProgress}%` }}
-                    />
-                  </div>
-                  <span>{importProgress}%</span>
-                </div>
-              )}
-              {importSummary && (
-                <div className="text-sm text-neutral-800">
-                  Created: <b>{importSummary.created}</b>, Failed:{" "}
-                  <b>{importSummary.failed}</b>, Skipped: <b>{importSummary.skipped}</b>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,0 +1,105 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth";
+
+export default function Landing() {
+  const { user } = useAuth();
+
+  return (
+    <div className="grid gap-14 pb-10 pt-4 sm:pt-10">
+      <section className="grid items-center gap-10 lg:grid-cols-[1.08fr_.92fr]">
+        <div>
+          <div className="game-chip inline-flex items-center gap-2 px-3 py-1.5 text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">
+            ⚡ Featured deck · Platform Engineering
+          </div>
+          <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[.98] tracking-[-0.045em] text-white sm:text-6xl lg:text-7xl">
+            Learn it. Break it. <span className="ember-text">Fix it.</span> Remember it.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+            FlashQuest’s turns study cards into a game loop. Start with 216 Platform Engineering challenges, then sign in and build decks for anything you want to learn.
+          </p>
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">
+              🎮 Try the Platform demo
+            </Link>
+            <Link
+              className="game-button border border-[#faa307]/40 bg-[#6a040f]/45 px-5 py-3 text-sm font-black text-[#ffba08]"
+              to={user ? "/decks" : "/signup"}
+            >
+              ✨ Make your own deck
+            </Link>
+            <a
+              className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-slate-200"
+              href="https://flashquest-docs.netlify.app/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              📖 Read the docs
+            </a>
+          </div>
+          <div className="mt-8 flex flex-wrap gap-5 text-sm text-slate-400">
+            <span><b className="text-white">144</b> concepts</span>
+            <span><b className="text-white">72</b> break/fix labs</span>
+            <span><b className="text-white">12</b> domains</span>
+            <span><b className="text-white">12</b> mastery levels</span>
+          </div>
+        </div>
+
+        <div className="quest-card p-6 sm:p-8">
+          <div className="relative z-10">
+            <div className="flex items-center justify-between gap-3">
+              <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">🔧 BREAK/FIX LAB</span>
+              <span className="text-xs font-bold text-slate-500">Kubernetes</span>
+            </div>
+            <p className="mt-8 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Your challenge</p>
+            <h2 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">
+              A Service has no traffic even though the Pods are Running. What do you check first?
+            </h2>
+            <div className="mt-7 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-5">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">Think like the engineer</p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Check Service selectors against Pod labels, inspect EndpointSlices, verify targetPort, then confirm readiness and network policy.
+              </p>
+            </div>
+            <div className="mt-6 xp-track"><div className="xp-fill" style={{ width: "68%" }} /></div>
+            <div className="mt-2 flex justify-between text-xs font-bold text-slate-500"><span>Mastery path</span><span>Level 7 / 11</span></div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {[
+          ["🧠", "Learn the idea", "Concept cards build the mental models behind Linux, networking, containers, Kubernetes, Terraform, databases, SRE, and more."],
+          ["🛠️", "Practice the failure", "Lab cards drop you into realistic break/fix situations and make you explain what you would inspect, change, and verify."],
+          ["🗂️", "Build anything", "Create an account, verify your email, and make your own private decks for certifications, school, coding, languages, interviews, or whatever comes next."],
+        ].map(([icon, title, body]) => (
+          <article key={title} className="game-panel p-6">
+            <div className="text-3xl">{icon}</div>
+            <h2 className="mt-4 text-xl font-black text-white">{title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-400">{body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="game-panel p-6 sm:p-8">
+        <div className="max-w-2xl">
+          <p className="metric-label">Make your own deck</p>
+          <h2 className="mt-2 text-3xl font-black text-white">Same game engine. Your topic.</h2>
+          <p className="mt-3 text-slate-400">Sign up, verify your email, create a deck, add questions or labs, then study with XP, streaks, mastery, and spaced repetition.</p>
+        </div>
+        <div className="mt-7 grid gap-3 sm:grid-cols-4">
+          {[
+            ["1", "Sign up"],
+            ["2", "Verify email"],
+            ["3", "Build a deck"],
+            ["4", "Play + remember"],
+          ].map(([step, label]) => (
+            <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
+              <p className="mt-2 font-black text-white">{label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "../auth";
+
+export default function Login() {
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await signIn({ email, password });
+      const next = (location.state as { from?: string } | null)?.from ?? "/decks";
+      navigate(next, { replace: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not sign in");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl py-6 sm:py-10">
+      <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
+        <p className="metric-label">Welcome back</p>
+        <h1 className="mt-2 text-3xl font-black text-white">Sign in to your decks</h1>
+        <p className="mt-2 text-sm text-slate-400">Your custom decks and progress stay tied to your verified account.</p>
+        <div className="mt-6 grid gap-4">
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
+            <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password
+            <input className="game-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" required />
+          </label>
+        </div>
+        {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
+        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Signing in…" : "Sign in →"}</button>
+        <p className="mt-5 text-center text-sm text-slate-500">Need an account? <Link className="font-bold text-[#faa307]" to="/signup">Create one</Link></p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/MyDecks.tsx
+++ b/frontend/src/pages/MyDecks.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { copyFeaturedDeck, createDeck, deleteDeck, getFeaturedDecks, getMyDecks } from "../api";
+import { useAuth } from "../auth";
+import type { DeckRead } from "../types";
+
+export default function MyDecks() {
+  const { user, loading: authLoading } = useAuth();
+  const navigate = useNavigate();
+  const [decks, setDecks] = useState<DeckRead[]>([]);
+  const [featured, setFeatured] = useState<DeckRead[]>([]);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function refresh() {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [mine, featuredRows] = await Promise.all([getMyDecks(), getFeaturedDecks()]);
+      setDecks(mine);
+      setFeatured(featuredRows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not load decks");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!authLoading && !user) navigate("/login", { replace: true, state: { from: "/decks" } });
+    if (user) void refresh();
+  }, [user, authLoading]);
+
+  async function onCreate(event: React.FormEvent) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const deck = await createDeck(title, description);
+      setTitle("");
+      setDescription("");
+      navigate(`/deck-lab?deck=${deck.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create deck");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onCopy(deckId: number) {
+    setLoading(true);
+    setError(null);
+    try {
+      const deck = await copyFeaturedDeck(deckId);
+      navigate(`/deck-lab?deck=${deck.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not copy featured deck");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onDelete(deck: DeckRead) {
+    if (!confirm(`Delete “${deck.title}” and all of its cards?`)) return;
+    try {
+      await deleteDeck(deck.id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete deck");
+    }
+  }
+
+  if (authLoading || !user) return <div className="game-panel p-8 text-slate-300">Loading your account…</div>;
+
+  return (
+    <div className="grid gap-8">
+      <section className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="metric-label">My decks</p>
+          <h1 className="mt-2 text-4xl font-black text-white">Make your own quest.</h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">Build a deck for any topic. Add normal concept cards, hands-on lab cards, or mix both.</p>
+        </div>
+        <div className="game-chip px-4 py-2 text-sm font-bold text-slate-300">👋 {user.display_name}</div>
+      </section>
+
+      {error && <div className="rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-4 text-sm text-rose-200">{error}</div>}
+
+      <section className="grid gap-5 lg:grid-cols-[.8fr_1.2fr]">
+        <form onSubmit={onCreate} className="game-panel p-6">
+          <p className="metric-label">New deck</p>
+          <h2 className="mt-2 text-2xl font-black text-white">What do you want to learn?</h2>
+          <div className="mt-5 grid gap-4">
+            <label className="grid gap-1.5 text-sm font-bold text-slate-200">Deck name
+              <input className="game-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="AWS Solutions Architect" required />
+            </label>
+            <label className="grid gap-1.5 text-sm font-bold text-slate-200">What is this deck for?
+              <textarea className="game-input min-h-24 resize-y" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Certification prep, interview questions, school notes…" />
+            </label>
+          </div>
+          <button className="game-button mt-5 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>Create deck →</button>
+        </form>
+
+        <div className="game-panel p-6">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="metric-label">Your library</p>
+              <h2 className="mt-2 text-2xl font-black text-white">{decks.length} custom {decks.length === 1 ? "deck" : "decks"}</h2>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3">
+            {!loading && decks.length === 0 && <div className="rounded-2xl border border-dashed border-white/15 p-6 text-center text-sm text-slate-400">You don’t have a custom deck yet. Make one on the left or copy the Platform Engineering starter deck below.</div>}
+            {decks.map((deck) => (
+              <article key={deck.id} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h3 className="font-black text-white">{deck.title}</h3>
+                    <p className="mt-1 text-xs leading-5 text-slate-400">{deck.description || "Your custom FlashQuest deck."}</p>
+                    <p className="mt-2 text-xs font-bold text-[#f48c06]">{deck.card_count} cards</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Link className="game-button bg-[#faa307] px-3 py-2 text-xs font-black text-[#370617]" to={`/study?deck=${deck.id}`}>Play</Link>
+                    <Link className="game-button border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-black text-white" to={`/deck-lab?deck=${deck.id}`}>Edit</Link>
+                    <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/40 px-3 py-2 text-xs font-black text-rose-200" onClick={() => void onDelete(deck)}>Delete</button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="game-panel p-6">
+        <p className="metric-label">Starter pack</p>
+        <h2 className="mt-2 text-2xl font-black text-white">Want to remix Platform Engineering?</h2>
+        <p className="mt-2 text-sm text-slate-400">The public demo stays protected, but you can copy all 216 cards into your account and customize your copy however you want.</p>
+        <div className="mt-5 grid gap-3 md:grid-cols-2">
+          {featured.map((deck) => (
+            <article key={deck.id} className="rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-5">
+              <h3 className="text-lg font-black text-white">{deck.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-400">{deck.description}</p>
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <span className="text-xs font-bold text-[#ffba08]">{deck.card_count} cards</span>
+                <button className="game-button bg-[#ffba08] px-4 py-2 text-xs font-black text-[#370617]" onClick={() => void onCopy(deck.id)} disabled={loading}>Copy to my decks</button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { resendVerification, signup } from "../api";
+
+export default function Signup() {
+  const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [sentTo, setSentTo] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await signup({ display_name: displayName, email, password });
+      setSentTo(result.email);
+      setMessage(result.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create account");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function resend() {
+    if (!sentTo) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setMessage(await resendVerification(sentTo));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not resend email");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (sentTo) {
+    return (
+      <div className="mx-auto max-w-xl py-10">
+        <div className="game-panel p-7 text-center sm:p-10">
+          <div className="text-6xl">📬</div>
+          <p className="metric-label mt-5">Almost there</p>
+          <h1 className="mt-2 text-3xl font-black text-white">Check your inbox!</h1>
+          <p className="mt-3 text-slate-300">We sent a verification link to <b className="text-[#ffba08]">{sentTo}</b>.</p>
+          <p className="mt-2 text-sm text-slate-500">Click it to unlock Make Your Own Deck.</p>
+          {message && <p className="mt-5 rounded-xl border border-[#faa307]/20 bg-[#faa307]/10 p-3 text-sm text-[#ffba08]">{message}</p>}
+          {error && <p className="mt-5 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <button className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]" onClick={() => void resend()} disabled={loading}>Resend email</button>
+            <Link className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-black text-white" to="/login">Go to sign in</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl py-6 sm:py-10">
+      <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
+        <p className="metric-label">Make your own deck</p>
+        <h1 className="mt-2 text-3xl font-black text-white">Create your FlashQuest account</h1>
+        <p className="mt-2 text-sm leading-6 text-slate-400">The Platform Engineering demo is free to try. An account lets you save private decks and progress.</p>
+
+        <div className="mt-6 grid gap-4">
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Name
+            <input className="game-input" value={displayName} onChange={(e) => setDisplayName(e.target.value)} autoComplete="name" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
+            <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password
+            <input className="game-input" type="password" minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="new-password" required />
+            <span className="text-xs font-normal text-slate-500">At least 8 characters.</span>
+          </label>
+        </div>
+
+        {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
+        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : "Create account →"}</button>
+        <p className="mt-5 text-center text-sm text-slate-500">Already verified? <Link className="font-bold text-[#faa307]" to="/login">Sign in</Link></p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -1,426 +1,192 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   apiBaseURL,
   binLabel,
+  getFeaturedDecks,
+  getMyDecks,
   getStudyNext,
-  getStudyTopics,
   postStudyAnswer,
   type StudyTrack,
 } from "../api";
-import type { StudyNext, StudyTopicSummary } from "../types";
+import { useAuth } from "../auth";
+import type { DeckRead, StudyNext } from "../types";
 
-type Feedback = {
-  kind: "correct" | "wrong";
-  title: string;
-  detail: string;
-  xp: number;
-};
-
-const readSessionNumber = (key: string): number => {
-  const value = window.sessionStorage.getItem(key);
-  const parsed = value ? Number(value) : 0;
-  return Number.isFinite(parsed) ? parsed : 0;
-};
+type Feedback = { kind: "correct" | "wrong"; title: string; detail: string; xp: number };
 
 const trackCopy: Record<StudyTrack, { title: string; detail: string; icon: string }> = {
-  mixed: { title: "All", detail: "Mix everything together", icon: "🎲" },
+  mixed: { title: "All cards", detail: "Mix concepts and labs", icon: "🎲" },
   concept: { title: "Concepts", detail: "Learn what things mean", icon: "📚" },
-  lab: { title: "Labs", detail: "Pretend it broke. Figure out what to check", icon: "🔧" },
+  lab: { title: "Break/Fix Labs", detail: "Pretend it broke. Find the fix", icon: "🔧" },
 };
 
+function sessionNumber(key: string): number {
+  const parsed = Number(window.sessionStorage.getItem(key) ?? "0");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export default function Study() {
-  const [data, setData] = useState<StudyNext | null>(null);
-  const [topics, setTopics] = useState<StudyTopicSummary[]>([]);
-  const [topic, setTopic] = useState("Platform Engineering");
+  const { user } = useAuth();
+  const [params, setParams] = useSearchParams();
+  const requestedDeck = Number(params.get("deck") || 0) || null;
+
+  const [decks, setDecks] = useState<DeckRead[]>([]);
+  const [deckId, setDeckId] = useState<number | null>(requestedDeck);
   const [track, setTrack] = useState<StudyTrack>("mixed");
-  const [showDef, setShowDef] = useState(false);
-  const [showLegend, setShowLegend] = useState(false);
+  const [data, setData] = useState<StudyNext | null>(null);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const [showMastery, setShowMastery] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
 
-  const [sessionXP, setSessionXP] = useState(() => readSessionNumber("flashquest-xp"));
-  const [streak, setStreak] = useState(() => readSessionNumber("flashquest-streak"));
-  const [bestStreak, setBestStreak] = useState(() => readSessionNumber("flashquest-best"));
-  const [answered, setAnswered] = useState(() => readSessionNumber("flashquest-answered"));
-  const [correct, setCorrect] = useState(() => readSessionNumber("flashquest-correct"));
+  const [xp, setXp] = useState(() => sessionNumber("flashquest-xp"));
+  const [streak, setStreak] = useState(() => sessionNumber("flashquest-streak"));
+  const [best, setBest] = useState(() => sessionNumber("flashquest-best"));
+  const [answered, setAnswered] = useState(() => sessionNumber("flashquest-answered"));
+  const [correct, setCorrect] = useState(() => sessionNumber("flashquest-correct"));
 
   useEffect(() => {
-    window.sessionStorage.setItem("flashquest-xp", String(sessionXP));
+    window.sessionStorage.setItem("flashquest-xp", String(xp));
     window.sessionStorage.setItem("flashquest-streak", String(streak));
-    window.sessionStorage.setItem("flashquest-best", String(bestStreak));
+    window.sessionStorage.setItem("flashquest-best", String(best));
     window.sessionStorage.setItem("flashquest-answered", String(answered));
     window.sessionStorage.setItem("flashquest-correct", String(correct));
-  }, [sessionXP, streak, bestStreak, answered, correct]);
+  }, [xp, streak, best, answered, correct]);
 
-  const level = Math.floor(sessionXP / 100) + 1;
-  const xpIntoLevel = sessionXP % 100;
-  const accuracy = answered > 0 ? Math.round((correct / answered) * 100) : 0;
+  const level = Math.floor(xp / 100) + 1;
+  const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
+  const mastery = data?.status === "ok" ? Math.round((data.card.bin / 11) * 100) : 0;
+  const selectedDeck = useMemo(() => decks.find((deck) => deck.id === deckId) ?? null, [decks, deckId]);
 
-  const loadTopics = useCallback(async () => {
+  const loadDecks = useCallback(async () => {
     try {
-      const rows = await getStudyTopics();
-      setTopics(rows);
-      if (rows.length > 0 && !rows.some((item) => item.topic === topic)) {
-        setTopic(rows[0].topic);
-      }
-    } catch {
-      // The study request below surfaces the actionable network error.
+      const featured = await getFeaturedDecks();
+      const mine = user ? await getMyDecks() : [];
+      const all = [...featured, ...mine];
+      setDecks(all);
+      setDeckId((current) => {
+        const wanted = requestedDeck ?? current;
+        if (wanted && all.some((deck) => deck.id === wanted)) return wanted;
+        return featured[0]?.id ?? mine[0]?.id ?? null;
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not load decks");
     }
-  }, [topic]);
+  }, [user, requestedDeck]);
 
-  const loadNext = useCallback(
-    async (clearFeedback = true) => {
-      setLoading(true);
-      setErr(null);
-      if (clearFeedback) setFeedback(null);
-      try {
-        const res = await getStudyNext(track, topic);
-        setData(res);
-        setShowDef(false);
-      } catch (e) {
-        setErr(e instanceof Error ? e.message : "Failed to load the next challenge");
-      } finally {
-        setLoading(false);
+  const loadNext = useCallback(async (clearFeedback = true) => {
+    if (!deckId) return;
+    setLoading(true);
+    setError(null);
+    if (clearFeedback) setFeedback(null);
+    try {
+      const next = await getStudyNext(track, deckId);
+      setData(next);
+      setShowAnswer(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not load the next card");
+    } finally {
+      setLoading(false);
+    }
+  }, [deckId, track]);
+
+  useEffect(() => { void loadDecks(); }, [loadDecks]);
+  useEffect(() => { void loadNext(); }, [loadNext]);
+
+  function chooseDeck(id: number) {
+    setDeckId(id);
+    setParams({ deck: String(id) }, { replace: true });
+  }
+
+  async function answer(result: "correct" | "wrong") {
+    if (data?.status !== "ok" || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await postStudyAnswer(data.card.id, result);
+      const nextStreak = result === "correct" ? streak + 1 : 0;
+      const reward = result === "correct" ? 10 + response.to_bin * 2 + Math.min(nextStreak, 5) * 3 : 2;
+      setAnswered((value) => value + 1);
+      setXp((value) => value + reward);
+      if (result === "correct") {
+        setCorrect((value) => value + 1);
+        setStreak(nextStreak);
+        setBest((value) => Math.max(value, nextStreak));
+        setFeedback({ kind: "correct", title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice recall!", detail: `Moved to mastery level ${response.to_bin}.`, xp: reward });
+      } else {
+        setStreak(0);
+        setFeedback({ kind: "wrong", title: "💪 Good practice rep", detail: "This card will come back sooner so it can stick.", xp: reward });
       }
-    },
-    [topic, track]
-  );
+      await loadNext(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save your answer");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    void loadTopics();
-  }, [loadTopics]);
-
-  useEffect(() => {
-    void loadNext();
-  }, [loadNext]);
-
-  const answer = useCallback(
-    async (result: "correct" | "wrong") => {
-      if (data?.status !== "ok" || loading) return;
-      setLoading(true);
-      setErr(null);
-      try {
-        const response = await postStudyAnswer(data.card.id, result);
-        const nextStreak = result === "correct" ? streak + 1 : 0;
-        const reward =
-          result === "correct"
-            ? 10 + response.to_bin * 2 + Math.min(nextStreak, 5) * 3
-            : 2;
-
-        setAnswered((value) => value + 1);
-        setSessionXP((value) => value + reward);
-        if (result === "correct") {
-          setCorrect((value) => value + 1);
-          setStreak(nextStreak);
-          setBestStreak((value) => Math.max(value, nextStreak));
-          setFeedback({
-            kind: "correct",
-            title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice work!",
-            detail: `Card moved to mastery level ${response.to_bin}.`,
-            xp: reward,
-          });
-        } else {
-          setStreak(0);
-          setFeedback({
-            kind: "wrong",
-            title: "💪 Good practice rep",
-            detail: "FlashQuest’s will bring this one back sooner.",
-            xp: reward,
-          });
-        }
-        await loadNext(false);
-      } catch (e) {
-        setErr(e instanceof Error ? e.message : "Failed to submit answer");
-      } finally {
-        setLoading(false);
-      }
-    },
-    [data, loadNext, loading, streak]
-  );
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (!data || loading) return;
-      if (e.key === " ") {
-        e.preventDefault();
-        setShowDef(true);
-      } else if (e.key === "1") {
-        void answer("wrong");
-      } else if (e.key === "2") {
-        void answer("correct");
-      }
+    const onKey = (event: KeyboardEvent) => {
+      if (loading || data?.status !== "ok") return;
+      if (event.key === " ") { event.preventDefault(); setShowAnswer(true); }
+      if (event.key === "1") void answer("wrong");
+      if (event.key === "2") void answer("correct");
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [data, loading, answer]);
-
-  const mastery = useMemo(() => {
-    if (data?.status !== "ok") return 0;
-    return Math.round((data.card.bin / 11) * 100);
-  }, [data]);
+  }, [data, loading, streak, loadNext]);
 
   return (
     <div className="mx-auto grid max-w-5xl gap-6">
       <section className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
         <div>
-          <div className="mb-2 flex items-center gap-2 text-xs font-black uppercase tracking-[0.2em] text-[#ffba08]">
-            <span>⚔️</span>
-            <span>Memory Quest</span>
-          </div>
-          <h1 className="text-3xl font-black tracking-tight text-white sm:text-4xl">
-            Learn it. <span className="text-[#faa307]">Remember it.</span>
-          </h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-            Pick a topic, answer one card at a time, and level up what sticks.
-          </p>
+          <p className="metric-label">⚔️ Memory Quest</p>
+          <h1 className="mt-2 text-4xl font-black tracking-tight text-white">Train your recall. <span className="ember-text">Level up.</span></h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">Pick a deck, think before you reveal, then tell FlashQuest’s if you remembered it.</p>
         </div>
-        <div className="game-chip flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-300">
-          <span className="rounded-lg bg-white/10 px-2 py-1 text-white">Space</span> reveal
-          <span className="rounded-lg bg-[#9d0208]/40 px-2 py-1 text-[#ffba08]">1</span> missed
-          <span className="rounded-lg bg-[#faa307]/20 px-2 py-1 text-[#ffba08]">2</span> got it
-        </div>
+        <div className="game-chip flex gap-3 px-4 py-2 text-xs font-bold text-slate-300"><span>Space · reveal</span><span>1 · missed</span><span>2 · got it</span></div>
       </section>
 
       <section className="game-panel p-5 sm:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">How to play</p>
-            <h2 className="mt-1 text-xl font-black text-white">It works like a tiny memory game.</h2>
-          </div>
-          <span className="game-chip px-3 py-1.5 text-xs font-bold text-slate-300">No timer. No pressure.</span>
-        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="metric-label">How to play</p><h2 className="mt-1 text-xl font-black text-white">Five tiny steps.</h2></div><span className="game-chip px-3 py-1.5 text-xs font-bold text-slate-300">No timer · no pressure</span></div>
         <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
           {[
-            ["1", "🎯", "Pick a topic", "Choose what you want to practice."],
-            ["2", "👀", "Read the question", "Think of your answer first."],
-            ["3", "✨", "Tap Reveal", "Now you can see the answer."],
-            ["4", "✅", "Tell the truth", "Tap Missed it or Got it."],
-            ["5", "⚡", "Keep going", "Cards come back until they stick."],
-          ].map(([step, icon, title, detail]) => (
-            <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-              <div className="flex items-center justify-between">
-                <span className="text-2xl">{icon}</span>
-                <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
-              </div>
-              <p className="mt-3 font-black text-white">{title}</p>
-              <p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p>
-            </div>
-          ))}
+            ["1", "🎯", "Pick a deck", "Choose what you want to learn."],
+            ["2", "👀", "Read", "Try to answer in your head."],
+            ["3", "✨", "Reveal", "Look at the real answer."],
+            ["4", "✅", "Be honest", "Missed it or got it?"],
+            ["5", "⚡", "Keep going", "FlashQuest brings weak cards back."],
+          ].map(([step, icon, title, detail]) => <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4"><div className="flex justify-between"><span className="text-2xl">{icon}</span><span className="text-xs font-black text-[#f48c06]">STEP {step}</span></div><p className="mt-3 font-black text-white">{title}</p><p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p></div>)}
         </div>
-        <div className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-4 text-sm text-slate-200">
-          <strong className="text-[#ffba08]">🔧 Labs are pretend break/fix missions:</strong>{" "}
-          imagine the system is broken, say what you would check first, then reveal the recovery path.
-        </div>
+        <p className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-4 text-sm text-slate-300"><b className="text-[#ffba08]">🔧 Lab card?</b> Pretend the thing is broken. Say what you would check first, then reveal the recovery path.</p>
       </section>
 
-      <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[0.9fr_1.4fr]">
-        <div>
-          <label htmlFor="topic" className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">
-            1 · Choose a topic
-          </label>
-          <select
-            id="topic"
-            className="mt-2 w-full rounded-xl border border-white/10 bg-[#03071e] px-4 py-3 font-bold text-white outline-none focus:border-[#faa307]/60"
-            value={topic}
-            onChange={(e) => setTopic(e.target.value)}
-          >
-            {topics.length === 0 && <option value={topic}>{topic}</option>}
-            {topics.map((item) => (
-              <option key={item.topic} value={item.topic}>
-                {item.topic} · {item.total} cards
-              </option>
-            ))}
-          </select>
-          <p className="mt-2 text-xs text-slate-500">Add a new topic in Deck Lab and it will show up here.</p>
-        </div>
-
-        <div>
-          <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">2 · Choose how to practice</p>
-          <div className="mt-2 grid gap-2 sm:grid-cols-3">
-            {(Object.keys(trackCopy) as StudyTrack[]).map((value) => {
-              const option = trackCopy[value];
-              const selected = value === track;
-              return (
-                <button
-                  key={value}
-                  className={[
-                    "rounded-xl border p-3 text-left transition",
-                    selected
-                      ? "border-[#faa307]/70 bg-[#d00000]/20 shadow-lg shadow-[#6a040f]/20"
-                      : "border-white/10 bg-black/15 hover:border-[#f48c06]/35 hover:bg-white/[0.04]",
-                  ].join(" ")}
-                  onClick={() => setTrack(value)}
-                >
-                  <span className="text-lg">{option.icon}</span>
-                  <span className="ml-2 font-black text-white">{option.title}</span>
-                  <span className="mt-1 block text-xs leading-4 text-slate-400">{option.detail}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
+      <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[.9fr_1.4fr]">
+        <div><label className="metric-label" htmlFor="deck">Choose a deck</label><select id="deck" className="game-input mt-2" value={deckId ?? ""} onChange={(e) => chooseDeck(Number(e.target.value))}>{decks.map((deck) => <option key={deck.id} value={deck.id}>{deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count}</option>)}</select><p className="mt-2 text-xs text-slate-500">⭐ is the public featured deck. Your private decks appear after sign in.</p></div>
+        <div><p className="metric-label">Choose a mode</p><div className="mt-2 grid gap-2 sm:grid-cols-3">{(Object.keys(trackCopy) as StudyTrack[]).map((value) => { const item = trackCopy[value]; const active = track === value; return <button key={value} className={`rounded-xl border p-3 text-left transition ${active ? "border-[#faa307]/70 bg-[#d00000]/20" : "border-white/10 bg-black/15 hover:border-[#f48c06]/40"}`} onClick={() => setTrack(value)}><span className="text-lg">{item.icon}</span><span className="ml-2 font-black text-white">{item.title}</span><span className="mt-1 block text-xs text-slate-400">{item.detail}</span></button>; })}</div></div>
       </section>
 
       <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="game-panel p-4">
-          <p className="metric-label">Player level</p>
-          <div className="mt-2 flex items-end justify-between gap-3">
-            <strong className="text-3xl font-black text-white">Lv. {level}</strong>
-            <span className="text-xs font-bold text-slate-400">{xpIntoLevel}/100 XP</span>
-          </div>
-          <div className="xp-track mt-3"><div className="xp-fill" style={{ width: `${xpIntoLevel}%` }} /></div>
-        </div>
-        <div className="game-panel p-4">
-          <p className="metric-label">Combo</p>
-          <strong className="mt-2 block text-3xl font-black text-white">{streak > 0 ? `🔥 ${streak}` : "—"}</strong>
-          <p className="mt-1 text-xs text-slate-400">Best this session: {bestStreak}</p>
-        </div>
-        <div className="game-panel p-4">
-          <p className="metric-label">Accuracy</p>
-          <strong className="mt-2 block text-3xl font-black text-white">{answered ? `${accuracy}%` : "—"}</strong>
-          <p className="mt-1 text-xs text-slate-400">{correct} correct · {answered} attempts</p>
-        </div>
-        <div className="game-panel p-4">
-          <p className="metric-label">Session XP</p>
-          <strong className="mt-2 block text-3xl font-black text-white">⚡ {sessionXP}</strong>
-          <p className="mt-1 text-xs text-slate-400">Game stats stay in this browser session.</p>
-        </div>
+        <div className="game-panel p-4"><p className="metric-label">Player level</p><div className="mt-2 flex items-end justify-between"><strong className="text-3xl font-black text-white">Lv. {level}</strong><span className="text-xs font-bold text-slate-400">{xp % 100}/100 XP</span></div><div className="xp-track mt-3"><div className="xp-fill" style={{ width: `${xp % 100}%` }} /></div></div>
+        <div className="game-panel p-4"><p className="metric-label">Combo</p><strong className="mt-2 block text-3xl font-black text-white">{streak ? `🔥 ${streak}` : "—"}</strong><p className="mt-1 text-xs text-slate-400">Best: {best}</p></div>
+        <div className="game-panel p-4"><p className="metric-label">Accuracy</p><strong className="mt-2 block text-3xl font-black text-white">{answered ? `${accuracy}%` : "—"}</strong><p className="mt-1 text-xs text-slate-400">{correct} correct · {answered} tries</p></div>
+        <div className="game-panel p-4"><p className="metric-label">Session XP</p><strong className="mt-2 block text-3xl font-black text-white">⚡ {xp}</strong><p className="mt-1 text-xs text-slate-400">Game stats stay in this browser session.</p></div>
       </section>
 
-      {feedback && (
-        <div className="reward-pop flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 px-5 py-4" role="status">
-          <div>
-            <p className="font-black text-white">{feedback.title}</p>
-            <p className="mt-1 text-sm text-slate-300">{feedback.detail}</p>
-          </div>
-          <div className="rounded-xl bg-[#ffba08] px-3 py-2 text-sm font-black text-[#370617]">+{feedback.xp} XP</div>
-        </div>
-      )}
+      {feedback && <div className="reward-pop flex items-center justify-between gap-4 rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 px-5 py-4"><div><p className="font-black text-white">{feedback.title}</p><p className="mt-1 text-sm text-slate-300">{feedback.detail}</p></div><div className="rounded-xl bg-[#ffba08] px-3 py-2 text-sm font-black text-[#370617]">+{feedback.xp} XP</div></div>}
+      {error && <div className="game-panel border-[#d00000]/60 p-5"><h2 className="font-black text-white">🛡️ Quest interrupted</h2><p className="mt-1 text-sm text-slate-300">{error}</p><p className="mt-2 break-all text-xs text-slate-500">API: {apiBaseURL()}</p><button className="game-button mt-4 bg-[#faa307] px-4 py-2 text-sm font-black text-[#370617]" onClick={() => void loadNext()}>Retry encounter</button></div>}
 
-      {err && (
-        <div className="game-panel border-[#d00000]/60 p-5">
-          <div className="flex items-start gap-3">
-            <span className="text-2xl">🛡️</span>
-            <div className="min-w-0">
-              <h2 className="font-black text-white">Quest interrupted</h2>
-              <p className="mt-1 text-sm text-slate-300">{err}</p>
-              <p className="mt-2 break-all text-xs text-slate-500">API: {apiBaseURL()}</p>
-              <button className="game-button mt-4 bg-[#faa307] px-4 py-2 text-sm text-[#370617]" onClick={() => void loadNext()}>
-                Retry encounter
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {loading && !data && !err && (
-        <div className="quest-card animate-pulse p-8 sm:p-10">
-          <div className="h-5 w-32 rounded bg-white/10" />
-          <div className="mt-8 h-12 w-2/3 rounded bg-white/10" />
-          <div className="mt-8 h-24 rounded-2xl bg-white/[0.06]" />
-        </div>
-      )}
-
-      {data?.status === "temporarily_done" && !err && (
-        <div className="game-panel p-8 text-center sm:p-10">
-          <div className="floaty text-6xl">🌙</div>
-          <h2 className="mt-5 text-2xl font-black text-white">Checkpoint reached</h2>
-          <p className="mx-auto mt-2 max-w-md text-slate-400">Nothing in this mode is due right now. Come back later or try another mode.</p>
-          <button className="game-button mt-6 bg-[#faa307] px-5 py-3 text-[#370617]" onClick={() => void loadNext()}>
-            Check again
-          </button>
-        </div>
-      )}
-
-      {data?.status === "permanently_done" && !err && (
-        <div className="game-panel p-8 text-center sm:p-12">
-          <div className="floaty text-7xl">🏆</div>
-          <h2 className="mt-5 text-3xl font-black text-white">No active cards here yet</h2>
-          <p className="mx-auto mt-2 max-w-lg text-slate-400">Try another topic or mode, or add cards in Deck Lab.</p>
-        </div>
-      )}
-
-      {data?.status === "ok" && !err && (
+      {data?.status === "ok" && !error && (
         <>
-          <article className="quest-card answer-pop p-6 sm:p-10">
-            <div className="relative z-10">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex flex-wrap gap-2">
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">{data.card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span>
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-200">{data.card.domain}</span>
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-[#faa307]">⭐ Mastery {data.card.bin}/11</span>
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">⏳ {binLabel(data.card.bin)}</span>
-                </div>
-                {data.card.is_builtin && <span className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">Built-in demo</span>}
-              </div>
-
-              <div className="mt-5">
-                <div className="mb-2 flex items-center justify-between text-[11px] font-black uppercase tracking-[0.14em] text-slate-500">
-                  <span>Card mastery</span><span>{mastery}%</span>
-                </div>
-                <div className="xp-track"><div className="xp-fill" style={{ width: `${mastery}%` }} /></div>
-              </div>
-
-              <div className="py-10 text-center sm:py-14">
-                <p className="text-xs font-black uppercase tracking-[0.25em] text-[#f48c06]">{data.card.kind === "lab" ? "Something broke" : "Your question"}</p>
-                <h2 className="mx-auto mt-4 max-w-3xl text-3xl font-black tracking-tight text-white sm:text-5xl">
-                  {data.card.word}
-                </h2>
-
-                {!showDef ? (
-                  <button className="game-button mt-10 bg-gradient-to-r from-[#dc2f02] via-[#f48c06] to-[#ffba08] px-7 py-3.5 text-base text-[#370617] shadow-xl shadow-black/30" onClick={() => setShowDef(true)}>
-                    ✨ Reveal {data.card.kind === "lab" ? "fix path" : "answer"}
-                  </button>
-                ) : (
-                  <div className="answer-pop mx-auto mt-9 max-w-2xl rounded-2xl border border-[#faa307]/30 bg-[#370617]/55 p-5 text-left sm:p-6">
-                    <p className="text-[11px] font-black uppercase tracking-[0.18em] text-[#ffba08]">{data.card.kind === "lab" ? "Recovery path" : "Answer unlocked"}</p>
-                    <p className="mt-3 text-lg font-semibold leading-8 text-slate-100">{data.card.definition}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </article>
-
-          <div className="grid gap-3 sm:grid-cols-3">
-            <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/65 px-5 py-4 text-left text-white hover:bg-[#9d0208]/70" onClick={() => void answer("wrong")} disabled={loading}>
-              <span className="block text-xs font-black uppercase tracking-[0.14em] text-[#ffba08]">1 · Missed it</span>
-              <span className="mt-1 block text-sm font-semibold">Bring it back sooner</span>
-            </button>
-            <button className="game-button border border-[#faa307]/35 bg-[#e85d04]/20 px-5 py-4 text-left text-white hover:bg-[#e85d04]/30" onClick={() => void answer("correct")} disabled={loading}>
-              <span className="block text-xs font-black uppercase tracking-[0.14em] text-[#ffba08]">2 · Got it</span>
-              <span className="mt-1 block text-sm font-semibold">Advance mastery + combo</span>
-            </button>
-            <button className="game-button border border-white/10 bg-white/[0.05] px-5 py-4 text-left text-slate-200 hover:bg-white/10" onClick={() => void loadNext()} disabled={loading}>
-              <span className="block text-xs font-black uppercase tracking-[0.14em] text-slate-400">Skip</span>
-              <span className="mt-1 block text-sm font-semibold">Draw another card</span>
-            </button>
-          </div>
-
-          <div className="game-panel overflow-hidden">
-            <button className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left" onClick={() => setShowLegend((value) => !value)} aria-expanded={showLegend}>
-              <div>
-                <p className="font-black text-white">🗺️ What do mastery levels mean?</p>
-                <p className="mt-1 text-xs text-slate-400">Cards you know well wait longer before they come back.</p>
-              </div>
-              <span className="text-sm font-black text-[#faa307]">{showLegend ? "Close" : "Show me"}</span>
-            </button>
-            {showLegend && (
-              <div className="grid grid-cols-2 gap-2 border-t border-white/10 p-4 sm:grid-cols-4 lg:grid-cols-6">
-                {Array.from({ length: 12 }, (_, i) => (
-                  <div key={i} className={[
-                    "rounded-xl border p-3",
-                    i === data.card.bin ? "border-[#faa307]/55 bg-[#e85d04]/15" : "border-white/10 bg-white/[0.035]",
-                  ].join(" ")}>
-                    <p className="text-xs font-black text-white">Level {i}</p>
-                    <p className="mt-1 text-xs text-slate-400">{binLabel(i)}</p>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          <article className="quest-card p-6 sm:p-10"><div className="relative z-10"><div className="flex flex-wrap items-center justify-between gap-3"><div className="flex flex-wrap gap-2"><span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">{data.card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span><span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">{data.card.domain}</span><span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">⭐ Mastery {data.card.bin}/11</span></div><span className="text-xs font-bold text-slate-500">{selectedDeck?.title ?? data.deck.title}</span></div><div className="mt-5 xp-track"><div className="xp-fill" style={{ width: `${mastery}%` }} /></div><div className="py-10 text-center sm:py-14"><p className="metric-label">Your challenge</p><h2 className="mx-auto mt-4 max-w-3xl text-3xl font-black leading-tight text-white sm:text-5xl">{data.card.word}</h2>{!showAnswer ? <button className="game-button mt-9 bg-[#ffba08] px-6 py-3 font-black text-[#370617]" onClick={() => setShowAnswer(true)}>✨ Reveal answer</button> : <div className="answer-pop mx-auto mt-8 max-w-2xl rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-5 text-left"><p className="metric-label">Answer unlocked</p><p className="mt-3 text-lg font-semibold leading-8 text-slate-100">{data.card.definition}</p></div>}</div></div></article>
+          <div className="grid gap-3 sm:grid-cols-3"><button className="game-button border border-[#d00000]/40 bg-[#6a040f]/45 px-5 py-4 text-left text-rose-100" onClick={() => void answer("wrong")} disabled={loading}><b className="block text-sm">1 · Missed it</b><span className="mt-1 block text-xs text-rose-200/70">Bring it back sooner</span></button><button className="game-button border border-[#faa307]/40 bg-[#e85d04]/20 px-5 py-4 text-left text-[#ffba08]" onClick={() => void answer("correct")} disabled={loading}><b className="block text-sm">2 · Got it</b><span className="mt-1 block text-xs text-[#ffba08]/70">Advance mastery + combo</span></button><button className="game-button border border-white/10 bg-white/[0.04] px-5 py-4 text-left text-slate-200" onClick={() => void loadNext()} disabled={loading}><b className="block text-sm">Skip</b><span className="mt-1 block text-xs text-slate-500">Draw another card</span></button></div>
+          <div className="game-panel overflow-hidden"><button className="flex w-full items-center justify-between px-5 py-4 text-left" onClick={() => setShowMastery((value) => !value)}><div><p className="font-black text-white">🗺️ Mastery map</p><p className="mt-1 text-xs text-slate-400">Higher levels wait longer before review.</p></div><span className="text-xs font-black text-[#faa307]">{showMastery ? "Close" : "Open"}</span></button>{showMastery && <div className="grid grid-cols-2 gap-2 border-t border-white/10 p-4 sm:grid-cols-4 lg:grid-cols-6">{Array.from({ length: 12 }, (_, index) => <div key={index} className={`rounded-xl border p-3 ${index === data.card.bin ? "border-[#faa307]/50 bg-[#d00000]/20" : "border-white/10 bg-black/10"}`}><p className="text-xs font-black text-white">Level {index}</p><p className="mt-1 text-xs text-slate-500">{binLabel(index)}</p></div>)}</div>}</div>
         </>
       )}
+
+      {data?.status === "temporarily_done" && !error && <div className="game-panel p-9 text-center"><div className="text-5xl">🌙</div><h2 className="mt-4 text-2xl font-black text-white">Checkpoint reached</h2><p className="mt-2 text-sm text-slate-400">Nothing in this mode is due right now.</p><button className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]" onClick={() => void loadNext()}>Check again</button></div>}
+      {data?.status === "permanently_done" && !error && <div className="game-panel p-9 text-center"><div className="text-6xl">🏆</div><h2 className="mt-4 text-2xl font-black text-white">Deck conquered!</h2><p className="mt-2 text-sm text-slate-400">Everything in this mode has reached its terminal state.</p></div>}
     </div>
   );
 }

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { binLabel, getStudyNext, postStudyAnswer } from "../api";
-import type { StudyNext } from "../types";
+import {
+  apiBaseURL,
+  binLabel,
+  getStudyNext,
+  getStudyTopics,
+  postStudyAnswer,
+  type StudyTrack,
+} from "../api";
+import type { StudyNext, StudyTopicSummary } from "../types";
 
 type Feedback = {
   kind: "correct" | "wrong";
@@ -15,15 +22,23 @@ const readSessionNumber = (key: string): number => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const trackCopy: Record<StudyTrack, { title: string; detail: string; icon: string }> = {
+  mixed: { title: "All", detail: "Mix everything together", icon: "🎲" },
+  concept: { title: "Concepts", detail: "Learn what things mean", icon: "📚" },
+  lab: { title: "Labs", detail: "Pretend it broke. Figure out what to check", icon: "🔧" },
+};
+
 export default function Study() {
   const [data, setData] = useState<StudyNext | null>(null);
+  const [topics, setTopics] = useState<StudyTopicSummary[]>([]);
+  const [topic, setTopic] = useState("Platform Engineering");
+  const [track, setTrack] = useState<StudyTrack>("mixed");
   const [showDef, setShowDef] = useState(false);
   const [showLegend, setShowLegend] = useState(false);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
 
-  // These are intentionally session-local game stats. Study mastery itself comes from the API.
   const [sessionXP, setSessionXP] = useState(() => readSessionNumber("flashquest-xp"));
   const [streak, setStreak] = useState(() => readSessionNumber("flashquest-streak"));
   const [bestStreak, setBestStreak] = useState(() => readSessionNumber("flashquest-best"));
@@ -42,20 +57,39 @@ export default function Study() {
   const xpIntoLevel = sessionXP % 100;
   const accuracy = answered > 0 ? Math.round((correct / answered) * 100) : 0;
 
-  const loadNext = useCallback(async (clearFeedback = true) => {
-    setLoading(true);
-    setErr(null);
-    if (clearFeedback) setFeedback(null);
+  const loadTopics = useCallback(async () => {
     try {
-      const res = await getStudyNext();
-      setData(res);
-      setShowDef(false);
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to load the next challenge");
-    } finally {
-      setLoading(false);
+      const rows = await getStudyTopics();
+      setTopics(rows);
+      if (rows.length > 0 && !rows.some((item) => item.topic === topic)) {
+        setTopic(rows[0].topic);
+      }
+    } catch {
+      // The study request below surfaces the actionable network error.
     }
-  }, []);
+  }, [topic]);
+
+  const loadNext = useCallback(
+    async (clearFeedback = true) => {
+      setLoading(true);
+      setErr(null);
+      if (clearFeedback) setFeedback(null);
+      try {
+        const res = await getStudyNext(track, topic);
+        setData(res);
+        setShowDef(false);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : "Failed to load the next challenge");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [topic, track]
+  );
+
+  useEffect(() => {
+    void loadTopics();
+  }, [loadTopics]);
 
   useEffect(() => {
     void loadNext();
@@ -76,27 +110,25 @@ export default function Study() {
 
         setAnswered((value) => value + 1);
         setSessionXP((value) => value + reward);
-
         if (result === "correct") {
           setCorrect((value) => value + 1);
           setStreak(nextStreak);
           setBestStreak((value) => Math.max(value, nextStreak));
           setFeedback({
             kind: "correct",
-            title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice recall!",
-            detail: `Card advanced to mastery level ${response.to_bin}.`,
+            title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice work!",
+            detail: `Card moved to mastery level ${response.to_bin}.`,
             xp: reward,
           });
         } else {
           setStreak(0);
           setFeedback({
             kind: "wrong",
-            title: "💪 Training rep logged",
-            detail: "The card is coming back sooner so you can lock it in.",
+            title: "💪 Good practice rep",
+            detail: "FlashQuest’s will bring this one back sooner.",
             xp: reward,
           });
         }
-
         await loadNext(false);
       } catch (e) {
         setErr(e instanceof Error ? e.message : "Failed to submit answer");
@@ -132,27 +164,107 @@ export default function Study() {
     <div className="mx-auto grid max-w-5xl gap-6">
       <section className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
         <div>
-          <div className="mb-2 flex items-center gap-2 text-xs font-black uppercase tracking-[0.2em] text-violet-300">
+          <div className="mb-2 flex items-center gap-2 text-xs font-black uppercase tracking-[0.2em] text-[#ffba08]">
             <span>⚔️</span>
             <span>Memory Quest</span>
           </div>
           <h1 className="text-3xl font-black tracking-tight text-white sm:text-4xl">
-            Train your recall. <span className="text-cyan-300">Level up.</span>
+            Learn it. <span className="text-[#faa307]">Remember it.</span>
           </h1>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-            Reveal the answer, make the call, and push cards through all 12 mastery levels.
+            Pick a topic, answer one card at a time, and level up what sticks.
           </p>
         </div>
         <div className="game-chip flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-300">
           <span className="rounded-lg bg-white/10 px-2 py-1 text-white">Space</span> reveal
-          <span className="rounded-lg bg-rose-400/15 px-2 py-1 text-rose-200">1</span> miss
-          <span className="rounded-lg bg-emerald-400/15 px-2 py-1 text-emerald-200">2</span> got it
+          <span className="rounded-lg bg-[#9d0208]/40 px-2 py-1 text-[#ffba08]">1</span> missed
+          <span className="rounded-lg bg-[#faa307]/20 px-2 py-1 text-[#ffba08]">2</span> got it
+        </div>
+      </section>
+
+      <section className="game-panel p-5 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">How to play</p>
+            <h2 className="mt-1 text-xl font-black text-white">It works like a tiny memory game.</h2>
+          </div>
+          <span className="game-chip px-3 py-1.5 text-xs font-bold text-slate-300">No timer. No pressure.</span>
+        </div>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          {[
+            ["1", "🎯", "Pick a topic", "Choose what you want to practice."],
+            ["2", "👀", "Read the question", "Think of your answer first."],
+            ["3", "✨", "Tap Reveal", "Now you can see the answer."],
+            ["4", "✅", "Tell the truth", "Tap Missed it or Got it."],
+            ["5", "⚡", "Keep going", "Cards come back until they stick."],
+          ].map(([step, icon, title, detail]) => (
+            <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-2xl">{icon}</span>
+                <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
+              </div>
+              <p className="mt-3 font-black text-white">{title}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-4 text-sm text-slate-200">
+          <strong className="text-[#ffba08]">🔧 Labs are pretend break/fix missions:</strong>{" "}
+          imagine the system is broken, say what you would check first, then reveal the recovery path.
+        </div>
+      </section>
+
+      <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[0.9fr_1.4fr]">
+        <div>
+          <label htmlFor="topic" className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">
+            1 · Choose a topic
+          </label>
+          <select
+            id="topic"
+            className="mt-2 w-full rounded-xl border border-white/10 bg-[#03071e] px-4 py-3 font-bold text-white outline-none focus:border-[#faa307]/60"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+          >
+            {topics.length === 0 && <option value={topic}>{topic}</option>}
+            {topics.map((item) => (
+              <option key={item.topic} value={item.topic}>
+                {item.topic} · {item.total} cards
+              </option>
+            ))}
+          </select>
+          <p className="mt-2 text-xs text-slate-500">Add a new topic in Deck Lab and it will show up here.</p>
+        </div>
+
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-[#ffba08]">2 · Choose how to practice</p>
+          <div className="mt-2 grid gap-2 sm:grid-cols-3">
+            {(Object.keys(trackCopy) as StudyTrack[]).map((value) => {
+              const option = trackCopy[value];
+              const selected = value === track;
+              return (
+                <button
+                  key={value}
+                  className={[
+                    "rounded-xl border p-3 text-left transition",
+                    selected
+                      ? "border-[#faa307]/70 bg-[#d00000]/20 shadow-lg shadow-[#6a040f]/20"
+                      : "border-white/10 bg-black/15 hover:border-[#f48c06]/35 hover:bg-white/[0.04]",
+                  ].join(" ")}
+                  onClick={() => setTrack(value)}
+                >
+                  <span className="text-lg">{option.icon}</span>
+                  <span className="ml-2 font-black text-white">{option.title}</span>
+                  <span className="mt-1 block text-xs leading-4 text-slate-400">{option.detail}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </section>
 
       <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <div className="game-panel p-4">
-          <p className="text-[11px] font-black uppercase tracking-[0.16em] text-violet-300">Player level</p>
+          <p className="metric-label">Player level</p>
           <div className="mt-2 flex items-end justify-between gap-3">
             <strong className="text-3xl font-black text-white">Lv. {level}</strong>
             <span className="text-xs font-bold text-slate-400">{xpIntoLevel}/100 XP</span>
@@ -160,51 +272,41 @@ export default function Study() {
           <div className="xp-track mt-3"><div className="xp-fill" style={{ width: `${xpIntoLevel}%` }} /></div>
         </div>
         <div className="game-panel p-4">
-          <p className="text-[11px] font-black uppercase tracking-[0.16em] text-orange-300">Combo</p>
+          <p className="metric-label">Combo</p>
           <strong className="mt-2 block text-3xl font-black text-white">{streak > 0 ? `🔥 ${streak}` : "—"}</strong>
-          <p className="mt-1 text-xs font-medium text-slate-400">Best this session: {bestStreak}</p>
+          <p className="mt-1 text-xs text-slate-400">Best this session: {bestStreak}</p>
         </div>
         <div className="game-panel p-4">
-          <p className="text-[11px] font-black uppercase tracking-[0.16em] text-cyan-300">Accuracy</p>
+          <p className="metric-label">Accuracy</p>
           <strong className="mt-2 block text-3xl font-black text-white">{answered ? `${accuracy}%` : "—"}</strong>
-          <p className="mt-1 text-xs font-medium text-slate-400">{correct} correct · {answered} attempts</p>
+          <p className="mt-1 text-xs text-slate-400">{correct} correct · {answered} attempts</p>
         </div>
         <div className="game-panel p-4">
-          <p className="text-[11px] font-black uppercase tracking-[0.16em] text-amber-300">Session XP</p>
+          <p className="metric-label">Session XP</p>
           <strong className="mt-2 block text-3xl font-black text-white">⚡ {sessionXP}</strong>
-          <p className="mt-1 text-xs font-medium text-slate-400">Game stats stay in this browser session.</p>
+          <p className="mt-1 text-xs text-slate-400">Game stats stay in this browser session.</p>
         </div>
       </section>
 
       {feedback && (
-        <div
-          className={[
-            "reward-pop flex flex-wrap items-center justify-between gap-4 rounded-2xl border px-5 py-4",
-            feedback.kind === "correct"
-              ? "border-emerald-300/20 bg-emerald-400/10"
-              : "border-amber-300/20 bg-amber-300/10",
-          ].join(" ")}
-          role="status"
-        >
+        <div className="reward-pop flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 px-5 py-4" role="status">
           <div>
             <p className="font-black text-white">{feedback.title}</p>
             <p className="mt-1 text-sm text-slate-300">{feedback.detail}</p>
           </div>
-          <div className="rounded-xl bg-white px-3 py-2 text-sm font-black text-slate-950">+{feedback.xp} XP</div>
+          <div className="rounded-xl bg-[#ffba08] px-3 py-2 text-sm font-black text-[#370617]">+{feedback.xp} XP</div>
         </div>
       )}
 
       {err && (
-        <div className="game-panel border-rose-400/25 p-5">
+        <div className="game-panel border-[#d00000]/60 p-5">
           <div className="flex items-start gap-3">
             <span className="text-2xl">🛡️</span>
-            <div>
+            <div className="min-w-0">
               <h2 className="font-black text-white">Quest interrupted</h2>
-              <p className="mt-1 text-sm text-slate-400">{err}</p>
-              <button
-                className="game-button mt-4 bg-rose-300 px-4 py-2 text-sm text-rose-950"
-                onClick={() => void loadNext()}
-              >
+              <p className="mt-1 text-sm text-slate-300">{err}</p>
+              <p className="mt-2 break-all text-xs text-slate-500">API: {apiBaseURL()}</p>
+              <button className="game-button mt-4 bg-[#faa307] px-4 py-2 text-sm text-[#370617]" onClick={() => void loadNext()}>
                 Retry encounter
               </button>
             </div>
@@ -222,11 +324,11 @@ export default function Study() {
 
       {data?.status === "temporarily_done" && !err && (
         <div className="game-panel p-8 text-center sm:p-10">
-          <div className="floaty mx-auto grid h-20 w-20 place-items-center rounded-3xl bg-cyan-300/10 text-5xl">🌙</div>
-          <h2 className="mt-6 text-2xl font-black text-white">Checkpoint reached</h2>
-          <p className="mx-auto mt-2 max-w-md text-slate-400">Nothing is due right now. Your memory engine is doing its thing.</p>
-          <button className="game-button mt-6 bg-cyan-300 px-5 py-3 text-cyan-950" onClick={() => void loadNext()}>
-            Check for new quests
+          <div className="floaty text-6xl">🌙</div>
+          <h2 className="mt-5 text-2xl font-black text-white">Checkpoint reached</h2>
+          <p className="mx-auto mt-2 max-w-md text-slate-400">Nothing in this mode is due right now. Come back later or try another mode.</p>
+          <button className="game-button mt-6 bg-[#faa307] px-5 py-3 text-[#370617]" onClick={() => void loadNext()}>
+            Check again
           </button>
         </div>
       )}
@@ -234,8 +336,8 @@ export default function Study() {
       {data?.status === "permanently_done" && !err && (
         <div className="game-panel p-8 text-center sm:p-12">
           <div className="floaty text-7xl">🏆</div>
-          <h2 className="mt-5 text-3xl font-black text-white">Deck conquered!</h2>
-          <p className="mx-auto mt-2 max-w-lg text-slate-400">Every card has reached its terminal study state. That is a completed run.</p>
+          <h2 className="mt-5 text-3xl font-black text-white">No active cards here yet</h2>
+          <p className="mx-auto mt-2 max-w-lg text-slate-400">Try another topic or mode, or add cards in Deck Lab.</p>
         </div>
       )}
 
@@ -245,10 +347,12 @@ export default function Study() {
             <div className="relative z-10">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-wrap gap-2">
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-violet-200">⭐ Mastery {data.card.bin}/11</span>
-                  <span className="game-chip px-3 py-1.5 text-xs font-black text-cyan-200">⏳ ~{binLabel(data.card.bin)}</span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">{data.card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-200">{data.card.domain}</span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-[#faa307]">⭐ Mastery {data.card.bin}/11</span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">⏳ {binLabel(data.card.bin)}</span>
                 </div>
-                <span className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">{data.card.status}</span>
+                {data.card.is_builtin && <span className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">Built-in demo</span>}
               </div>
 
               <div className="mt-5">
@@ -259,22 +363,19 @@ export default function Study() {
               </div>
 
               <div className="py-10 text-center sm:py-14">
-                <p className="text-xs font-black uppercase tracking-[0.25em] text-violet-300">Your challenge</p>
-                <h2 className="mx-auto mt-4 max-w-3xl text-4xl font-black tracking-tight text-white sm:text-6xl">
+                <p className="text-xs font-black uppercase tracking-[0.25em] text-[#f48c06]">{data.card.kind === "lab" ? "Something broke" : "Your question"}</p>
+                <h2 className="mx-auto mt-4 max-w-3xl text-3xl font-black tracking-tight text-white sm:text-5xl">
                   {data.card.word}
                 </h2>
 
                 {!showDef ? (
-                  <button
-                    className="game-button mt-10 bg-gradient-to-r from-violet-300 to-cyan-300 px-7 py-3.5 text-base text-slate-950 shadow-xl shadow-violet-950/30"
-                    onClick={() => setShowDef(true)}
-                  >
-                    ✨ Reveal answer
+                  <button className="game-button mt-10 bg-gradient-to-r from-[#dc2f02] via-[#f48c06] to-[#ffba08] px-7 py-3.5 text-base text-[#370617] shadow-xl shadow-black/30" onClick={() => setShowDef(true)}>
+                    ✨ Reveal {data.card.kind === "lab" ? "fix path" : "answer"}
                   </button>
                 ) : (
-                  <div className="answer-pop mx-auto mt-9 max-w-2xl rounded-2xl border border-cyan-300/20 bg-cyan-300/[0.07] p-5 text-left sm:p-6">
-                    <p className="text-[11px] font-black uppercase tracking-[0.18em] text-cyan-300">Answer unlocked</p>
-                    <p className="mt-3 text-xl font-semibold leading-8 text-slate-100">{data.card.definition}</p>
+                  <div className="answer-pop mx-auto mt-9 max-w-2xl rounded-2xl border border-[#faa307]/30 bg-[#370617]/55 p-5 text-left sm:p-6">
+                    <p className="text-[11px] font-black uppercase tracking-[0.18em] text-[#ffba08]">{data.card.kind === "lab" ? "Recovery path" : "Answer unlocked"}</p>
+                    <p className="mt-3 text-lg font-semibold leading-8 text-slate-100">{data.card.definition}</p>
                   </div>
                 )}
               </div>
@@ -282,58 +383,37 @@ export default function Study() {
           </article>
 
           <div className="grid gap-3 sm:grid-cols-3">
-            <button
-              className="game-button border border-rose-300/20 bg-rose-400/15 px-5 py-4 text-left text-rose-100 shadow-lg shadow-rose-950/20 hover:bg-rose-400/25"
-              onClick={() => void answer("wrong")}
-              disabled={loading}
-            >
-              <span className="block text-xs font-black uppercase tracking-[0.14em] text-rose-300">1 · Missed it</span>
+            <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/65 px-5 py-4 text-left text-white hover:bg-[#9d0208]/70" onClick={() => void answer("wrong")} disabled={loading}>
+              <span className="block text-xs font-black uppercase tracking-[0.14em] text-[#ffba08]">1 · Missed it</span>
               <span className="mt-1 block text-sm font-semibold">Bring it back sooner</span>
             </button>
-            <button
-              className="game-button border border-emerald-300/20 bg-emerald-400/15 px-5 py-4 text-left text-emerald-50 shadow-lg shadow-emerald-950/20 hover:bg-emerald-400/25"
-              onClick={() => void answer("correct")}
-              disabled={loading}
-            >
-              <span className="block text-xs font-black uppercase tracking-[0.14em] text-emerald-300">2 · Nailed it</span>
+            <button className="game-button border border-[#faa307]/35 bg-[#e85d04]/20 px-5 py-4 text-left text-white hover:bg-[#e85d04]/30" onClick={() => void answer("correct")} disabled={loading}>
+              <span className="block text-xs font-black uppercase tracking-[0.14em] text-[#ffba08]">2 · Got it</span>
               <span className="mt-1 block text-sm font-semibold">Advance mastery + combo</span>
             </button>
-            <button
-              className="game-button border border-white/10 bg-white/[0.05] px-5 py-4 text-left text-slate-200 hover:bg-white/10"
-              onClick={() => void loadNext()}
-              disabled={loading}
-            >
+            <button className="game-button border border-white/10 bg-white/[0.05] px-5 py-4 text-left text-slate-200 hover:bg-white/10" onClick={() => void loadNext()} disabled={loading}>
               <span className="block text-xs font-black uppercase tracking-[0.14em] text-slate-400">Skip</span>
               <span className="mt-1 block text-sm font-semibold">Draw another card</span>
             </button>
           </div>
 
           <div className="game-panel overflow-hidden">
-            <button
-              className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
-              onClick={() => setShowLegend((value) => !value)}
-              aria-expanded={showLegend}
-            >
+            <button className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left" onClick={() => setShowLegend((value) => !value)} aria-expanded={showLegend}>
               <div>
-                <p className="font-black text-white">🗺️ Mastery map</p>
-                <p className="mt-1 text-xs text-slate-400">See how the 12 spaced-repetition levels stretch out review time.</p>
+                <p className="font-black text-white">🗺️ What do mastery levels mean?</p>
+                <p className="mt-1 text-xs text-slate-400">Cards you know well wait longer before they come back.</p>
               </div>
-              <span className="text-sm font-black text-violet-300">{showLegend ? "Close" : "Open"}</span>
+              <span className="text-sm font-black text-[#faa307]">{showLegend ? "Close" : "Show me"}</span>
             </button>
             {showLegend && (
               <div className="grid grid-cols-2 gap-2 border-t border-white/10 p-4 sm:grid-cols-4 lg:grid-cols-6">
                 {Array.from({ length: 12 }, (_, i) => (
-                  <div
-                    key={i}
-                    className={[
-                      "rounded-xl border p-3",
-                      i === data.card.bin
-                        ? "border-violet-300/40 bg-violet-400/15"
-                        : "border-white/10 bg-white/[0.035]",
-                    ].join(" ")}
-                  >
+                  <div key={i} className={[
+                    "rounded-xl border p-3",
+                    i === data.card.bin ? "border-[#faa307]/55 bg-[#e85d04]/15" : "border-white/10 bg-white/[0.035]",
+                  ].join(" ")}>
                     <p className="text-xs font-black text-white">Level {i}</p>
-                    <p className="mt-1 text-xs font-medium text-slate-400">{binLabel(i)}</p>
+                    <p className="mt-1 text-xs text-slate-400">{binLabel(i)}</p>
                   </div>
                 ))}
               </div>

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { verifyEmail } from "../api";
+
+export default function VerifyEmail() {
+  const [params] = useSearchParams();
+  const token = params.get("token") ?? "";
+  const [state, setState] = useState<"loading" | "success" | "error">("loading");
+  const [message, setMessage] = useState("Verifying your email…");
+
+  useEffect(() => {
+    if (!token) {
+      setState("error");
+      setMessage("This verification link is missing its token.");
+      return;
+    }
+    void verifyEmail(token)
+      .then((result) => {
+        setState("success");
+        setMessage(result);
+      })
+      .catch((error: unknown) => {
+        setState("error");
+        setMessage(error instanceof Error ? error.message : "Verification failed");
+      });
+  }, [token]);
+
+  return (
+    <div className="mx-auto max-w-xl py-10">
+      <div className="game-panel p-8 text-center sm:p-10">
+        <div className="text-6xl">{state === "success" ? "✅" : state === "error" ? "⚠️" : "📬"}</div>
+        <p className="metric-label mt-5">Email verification</p>
+        <h1 className="mt-2 text-3xl font-black text-white">
+          {state === "success" ? "You’re verified!" : state === "error" ? "That link didn’t work" : "Checking your link…"}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-slate-300">{message}</p>
+        <div className="mt-6 flex justify-center gap-3">
+          {state === "success" && <Link className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]" to="/login">Sign in + build a deck →</Link>}
+          {state === "error" && <Link className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 font-black text-white" to="/signup">Back to sign up</Link>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,43 +1,62 @@
-/**
- * Shared DTOs that mirror the backend responses.
- * Keep these in sync with FastAPI response models.
- */
+/** Shared DTOs that mirror the FastAPI responses. */
 
-/** ISO8601 date string (e.g., "2025-08-18T12:34:56Z"). */
 export type ISODate = string;
+export type CardKind = "concept" | "lab";
 
-/** Read-only card view returned by API. */
 export interface CardRead {
   id: number;
   word: string;
   definition: string;
+  topic: string;
+  domain: string;
+  kind: CardKind | string;
+  is_builtin: boolean;
   created_at: ISODate;
 }
 
-/** Admin view extends CardRead with study state. */
 export interface CardAdminRead extends CardRead {
   bin: number;
   status: "active" | "never" | "hard_to_remember" | string;
 }
 
-/** Study-next response variants (discriminated by `status`). */
 export type StudyNextOK = {
   status: "ok";
   card: {
     id: number;
     word: string;
     definition: string;
+    topic: string;
+    domain: string;
+    kind: CardKind | string;
+    is_builtin: boolean;
     bin: number;
     status: "active" | "never" | "hard_to_remember" | string;
   };
 };
+
 export type StudyNextTemporary = { status: "temporarily_done" };
 export type StudyNextPermanent = { status: "permanently_done" };
 export type StudyNext = StudyNextOK | StudyNextTemporary | StudyNextPermanent;
 
-/** Payload for creating a new card. */
 export interface CreateCardPayload {
   word: string;
   definition: string;
+  topic?: string;
+  domain?: string;
+  kind?: CardKind;
 }
 
+export interface UpdateCardPayload {
+  word?: string;
+  definition?: string;
+  topic?: string;
+  domain?: string;
+  kind?: CardKind;
+}
+
+export interface StudyTopicSummary {
+  topic: string;
+  total: number;
+  concepts: number;
+  labs: number;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,8 +3,27 @@
 export type ISODate = string;
 export type CardKind = "concept" | "lab";
 
+export interface UserRead {
+  id: number;
+  email: string;
+  display_name: string;
+  is_verified: boolean;
+}
+
+export interface DeckRead {
+  id: number;
+  owner_id: number | null;
+  title: string;
+  slug: string;
+  description: string;
+  is_builtin: boolean;
+  card_count: number;
+  created_at: ISODate;
+}
+
 export interface CardRead {
   id: number;
+  deck_id: number | null;
   word: string;
   definition: string;
   topic: string;
@@ -21,8 +40,14 @@ export interface CardAdminRead extends CardRead {
 
 export type StudyNextOK = {
   status: "ok";
+  deck: {
+    id: number;
+    title: string;
+    is_builtin: boolean;
+  };
   card: {
     id: number;
+    deck_id: number | null;
     word: string;
     definition: string;
     topic: string;
@@ -39,9 +64,9 @@ export type StudyNextPermanent = { status: "permanently_done" };
 export type StudyNext = StudyNextOK | StudyNextTemporary | StudyNextPermanent;
 
 export interface CreateCardPayload {
+  deck_id: number;
   word: string;
   definition: string;
-  topic?: string;
   domain?: string;
   kind?: CardKind;
 }
@@ -49,14 +74,23 @@ export interface CreateCardPayload {
 export interface UpdateCardPayload {
   word?: string;
   definition?: string;
-  topic?: string;
   domain?: string;
   kind?: CardKind;
 }
 
-export interface StudyTopicSummary {
-  topic: string;
-  total: number;
-  concepts: number;
-  labs: number;
+export interface SignupPayload {
+  display_name: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  token_type: "bearer";
+  user: UserRead;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: FlashQuest’s
-site_description: A reusable game-like study engine for concepts, break/fix labs, and spaced repetition.
+site_description: A reusable game-like study engine with a featured Platform Engineering deck, private custom decks, and spaced repetition.
 site_url: https://flashquest-docs.netlify.app/
 repo_name: mergemaven11/FlashQuest
 repo_url: https://github.com/mergemaven11/FlashQuest
@@ -21,15 +21,15 @@ theme:
   palette:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: deep purple
-      accent: cyan
+      primary: black
+      accent: amber
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: deep purple
-      accent: cyan
+      primary: deep orange
+      accent: amber
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
@@ -65,10 +65,13 @@ extra_css:
 nav:
   - Home: index.md
   - Open FlashQuest’s: https://flashcards-tobias.netlify.app/
-  - Study:
+  - Product:
+      - Make Your Own Deck: MAKE_YOUR_OWN_DECK.md
+      - Accounts & Email Verification: AUTHENTICATION.md
+  - Featured Platform Engineering:
       - Curriculum: CURRICULUM.md
       - Break/Fix Labs: LABS.md
-  - Platform Engineering:
+  - Engineering:
       - Architecture & Design: PLATFORM_ENGINEERING.md
       - Operations & Deployment: OPERATIONS.md
   - Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: FlashQuest’s
-site_description: Learn it. Break it. Fix it. Remember it — Platform Engineering study, labs, and operations.
-site_url: https://flashcards-docs.netlify.app/
+site_description: A reusable game-like study engine for concepts, break/fix labs, and spaced repetition.
+site_url: https://flashquest-docs.netlify.app/
 repo_name: mergemaven11/FlashQuest
 repo_url: https://github.com/mergemaven11/FlashQuest
 edit_uri: edit/main/docs/
@@ -64,6 +64,7 @@ extra_css:
 
 nav:
   - Home: index.md
+  - Open FlashQuest’s: https://flashcards-tobias.netlify.app/
   - Study:
       - Curriculum: CURRICULUM.md
       - Break/Fix Labs: LABS.md


### PR DESCRIPTION
## What changed

Turns FlashQuest’s from a Platform-Engineering-only demo into a reusable learning product while keeping Platform Engineering as the featured public starter deck.

### Product
- New landing page centered on the 216-card Platform Engineering demo.
- Public visitors can try the featured deck without an account.
- New **Make Your Own Deck** flow for verified users.
- Private user-owned decks with concept + break/fix lab cards.
- Copy the featured Platform Engineering deck into an account and customize the copy.
- Deck-aware Play screen with kid-simple five-step directions.
- Deck Lab now supports create/edit/delete for owned cards and read-only inspection of built-ins.
- Modern ember/amber visual system using the requested palette.

### Accounts + verification
- Sign up, email verification, resend verification, sign in, sign out, and `/auth/me`.
- Salted PBKDF2-HMAC-SHA256 password hashes.
- High-entropy opaque bearer sessions stored only as hashes in PostgreSQL.
- One-time expiring email-verification tokens stored only as hashes.
- Resend-backed hosted email delivery with console-mode local development.
- Owner-scoped deck/card APIs so users cannot modify another account’s content.

### Demo safety
- Featured Platform Engineering deck is modeled as a built-in Deck.
- Built-in cards are read-only through normal user routes.
- Destructive built-in deletion/reset requires server-side `DEMO_DELETE_PASSWORD`.
- The demo password is never embedded in the React bundle.

### Data + deployment
- New User, Deck, AuthSession, and EmailVerificationToken persistence.
- Card rows now belong to decks while retaining domain + concept/lab metadata.
- Anonymous demo study identity is reserved as user id 0; signed-in users receive their own progress.
- Fly release command runs Alembic migrations before the idempotent featured-deck seed.
- Production frontend API fallback points to the Fly backend.

### Docs
- MkDocs now uses the ember/amber visual language.
- Added Make Your Own Deck guide.
- Added Accounts & Email Verification guide.
- Updated home, operations runbook, README, deployment URLs, and the current docs URL: https://flashquest-docs.netlify.app/

### Production configuration required after merge
The backend must be deployed to Fly so the account/deck migration and seed release command run. Before public signup works in hosted email mode, configure a working `RESEND_API_KEY`, `EMAIL_FROM`, and `DEMO_DELETE_PASSWORD` for the Fly app.

### Validation
This PR should pass backend tests on Python 3.11/3.12, frontend lint/build, clean PostgreSQL Alembic migration, container builds, and strict MkDocs + TypeDoc docs build before it is ready to merge.