### PR TITLE
Fix live FlashQuest URLs and deck selector UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start instantly with a featured **216-card Platform Engineering deck**, then cre
 [![Docs Build](https://github.com/mergemaven11/FlashQuest/actions/workflows/docs-deploy.yml/badge.svg)](https://github.com/mergemaven11/FlashQuest/actions/workflows/docs-deploy.yml)
 [![Docs](https://img.shields.io/badge/docs-live-ffba08)](https://flashquest-docs.netlify.app/)
 
-**App:** https://flashcards-tobias.netlify.app/  
+**App:** https://flaskquest.netlify.app/  
 **Docs:** https://flashquest-docs.netlify.app/
 
 ---
@@ -207,7 +207,8 @@ For local email verification, watch API logs after signup for the verification U
 ### React / Netlify
 
 ```text
-Site: flashcards-tobias
+Site: flaskquest
+URL: https://flaskquest.netlify.app/
 Base directory: frontend
 Build command: npm run build
 Publish directory: dist

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ def _allowed_origins() -> list[str]:
     defaults = {
         "http://localhost:5173",
         "http://127.0.0.1:5173",
-        "https://flashcards-tobias.netlify.app",
+        "https://flaskquest.netlify.app",
     }
     raw = (settings.ALLOWED_ORIGINS or "").strip()
     if not raw:

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -15,7 +15,7 @@ primary_region = 'atl'
 [env]
   PORT = "8080"
   APP_ENV = "production"
-  FRONTEND_URL = "https://flashcards-tobias.netlify.app"
+  FRONTEND_URL = "https://flaskquest.netlify.app"
   EMAIL_DELIVERY_MODE = "resend"
 
 [[vm]]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -137,7 +137,7 @@ Fly is configured for:
 
 ```text
 EMAIL_DELIVERY_MODE=resend
-FRONTEND_URL=https://flashcards-tobias.netlify.app
+FRONTEND_URL=https://flaskquest.netlify.app
 ```
 
 Before enabling public signup, configure the provider secret and demo-owner secret:
@@ -290,7 +290,8 @@ FlashQuest’s has two separate Netlify concerns:
 ### React application
 
 ```text
-Site: flashcards-tobias
+Site: flaskquest
+URL: https://flaskquest.netlify.app/
 Base directory: frontend
 Build command: npm run build
 Publish directory: dist

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 Start instantly with the featured **216-card Platform Engineering deck**. Then create a verified account and build private decks for **anything you want to learn**.
 
-[Open FlashQuest’s →](https://flashcards-tobias.netlify.app/){ .md-button .md-button--primary }
+[Open FlashQuest’s →](https://flaskquest.netlify.app/){ .md-button .md-button--primary }
 [Make your own deck →](MAKE_YOUR_OWN_DECK.md){ .md-button }
 
 </div>

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -58,6 +58,7 @@ export default function Study() {
   const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
   const mastery = data?.status === "ok" ? Math.round((data.card.bin / 11) * 100) : 0;
   const selectedDeck = useMemo(() => decks.find((deck) => deck.id === deckId) ?? null, [decks, deckId]);
+  const hasMultipleDecks = decks.length > 1;
 
   const loadDecks = useCallback(async () => {
     try {
@@ -163,7 +164,24 @@ export default function Study() {
       </section>
 
       <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[.9fr_1.4fr]">
-        <div><label className="metric-label" htmlFor="deck">Choose a deck</label><select id="deck" className="game-input mt-2" value={deckId ?? ""} onChange={(e) => chooseDeck(Number(e.target.value))}>{decks.map((deck) => <option key={deck.id} value={deck.id}>{deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count}</option>)}</select><p className="mt-2 text-xs text-slate-500">⭐ is the public featured deck. Your private decks appear after sign in.</p></div>
+        <div>
+          <p className="metric-label">{hasMultipleDecks ? "Choose a deck" : "Featured deck"}</p>
+          {hasMultipleDecks ? (
+            <select id="deck" aria-label="Choose a deck" className="game-input mt-2" value={deckId ?? ""} onChange={(e) => chooseDeck(Number(e.target.value))}>
+              {decks.map((deck) => <option key={deck.id} value={deck.id}>{deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count}</option>)}
+            </select>
+          ) : selectedDeck ? (
+            <div className="mt-2 rounded-xl border border-[#faa307]/30 bg-[#faa307]/[0.08] px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-black text-white">{selectedDeck.is_builtin ? "⭐ " : ""}{selectedDeck.title}</span>
+                <span className="text-xs font-bold text-[#ffba08]">{selectedDeck.card_count} cards</span>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 rounded-xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-slate-400">Loading deck…</div>
+          )}
+          <p className="mt-2 text-xs text-slate-500">{user ? "Your private decks appear here beside the featured deck." : "This is the public featured deck. Sign in to add and switch between private decks."}</p>
+        </div>
         <div><p className="metric-label">Choose a mode</p><div className="mt-2 grid gap-2 sm:grid-cols-3">{(Object.keys(trackCopy) as StudyTrack[]).map((value) => { const item = trackCopy[value]; const active = track === value; return <button key={value} className={`rounded-xl border p-3 text-left transition ${active ? "border-[#faa307]/70 bg-[#d00000]/20" : "border-white/10 bg-black/15 hover:border-[#f48c06]/40"}`} onClick={() => setTrack(value)}><span className="text-lg">{item.icon}</span><span className="ml-2 font-black text-white">{item.title}</span><span className="mt-1 block text-xs text-slate-400">{item.detail}</span></button>; })}</div></div>
       </section>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ extra_css:
 
 nav:
   - Home: index.md
-  - Open FlashQuest’s: https://flashcards-tobias.netlify.app/
+  - Open FlashQuest’s: https://flaskquest.netlify.app/
   - Product:
       - Make Your Own Deck: MAKE_YOUR_OWN_DECK.md
       - Accounts & Email Verification: AUTHENTICATION.md


### PR DESCRIPTION
## Fixes

- Point docs and README at the live app: `https://flaskquest.netlify.app/`.
- Allow the live Netlify origin in FastAPI CORS defaults.
- Use the live app URL for hosted verification links in Fly config.
- Replace the misleading one-option deck `<select>` with a clear featured-deck card when only one deck is available.
- Keep the real selector when signed-in users have multiple decks.

## Why

After the reusable-decks merge, the app moved to the `flaskquest` Netlify site while docs/backend production config still referenced the old `flashcards-tobias.netlify.app` frontend. Anonymous users also saw a dropdown with only one possible option, making it look broken.

## Validation

CI should validate backend tests/lint, frontend lint/build, migrations, containers, and docs before merge.