### PR TITLE
Fix study rotation and add hints with TL;DR answers

### DIFF
--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy import and_, asc, desc, func
 from sqlmodel import Session, select
 
@@ -46,12 +47,48 @@ def _next_review_at_from_bin(b: int) -> Optional[datetime]:
     return None if delay is None else _now_utc() + delay
 
 
-def _card_filters(deck_id: int | None, track: str) -> list[Any]:
+def _demo_user_id(demo_session: str | None) -> int:
+    """Map one browser-session token to a stable negative demo user id.
+
+    Real account ids are positive. Negative ids keep anonymous progress isolated
+    per browser session without creating throwaway account rows.
+    """
+    token = (demo_session or "").strip()[:128]
+    if not token:
+        return DEMO_USER_ID
+    digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+    value = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+    return -(value or 1)
+
+
+def _parse_excluded_card_ids(raw: str | None) -> set[int]:
+    if not raw:
+        return set()
+    values: set[int] = set()
+    for item in raw.split(","):
+        try:
+            value = int(item.strip())
+        except ValueError:
+            continue
+        if value > 0:
+            values.add(value)
+        if len(values) >= 250:
+            break
+    return values
+
+
+def _card_filters(
+    deck_id: int | None,
+    track: str,
+    exclude_card_ids: set[int] | None = None,
+) -> list[Any]:
     filters: list[Any] = []
     if deck_id is not None:
         filters.append(Card.deck_id == deck_id)
     if track in {"concept", "lab"}:
         filters.append(Card.kind == track)
+    if exclude_card_ids:
+        filters.append(~cast(Any, Card.id).in_(sorted(exclude_card_ids)))
     return filters
 
 
@@ -60,6 +97,7 @@ def _select_next_card_pair(
     user_id: int = DEMO_USER_ID,
     deck_id: int | None = None,
     track: str = "mixed",
+    exclude_card_ids: set[int] | None = None,
 ) -> Optional[tuple[Card, UserCard]]:
     """Select the next due/new card for one user, deck, and learning mode."""
     nr = cast(Any, UserCard.next_review_at)
