### PR TITLE
Trigger Fly production deploy

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,6 +1,7 @@
 # fly.toml app configuration file generated on 2025-08-19T14:38:34-04:00
 #
 # See https://fly.io/docs/reference/configuration/ for information on this file.
+# Production deploys are triggered from GitHub Actions on pushes to main.
 
 app = 'flashcards-tobias'
 primary_region = 'atl'


### PR DESCRIPTION
This makes a no-op documentation comment change in `backend/fly.toml` so merging to `main` emits a normal backend push and triggers the `Fly · Deploy API` workflow. The production config itself already points at the FlaskQuest frontend, runs Alembic + seed, and checks `/health/ready`.