@@ -67,7 +105,7 @@ def _select_next_card_pair(
     cid = cast(Any, Card.id)
     created = cast(Any, Card.created_at)
     uc_card_id = cast(Any, UserCard.card_id)
-    card_filters = _card_filters(deck_id, track)
+    card_filters = _card_filters(deck_id, track, exclude_card_ids)
 
     due_conditions: list[Any] = [
         UserCard.user_id == user_id,
@@ -117,7 +155,10 @@ def _default_featured_deck(session: Session) -> Deck | None:
 
 
 def _resolve_deck(
-    session: Session, deck_id: int | None, user: User | None
+    session: Session,
+    deck_id: int | None,
+    user: User | None,
+    demo_session: str | None = None,
 ) -> tuple[Deck, int]:
     deck = session.get(Deck, deck_id) if deck_id is not None else _default_featured_deck(session)
     if deck is None:
@@ -127,7 +168,7 @@ def _resolve_deck(
             raise HTTPException(status_code=401, detail="Sign in to study this deck")
         if deck.owner_id != user.id:
             raise HTTPException(status_code=403, detail="This deck belongs to another account")
-    user_id = int(user.id or 0) if user is not None else DEMO_USER_ID
+    user_id = int(user.id or 0) if user is not None else _demo_user_id(demo_session)
     return deck, user_id
 
 
@@ -159,6 +200,11 @@ def study_next(
         description="Study track: mixed, concept, or lab",
         pattern="^(mixed|concept|lab)$",
     ),
+    exclude_card_ids: str | None = Query(
+        None,
+        description="Comma-separated card ids to avoid when drawing the next card",
+    ),
+    demo_session: str | None = Header(None, alias="X-Demo-Session"),
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
@@ -166,11 +212,23 @@ def study_next(
     if track not in VALID_TRACKS:
         raise HTTPException(status_code=422, detail="invalid study track")
 
-    deck, user_id = _resolve_deck(session, deck_id, user)
+    deck, user_id = _resolve_deck(session, deck_id, user, demo_session)
     resolved_deck_id = int(deck.id or 0)
     _ensure_progress(session, user_id, resolved_deck_id)
 
-    pair = _select_next_card_pair(session, user_id, resolved_deck_id, track)
+    excluded = _parse_excluded_card_ids(exclude_card_ids)
+    pair = _select_next_card_pair(
+        session,
+        user_id,
+        resolved_deck_id,
+        track,
+        exclude_card_ids=excluded,
+    )
+    # If a user skipped every eligible card, start a fresh pass instead of
+    # pretending the deck is finished.
+    if pair is None and excluded:
+        pair = _select_next_card_pair(session, user_id, resolved_deck_id, track)
+
     if pair:
         card, uc = pair
         return {
@@ -211,6 +269,7 @@ def study_next(
 def submit_answer(
     card_id: int = Query(...),
     result: str = Query(..., pattern="^(correct|wrong)$"),
+    demo_session: str | None = Header(None, alias="X-Demo-Session"),
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
@@ -221,7 +280,7 @@ def submit_answer(
     card = session.get(Card, card_id)
     if card is None or card.deck_id is None:
         raise HTTPException(status_code=404, detail="Card not found")
-    _deck, user_id = _resolve_deck(session, card.deck_id, user)
+    _deck, user_id = _resolve_deck(session, card.deck_id, user, demo_session)
     _ensure_progress(session, user_id, card.deck_id)
 
     uc = session.exec(

--- a/backend/tests/test_demo_study_sessions.py
+++ b/backend/tests/test_demo_study_sessions.py
@@ -1,0 +1,109 @@
+"""Regression tests for anonymous demo sessions and card skipping."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.models import Card, Deck
+
+
+def _featured_deck(session: Session) -> Deck:
+    deck = session.exec(select(Deck).where(Deck.slug == "platform-engineering")).first()
+    if deck is None:
+        deck = Deck(
+            owner_id=None,
+            title="Platform Engineering",
+            slug="platform-engineering",
+            description="Test featured deck",
+            is_builtin=True,
+        )
+        session.add(deck)
+        session.commit()
+        session.refresh(deck)
+    return deck
+
+
+def _mk_card(session: Session, word: str) -> Card:
+    deck = _featured_deck(session)
+    card = Card(
+        deck_id=deck.id,
+        word=word,
+        definition=f"Definition for {word}",
+        topic=deck.title,
+        domain="Testing",
+        kind="concept",
+        is_builtin=True,
+    )
+    session.add(card)
+    session.commit()
+    session.refresh(card)
+    return card
+
+
+def test_skip_exclusion_draws_a_different_eligible_card(
+    client: TestClient, sqlite_session: Session
+) -> None:
+    _mk_card(sqlite_session, "alpha")
+    _mk_card(sqlite_session, "bravo")
+    headers = {"X-Demo-Session": "skip-session"}
+
+    first = client.get("/study/next", headers=headers)
+    assert first.status_code == 200
+    first_id = first.json()["card"]["id"]
+
+    second = client.get(
+        "/study/next",
+        params={"exclude_card_ids": str(first_id)},
+        headers=headers,
+    )
+    assert second.status_code == 200
+    assert second.json()["status"] == "ok"
+    assert second.json()["card"]["id"] != first_id
+
+
+def test_skip_falls_back_after_every_eligible_card_is_excluded(
+    client: TestClient, sqlite_session: Session
+) -> None:
+    card = _mk_card(sqlite_session, "only-card")
+    headers = {"X-Demo-Session": "fallback-session"}
+
+    response = client.get(
+        "/study/next",
+        params={"exclude_card_ids": str(card.id)},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["card"]["id"] == card.id
+
+
+def test_anonymous_browser_sessions_have_isolated_progress(
+    client: TestClient, sqlite_session: Session
+) -> None:
+    card = _mk_card(sqlite_session, "session-card")
+    session_a = {"X-Demo-Session": "browser-session-a"}
+    session_b = {"X-Demo-Session": "browser-session-b"}
+
+    first_a = client.get("/study/next", headers=session_a)
+    assert first_a.status_code == 200
+    assert first_a.json()["card"]["bin"] == 0
+
+    answer_a = client.post(
+        "/study/answer",
+        params={"card_id": card.id, "result": "correct"},
+        headers=session_a,
+    )
+    assert answer_a.status_code == 200
+    assert answer_a.json()["to_bin"] == 1
+
+    first_b = client.get("/study/next", headers=session_b)
+    assert first_b.status_code == 200
+    assert first_b.json()["status"] == "ok"
+    assert first_b.json()["card"]["id"] == card.id
+    assert first_b.json()["card"]["bin"] == 0
+
+    next_a = client.get("/study/next", headers=session_a)
+    assert next_a.status_code == 200
+    assert next_a.json()["status"] == "temporarily_done"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,7 @@ import type {
 
 export type StudyTrack = "mixed" | "concept" | "lab";
 const TOKEN_KEY = "flashquest-access-token";
+const DEMO_SESSION_KEY = "flashquest-demo-session";
 
 export const BIN_DELAYS: Record<number, number> = {
   0: 0,
@@ -66,6 +67,18 @@ export function setAccessToken(token: string | null): void {
   else window.localStorage.removeItem(TOKEN_KEY);
 }
 
+function getDemoSessionId(): string | null {
+  if (typeof window === "undefined") return null;
+  let sessionId = window.sessionStorage.getItem(DEMO_SESSION_KEY);
+  if (!sessionId) {
+    sessionId = typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    window.sessionStorage.setItem(DEMO_SESSION_KEY, sessionId);
+  }
+  return sessionId;
+}
+
 export const api = axios.create({
   baseURL: apiBaseURL(),
   timeout: 12_000,
@@ -75,7 +88,12 @@ export const api = axios.create({
 
 api.interceptors.request.use((config) => {
   const token = typeof window !== "undefined" ? getAccessToken() : null;
-  if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  } else {
+    const demoSession = getDemoSessionId();
+    if (demoSession) config.headers["X-Demo-Session"] = demoSession;
+  }
   return config;
 });
 
@@ -215,11 +233,16 @@ export async function deleteDeck(deckId: number): Promise<void> {
 
 export async function getStudyNext(
   track: StudyTrack = "mixed",
-  deckId?: number
+  deckId?: number,
+  excludeCardIds: number[] = []
 ): Promise<StudyNext> {
   try {
     const { data } = await api.get<StudyNext>("/study/next", {
-      params: { track, deck_id: deckId },
+      params: {
+        track,
+        deck_id: deckId,
+        exclude_card_ids: excludeCardIds.length ? excludeCardIds.join(",") : undefined,
+      },
     });
     return data;
   } catch (e) {

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -10,9 +10,15 @@ import {
   type StudyTrack,
 } from "../api";
 import { useAuth } from "../auth";
+import { studyHint, studyTldr } from "../studyText";
 import type { DeckRead, StudyNext } from "../types";
 
-type Feedback = { kind: "correct" | "wrong"; title: string; detail: string; xp: number };
+type Feedback = {
+  kind: "correct" | "wrong";
+  title: string;
+  detail: string;
+  xp: number;
+};
 
 const trackCopy: Record<StudyTrack, { title: string; detail: string; icon: string }> = {
   mixed: { title: "All cards", detail: "Mix concepts and labs", icon: "🎲" },
@@ -34,8 +40,11 @@ export default function Study() {
   const [deckId, setDeckId] = useState<number | null>(requestedDeck);
   const [track, setTrack] = useState<StudyTrack>("mixed");
   const [data, setData] = useState<StudyNext | null>(null);
+  const [showHint, setShowHint] = useState(false);
   const [showAnswer, setShowAnswer] = useState(false);
+  const [showFullAnswer, setShowFullAnswer] = useState(false);
   const [showMastery, setShowMastery] = useState(false);
+  const [skippedCardIds, setSkippedCardIds] = useState<number[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
@@ -57,7 +66,10 @@ export default function Study() {
   const level = Math.floor(xp / 100) + 1;
   const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
   const mastery = data?.status === "ok" ? Math.round((data.card.bin / 11) * 100) : 0;
-  const selectedDeck = useMemo(() => decks.find((deck) => deck.id === deckId) ?? null, [decks, deckId]);
+  const selectedDeck = useMemo(
+    () => decks.find((deck) => deck.id === deckId) ?? null,
+    [decks, deckId]
+  );
   const hasMultipleDecks = decks.length > 1;
 
   const loadDecks = useCallback(async () => {
@@ -76,135 +88,452 @@ export default function Study() {
     }
   }, [user, requestedDeck]);
 
-  const loadNext = useCallback(async (clearFeedback = true) => {
-    if (!deckId) return;
-    setLoading(true);
-    setError(null);
-    if (clearFeedback) setFeedback(null);
-    try {
-      const next = await getStudyNext(track, deckId);
-      setData(next);
-      setShowAnswer(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not load the next card");
-    } finally {
-      setLoading(false);
-    }
-  }, [deckId, track]);
+  const loadNext = useCallback(
+    async (clearFeedback = true, excludeIds: number[] = []) => {
+      if (!deckId) return;
+      setLoading(true);
+      setError(null);
+      if (clearFeedback) setFeedback(null);
+      try {
+        const next = await getStudyNext(track, deckId, excludeIds);
+        setData(next);
+        setShowHint(false);
+        setShowAnswer(false);
+        setShowFullAnswer(false);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Could not load the next card");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [deckId, track]
+  );
 
-  useEffect(() => { void loadDecks(); }, [loadDecks]);
-  useEffect(() => { void loadNext(); }, [loadNext]);
+  useEffect(() => {
+    void loadDecks();
+  }, [loadDecks]);
+
+  useEffect(() => {
+    setSkippedCardIds([]);
+    void loadNext();
+  }, [deckId, track, loadNext]);
 
   function chooseDeck(id: number) {
     setDeckId(id);
     setParams({ deck: String(id) }, { replace: true });
   }
 
-  async function answer(result: "correct" | "wrong") {
-    if (data?.status !== "ok" || loading) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const response = await postStudyAnswer(data.card.id, result);
-      const nextStreak = result === "correct" ? streak + 1 : 0;
-      const reward = result === "correct" ? 10 + response.to_bin * 2 + Math.min(nextStreak, 5) * 3 : 2;
-      setAnswered((value) => value + 1);
-      setXp((value) => value + reward);
-      if (result === "correct") {
-        setCorrect((value) => value + 1);
-        setStreak(nextStreak);
-        setBest((value) => Math.max(value, nextStreak));
-        setFeedback({ kind: "correct", title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice recall!", detail: `Moved to mastery level ${response.to_bin}.`, xp: reward });
-      } else {
-        setStreak(0);
-        setFeedback({ kind: "wrong", title: "💪 Good practice rep", detail: "This card will come back sooner so it can stick.", xp: reward });
+  const answer = useCallback(
+    async (result: "correct" | "wrong") => {
+      if (data?.status !== "ok" || loading) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await postStudyAnswer(data.card.id, result);
+        const nextStreak = result === "correct" ? streak + 1 : 0;
+        const reward =
+          result === "correct"
+            ? 10 + response.to_bin * 2 + Math.min(nextStreak, 5) * 3
+            : 2;
+        setAnswered((value) => value + 1);
+        setXp((value) => value + reward);
+        if (result === "correct") {
+          setCorrect((value) => value + 1);
+          setStreak(nextStreak);
+          setBest((value) => Math.max(value, nextStreak));
+          setFeedback({
+            kind: "correct",
+            title: nextStreak >= 3 ? `🔥 ${nextStreak} hit combo!` : "✨ Nice recall!",
+            detail: `Moved to mastery level ${response.to_bin}.`,
+            xp: reward,
+          });
+        } else {
+          setStreak(0);
+          setFeedback({
+            kind: "wrong",
+            title: "💪 Good practice rep",
+            detail: "This card will come back sooner so it can stick.",
+            xp: reward,
+          });
+        }
+        await loadNext(false, skippedCardIds);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Could not save your answer");
+      } finally {
+        setLoading(false);
       }
-      await loadNext(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not save your answer");
-    } finally {
-      setLoading(false);
-    }
-  }
+    },
+    [data, loading, streak, loadNext, skippedCardIds]
+  );
+
+  const skipCard = useCallback(async () => {
+    if (data?.status !== "ok" || loading) return;
+    const currentId = data.card.id;
+    const nextSkipped = [
+      ...skippedCardIds.filter((cardId) => cardId !== currentId),
+      currentId,
+    ].slice(-60);
+    setSkippedCardIds(nextSkipped);
+    await loadNext(true, nextSkipped);
+  }, [data, loading, skippedCardIds, loadNext]);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.matches("input, textarea, select, [contenteditable='true']")) return;
       if (loading || data?.status !== "ok") return;
-      if (event.key === " ") { event.preventDefault(); setShowAnswer(true); }
+
+      if (event.key.toLowerCase() === "h") setShowHint(true);
+      if (event.key === " ") {
+        event.preventDefault();
+        setShowAnswer(true);
+      }
+      if (event.key.toLowerCase() === "s") void skipCard();
       if (event.key === "1") void answer("wrong");
       if (event.key === "2") void answer("correct");
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [data, loading, streak, loadNext]);
+  }, [data, loading, answer, skipCard]);
 
   return (
     <div className="mx-auto grid max-w-5xl gap-6">
       <section className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
         <div>
           <p className="metric-label">⚔️ Memory Quest</p>
-          <h1 className="mt-2 text-4xl font-black tracking-tight text-white">Train your recall. <span className="ember-text">Level up.</span></h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">Pick a deck, think before you reveal, then tell FlashQuest’s if you remembered it.</p>
+          <h1 className="mt-2 text-4xl font-black tracking-tight text-white">
+            Train your recall. <span className="ember-text">Level up.</span>
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+            Think first, ask for a hint if you want one, reveal the short answer, then dig deeper.
+          </p>
         </div>
-        <div className="game-chip flex gap-3 px-4 py-2 text-xs font-bold text-slate-300"><span>Space · reveal</span><span>1 · missed</span><span>2 · got it</span></div>
+        <div className="game-chip flex flex-wrap gap-3 px-4 py-2 text-xs font-bold text-slate-300">
+          <span>H · hint</span>
+          <span>Space · reveal</span>
+          <span>S · skip</span>
+          <span>1/2 · rate</span>
+        </div>
       </section>
 
       <section className="game-panel p-5 sm:p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="metric-label">How to play</p><h2 className="mt-1 text-xl font-black text-white">Five tiny steps.</h2></div><span className="game-chip px-3 py-1.5 text-xs font-bold text-slate-300">No timer · no pressure</span></div>
-        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          {[
-            ["1", "🎯", "Pick a deck", "Choose what you want to learn."],
-            ["2", "👀", "Read", "Try to answer in your head."],
-            ["3", "✨", "Reveal", "Look at the real answer."],
-            ["4", "✅", "Be honest", "Missed it or got it?"],
-            ["5", "⚡", "Keep going", "FlashQuest brings weak cards back."],
-          ].map(([step, icon, title, detail]) => <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4"><div className="flex justify-between"><span className="text-2xl">{icon}</span><span className="text-xs font-black text-[#f48c06]">STEP {step}</span></div><p className="mt-3 font-black text-white">{title}</p><p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p></div>)}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="metric-label">How to play</p>
+            <h2 className="mt-1 text-xl font-black text-white">Six tiny steps.</h2>
+          </div>
+          <span className="game-chip px-3 py-1.5 text-xs font-bold text-slate-300">
+            No timer · no pressure
+          </span>
         </div>
-        <p className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-4 text-sm text-slate-300"><b className="text-[#ffba08]">🔧 Lab card?</b> Pretend the thing is broken. Say what you would check first, then reveal the recovery path.</p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+          {[
+            ["1", "🎯", "Pick", "Choose what you want to learn."],
+            ["2", "👀", "Think", "Try it in your head first."],
+            ["3", "💡", "Hint", "Ask for a nudge if you need it."],
+            ["4", "✨", "Reveal", "Get the TL;DR, then full answer."],
+            ["5", "✅", "Rate", "Missed it or got it?"],
+            ["6", "⚡", "Continue", "Weak cards come back sooner."],
+          ].map(([step, icon, title, detail]) => (
+            <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+              <div className="flex justify-between">
+                <span className="text-2xl">{icon}</span>
+                <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
+              </div>
+              <p className="mt-3 font-black text-white">{title}</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">{detail}</p>
+            </div>
+          ))}
+        </div>
+        <p className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-4 text-sm text-slate-300">
+          <b className="text-[#ffba08]">🔧 Lab card?</b> Pretend the thing is broken. Say what you would inspect first, then reveal the recovery path.
+        </p>
       </section>
 
       <section className="game-panel grid gap-5 p-5 sm:p-6 lg:grid-cols-[.9fr_1.4fr]">
         <div>
           <p className="metric-label">{hasMultipleDecks ? "Choose a deck" : "Featured deck"}</p>
           {hasMultipleDecks ? (
-            <select id="deck" aria-label="Choose a deck" className="game-input mt-2" value={deckId ?? ""} onChange={(e) => chooseDeck(Number(e.target.value))}>
-              {decks.map((deck) => <option key={deck.id} value={deck.id}>{deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count}</option>)}
+            <select
+              id="deck"
+              aria-label="Choose a deck"
+              className="game-input mt-2"
+              value={deckId ?? ""}
+              onChange={(e) => chooseDeck(Number(e.target.value))}
+            >
+              {decks.map((deck) => (
+                <option key={deck.id} value={deck.id}>
+                  {deck.is_builtin ? "⭐ " : ""}{deck.title} · {deck.card_count}
+                </option>
+              ))}
             </select>
           ) : selectedDeck ? (
             <div className="mt-2 rounded-xl border border-[#faa307]/30 bg-[#faa307]/[0.08] px-4 py-3">
               <div className="flex items-center justify-between gap-3">
-                <span className="font-black text-white">{selectedDeck.is_builtin ? "⭐ " : ""}{selectedDeck.title}</span>
-                <span className="text-xs font-bold text-[#ffba08]">{selectedDeck.card_count} cards</span>
+                <span className="font-black text-white">
+                  {selectedDeck.is_builtin ? "⭐ " : ""}{selectedDeck.title}
+                </span>
+                <span className="text-xs font-bold text-[#ffba08]">
+                  {selectedDeck.card_count} cards
+                </span>
               </div>
             </div>
           ) : (
-            <div className="mt-2 rounded-xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-slate-400">Loading deck…</div>
+            <div className="mt-2 rounded-xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-slate-400">
+              Loading deck…
+            </div>
           )}
-          <p className="mt-2 text-xs text-slate-500">{user ? "Your private decks appear here beside the featured deck." : "This is the public featured deck. Sign in to add and switch between private decks."}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            {user
+              ? "Your private decks appear here beside the featured deck."
+              : "Fresh demo progress starts with every new browser session. Sign in when you want durable progress."}
+          </p>
         </div>
-        <div><p className="metric-label">Choose a mode</p><div className="mt-2 grid gap-2 sm:grid-cols-3">{(Object.keys(trackCopy) as StudyTrack[]).map((value) => { const item = trackCopy[value]; const active = track === value; return <button key={value} className={`rounded-xl border p-3 text-left transition ${active ? "border-[#faa307]/70 bg-[#d00000]/20" : "border-white/10 bg-black/15 hover:border-[#f48c06]/40"}`} onClick={() => setTrack(value)}><span className="text-lg">{item.icon}</span><span className="ml-2 font-black text-white">{item.title}</span><span className="mt-1 block text-xs text-slate-400">{item.detail}</span></button>; })}</div></div>
+        <div>
+          <p className="metric-label">Choose a mode</p>
+          <div className="mt-2 grid gap-2 sm:grid-cols-3">
+            {(Object.keys(trackCopy) as StudyTrack[]).map((value) => {
+              const item = trackCopy[value];
+              const active = track === value;
+              return (
+                <button
+                  key={value}
+                  className={`rounded-xl border p-3 text-left transition ${
+                    active
+                      ? "border-[#faa307]/70 bg-[#d00000]/20"
+                      : "border-white/10 bg-black/15 hover:border-[#f48c06]/40"
+                  }`}
+                  onClick={() => setTrack(value)}
+                >
+                  <span className="text-lg">{item.icon}</span>
+                  <span className="ml-2 font-black text-white">{item.title}</span>
+                  <span className="mt-1 block text-xs text-slate-400">{item.detail}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </section>
 
       <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="game-panel p-4"><p className="metric-label">Player level</p><div className="mt-2 flex items-end justify-between"><strong className="text-3xl font-black text-white">Lv. {level}</strong><span className="text-xs font-bold text-slate-400">{xp % 100}/100 XP</span></div><div className="xp-track mt-3"><div className="xp-fill" style={{ width: `${xp % 100}%` }} /></div></div>
-        <div className="game-panel p-4"><p className="metric-label">Combo</p><strong className="mt-2 block text-3xl font-black text-white">{streak ? `🔥 ${streak}` : "—"}</strong><p className="mt-1 text-xs text-slate-400">Best: {best}</p></div>
-        <div className="game-panel p-4"><p className="metric-label">Accuracy</p><strong className="mt-2 block text-3xl font-black text-white">{answered ? `${accuracy}%` : "—"}</strong><p className="mt-1 text-xs text-slate-400">{correct} correct · {answered} tries</p></div>
-        <div className="game-panel p-4"><p className="metric-label">Session XP</p><strong className="mt-2 block text-3xl font-black text-white">⚡ {xp}</strong><p className="mt-1 text-xs text-slate-400">Game stats stay in this browser session.</p></div>
+        <div className="game-panel p-4">
+          <p className="metric-label">Player level</p>
+          <div className="mt-2 flex items-end justify-between">
+            <strong className="text-3xl font-black text-white">Lv. {level}</strong>
+            <span className="text-xs font-bold text-slate-400">{xp % 100}/100 XP</span>
+          </div>
+          <div className="xp-track mt-3"><div className="xp-fill" style={{ width: `${xp % 100}%` }} /></div>
+        </div>
+        <div className="game-panel p-4">
+          <p className="metric-label">Combo</p>
+          <strong className="mt-2 block text-3xl font-black text-white">{streak ? `🔥 ${streak}` : "—"}</strong>
+          <p className="mt-1 text-xs text-slate-400">Best: {best}</p>
+        </div>
+        <div className="game-panel p-4">
+          <p className="metric-label">Accuracy</p>
+          <strong className="mt-2 block text-3xl font-black text-white">{answered ? `${accuracy}%` : "—"}</strong>
+          <p className="mt-1 text-xs text-slate-400">{correct} correct · {answered} tries</p>
+        </div>
+        <div className="game-panel p-4">
+          <p className="metric-label">Session XP</p>
+          <strong className="mt-2 block text-3xl font-black text-white">⚡ {xp}</strong>
+          <p className="mt-1 text-xs text-slate-400">Skipped this run: {skippedCardIds.length}</p>
+        </div>
       </section>
 
-      {feedback && <div className="reward-pop flex items-center justify-between gap-4 rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 px-5 py-4"><div><p className="font-black text-white">{feedback.title}</p><p className="mt-1 text-sm text-slate-300">{feedback.detail}</p></div><div className="rounded-xl bg-[#ffba08] px-3 py-2 text-sm font-black text-[#370617]">+{feedback.xp} XP</div></div>}
-      {error && <div className="game-panel border-[#d00000]/60 p-5"><h2 className="font-black text-white">🛡️ Quest interrupted</h2><p className="mt-1 text-sm text-slate-300">{error}</p><p className="mt-2 break-all text-xs text-slate-500">API: {apiBaseURL()}</p><button className="game-button mt-4 bg-[#faa307] px-4 py-2 text-sm font-black text-[#370617]" onClick={() => void loadNext()}>Retry encounter</button></div>}
+      {feedback && (
+        <div className="reward-pop flex items-center justify-between gap-4 rounded-2xl border border-[#faa307]/30 bg-[#faa307]/10 px-5 py-4">
+          <div>
+            <p className="font-black text-white">{feedback.title}</p>
+            <p className="mt-1 text-sm text-slate-300">{feedback.detail}</p>
+          </div>
+          <div className="rounded-xl bg-[#ffba08] px-3 py-2 text-sm font-black text-[#370617]">
+            +{feedback.xp} XP
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="game-panel border-[#d00000]/60 p-5">
+          <h2 className="font-black text-white">🛡️ Quest interrupted</h2>
+          <p className="mt-1 text-sm text-slate-300">{error}</p>
+          <p className="mt-2 break-all text-xs text-slate-500">API: {apiBaseURL()}</p>
+          <button
+            className="game-button mt-4 bg-[#faa307] px-4 py-2 text-sm font-black text-[#370617]"
+            onClick={() => void loadNext(true, skippedCardIds)}
+          >
+            Retry encounter
+          </button>
+        </div>
+      )}
 
       {data?.status === "ok" && !error && (
         <>
-          <article className="quest-card p-6 sm:p-10"><div className="relative z-10"><div className="flex flex-wrap items-center justify-between gap-3"><div className="flex flex-wrap gap-2"><span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">{data.card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}</span><span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">{data.card.domain}</span><span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">⭐ Mastery {data.card.bin}/11</span></div><span className="text-xs font-bold text-slate-500">{selectedDeck?.title ?? data.deck.title}</span></div><div className="mt-5 xp-track"><div className="xp-fill" style={{ width: `${mastery}%` }} /></div><div className="py-10 text-center sm:py-14"><p className="metric-label">Your challenge</p><h2 className="mx-auto mt-4 max-w-3xl text-3xl font-black leading-tight text-white sm:text-5xl">{data.card.word}</h2>{!showAnswer ? <button className="game-button mt-9 bg-[#ffba08] px-6 py-3 font-black text-[#370617]" onClick={() => setShowAnswer(true)}>✨ Reveal answer</button> : <div className="answer-pop mx-auto mt-8 max-w-2xl rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-5 text-left"><p className="metric-label">Answer unlocked</p><p className="mt-3 text-lg font-semibold leading-8 text-slate-100">{data.card.definition}</p></div>}</div></div></article>
-          <div className="grid gap-3 sm:grid-cols-3"><button className="game-button border border-[#d00000]/40 bg-[#6a040f]/45 px-5 py-4 text-left text-rose-100" onClick={() => void answer("wrong")} disabled={loading}><b className="block text-sm">1 · Missed it</b><span className="mt-1 block text-xs text-rose-200/70">Bring it back sooner</span></button><button className="game-button border border-[#faa307]/40 bg-[#e85d04]/20 px-5 py-4 text-left text-[#ffba08]" onClick={() => void answer("correct")} disabled={loading}><b className="block text-sm">2 · Got it</b><span className="mt-1 block text-xs text-[#ffba08]/70">Advance mastery + combo</span></button><button className="game-button border border-white/10 bg-white/[0.04] px-5 py-4 text-left text-slate-200" onClick={() => void loadNext()} disabled={loading}><b className="block text-sm">Skip</b><span className="mt-1 block text-xs text-slate-500">Draw another card</span></button></div>
-          <div className="game-panel overflow-hidden"><button className="flex w-full items-center justify-between px-5 py-4 text-left" onClick={() => setShowMastery((value) => !value)}><div><p className="font-black text-white">🗺️ Mastery map</p><p className="mt-1 text-xs text-slate-400">Higher levels wait longer before review.</p></div><span className="text-xs font-black text-[#faa307]">{showMastery ? "Close" : "Open"}</span></button>{showMastery && <div className="grid grid-cols-2 gap-2 border-t border-white/10 p-4 sm:grid-cols-4 lg:grid-cols-6">{Array.from({ length: 12 }, (_, index) => <div key={index} className={`rounded-xl border p-3 ${index === data.card.bin ? "border-[#faa307]/50 bg-[#d00000]/20" : "border-white/10 bg-black/10"}`}><p className="text-xs font-black text-white">Level {index}</p><p className="mt-1 text-xs text-slate-500">{binLabel(index)}</p></div>)}</div>}</div>
+          <article className="quest-card p-6 sm:p-10">
+            <div className="relative z-10">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap gap-2">
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">
+                    {data.card.kind === "lab" ? "🔧 LAB" : "📚 CONCEPT"}
+                  </span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">
+                    {data.card.domain}
+                  </span>
+                  <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">
+                    ⭐ Mastery {data.card.bin}/11
+                  </span>
+                </div>
+                <span className="text-xs font-bold text-slate-500">
+                  {selectedDeck?.title ?? data.deck.title}
+                </span>
+              </div>
+
+              <div className="mt-5 xp-track">
+                <div className="xp-fill" style={{ width: `${mastery}%` }} />
+              </div>
+
+              <div className="py-10 text-center sm:py-14">
+                <p className="metric-label">Your challenge</p>
+                <h2 className="mx-auto mt-4 max-w-3xl text-3xl font-black leading-tight text-white sm:text-5xl">
+                  {data.card.word}
+                </h2>
+
+                {!showAnswer && (
+                  <div className="mt-8 flex flex-wrap justify-center gap-3">
+                    <button
+                      className="game-button border border-violet-400/30 bg-violet-400/10 px-5 py-3 font-black text-violet-100"
+                      onClick={() => setShowHint(true)}
+                    >
+                      💡 {showHint ? "Hint shown" : "Give me a hint"}
+                    </button>
+                    <button
+                      className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+                      onClick={() => setShowAnswer(true)}
+                    >
+                      ✨ Reveal answer
+                    </button>
+                  </div>
+                )}
+
+                {showHint && !showAnswer && (
+                  <div className="mx-auto mt-5 max-w-2xl rounded-2xl border border-violet-400/30 bg-violet-400/[0.08] p-5 text-left">
+                    <p className="text-xs font-black uppercase tracking-[0.18em] text-violet-300">💡 Hint</p>
+                    <p className="mt-3 text-base font-semibold leading-7 text-violet-50">
+                      {studyHint(data.card.word, data.card.domain, data.card.kind)}
+                    </p>
+                  </div>
+                )}
+
+                {showAnswer && (
+                  <div className="mx-auto mt-8 grid max-w-2xl gap-4 text-left">
+                    <div className="answer-pop rounded-2xl border border-cyan-300/30 bg-cyan-300/[0.08] p-5">
+                      <p className="text-xs font-black uppercase tracking-[0.18em] text-cyan-300">⚡ TL;DR</p>
+                      <p className="mt-3 text-lg font-black leading-8 text-cyan-50">
+                        {studyTldr(data.card.definition)}
+                      </p>
+                    </div>
+
+                    <button
+                      className="game-button w-full border border-[#faa307]/30 bg-[#faa307]/[0.07] px-5 py-3 text-left font-black text-[#ffba08]"
+                      onClick={() => setShowFullAnswer((value) => !value)}
+                    >
+                      {showFullAnswer ? "▾ Hide full answer" : "▸ Read full answer"}
+                    </button>
+
+                    {showFullAnswer && (
+                      <div className="answer-pop rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-5">
+                        <p className="metric-label">Full answer</p>
+                        <p className="mt-3 text-lg font-semibold leading-8 text-slate-100">
+                          {data.card.definition}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </article>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <button
+              className="game-button border border-[#d00000]/40 bg-[#6a040f]/45 px-5 py-4 text-left text-rose-100"
+              onClick={() => void answer("wrong")}
+              disabled={loading}
+            >
+              <b className="block text-sm">1 · Missed it</b>
+              <span className="mt-1 block text-xs text-rose-200/70">Bring it back sooner</span>
+            </button>
+            <button
+              className="game-button border border-[#faa307]/40 bg-[#e85d04]/20 px-5 py-4 text-left text-[#ffba08]"
+              onClick={() => void answer("correct")}
+              disabled={loading}
+            >
+              <b className="block text-sm">2 · Got it</b>
+              <span className="mt-1 block text-xs text-[#ffba08]/70">Advance mastery + combo</span>
+            </button>
+            <button
+              className="game-button border border-white/10 bg-white/[0.04] px-5 py-4 text-left text-slate-200"
+              onClick={() => void skipCard()}
+              disabled={loading}
+            >
+              <b className="block text-sm">S · Skip</b>
+              <span className="mt-1 block text-xs text-slate-500">Draw a different eligible card</span>
+            </button>
+          </div>
+
+          <div className="game-panel overflow-hidden">
+            <button
+              className="flex w-full items-center justify-between px-5 py-4 text-left"
+              onClick={() => setShowMastery((value) => !value)}
+            >
+              <div>
+                <p className="font-black text-white">🗺️ Mastery map</p>
+                <p className="mt-1 text-xs text-slate-400">Higher levels wait longer before review.</p>
+              </div>
+              <span className="text-xs font-black text-[#faa307]">{showMastery ? "Close" : "Open"}</span>
+            </button>
+            {showMastery && (
+              <div className="grid grid-cols-2 gap-2 border-t border-white/10 p-4 sm:grid-cols-4 lg:grid-cols-6">
+                {Array.from({ length: 12 }, (_, index) => (
+                  <div
+                    key={index}
+                    className={`rounded-xl border p-3 ${
+                      index === data.card.bin
+                        ? "border-[#faa307]/50 bg-[#d00000]/20"
+                        : "border-white/10 bg-black/10"
+                    }`}
+                  >
+                    <p className="text-xs font-black text-white">Level {index}</p>
+                    <p className="mt-1 text-xs text-slate-500">{binLabel(index)}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </>
       )}
 
-      {data?.status === "temporarily_done" && !error && <div className="game-panel p-9 text-center"><div className="text-5xl">🌙</div><h2 className="mt-4 text-2xl font-black text-white">Checkpoint reached</h2><p className="mt-2 text-sm text-slate-400">Nothing in this mode is due right now.</p><button className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]" onClick={() => void loadNext()}>Check again</button></div>}
-      {data?.status === "permanently_done" && !error && <div className="game-panel p-9 text-center"><div className="text-6xl">🏆</div><h2 className="mt-4 text-2xl font-black text-white">Deck conquered!</h2><p className="mt-2 text-sm text-slate-400">Everything in this mode has reached its terminal state.</p></div>}
+      {data?.status === "temporarily_done" && !error && (
+        <div className="game-panel p-9 text-center">
+          <div className="text-5xl">🌙</div>
+          <h2 className="mt-4 text-2xl font-black text-white">Checkpoint reached</h2>
+          <p className="mt-2 text-sm text-slate-400">Nothing in this mode is due right now.</p>
+          <button
+            className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+            onClick={() => void loadNext(true, skippedCardIds)}
+          >
+            Check again
+          </button>
+        </div>
+      )}
+
+      {data?.status === "permanently_done" && !error && (
+        <div className="game-panel p-9 text-center">
+          <div className="text-6xl">🏆</div>
+          <h2 className="mt-4 text-2xl font-black text-white">Deck conquered!</h2>
+          <p className="mt-2 text-sm text-slate-400">Everything in this mode has reached its terminal state.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/studyText.ts
+++ b/frontend/src/studyText.ts
@@ -1,0 +1,45 @@
+import type { CardKind } from "./types";
+
+/**
+ * Build a compact study summary without needing a second answer payload.
+ * This is intentionally deterministic so the same card renders consistently.
+ */
+export function studyTldr(definition: string, maxWords = 16): string {
+  const clean = definition.replace(/\s+/g, " ").trim();
+  if (!clean) return "No summary available yet.";
+
+  const clause = clean.split(/[;.!?](?:\s|$)/, 1)[0]?.trim() ?? clean;
+  const words = clause.split(" ").filter(Boolean);
+  if (words.length <= maxWords && clause.length >= 32) {
+    return clause.endsWith(".") ? clause : `${clause}.`;
+  }
+
+  const sourceWords = clean.split(" ").filter(Boolean);
+  if (sourceWords.length <= maxWords) return clean;
+  return `${sourceWords.slice(0, maxWords).join(" ")}…`;
+}
+
+/**
+ * Produce a non-spoiler coaching hint from prompt metadata only.
+ * The answer text is deliberately not accepted by this function.
+ */
+export function studyHint(prompt: string, domain: string, kind: CardKind | string): string {
+  const normalized = prompt.toLowerCase();
+
+  if (kind === "lab") {
+    return `Start with evidence in ${domain}: check the observable signal first, then logs, configuration, and dependencies before changing anything.`;
+  }
+  if (normalized.includes("difference between")) {
+    return "Compare the two by purpose, behavior, and trade-offs. What does each one control or guarantee?";
+  }
+  if (normalized.includes("why")) {
+    return "Think about the failure, cost, or trade-off this practice is trying to prevent.";
+  }
+  if (normalized.includes("what does") || normalized.includes("what is")) {
+    return `Think about the job this ${domain} concept performs: what problem does it solve, expose, isolate, or control?`;
+  }
+  if (normalized.includes("how")) {
+    return "Walk through the sequence from the first observable event to the final outcome.";
+  }
+  return `Anchor it to ${domain}: name the problem first, then the mechanism that solves it.`;
+}


### PR DESCRIPTION
## What changed

Finishes the P0 study-experience work before Library/Quest Rooms build on top of it.

### Study loop
- Isolate anonymous demo progress per browser session.
- Keep authenticated spaced-repetition progress durable and unchanged.
- Let the frontend exclude recently skipped cards so Skip draws a different eligible card when possible.
- Fall back to a fresh pass after every eligible card has been skipped.

### Learning UX
- Add optional spoiler-safe hints before reveal.
- Reveal a visually distinct TL;DR first.
- Keep the full answer expandable underneath.
- Add H / Space / S keyboard controls for hint, reveal, and skip.
- Make fresh demo-session behavior visible to anonymous learners.

### Tests
- Cover skip exclusions.
- Cover fallback after all eligible cards are excluded.
- Cover anonymous browser-session progress isolation.

Closes #6
Closes #7
Closes #8

This intentionally does not include Library, Arcade, or Quest Room implementation so those can build on a stable study engine in separate PRs.