### PR TITLE
Add shared app-wide game feel foundation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
-import { BrowserRouter, Navigate, NavLink, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, NavLink, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "./auth";
+import { GameFeelProvider, SoundToggle } from "./gameFeel";
 import Admin from "./pages/Admin";
 import Landing from "./pages/Landing";
 import Login from "./pages/Login";
@@ -13,6 +14,7 @@ const DOCS_URL = "https://flashquest-docs.netlify.app/";
 
 function Shell() {
   const { user, signOut } = useAuth();
+  const location = useLocation();
   const navItems = [
     { to: "/study", icon: "⚡", label: "Play" },
     { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
@@ -42,6 +44,7 @@ function Shell() {
                 </NavLink>
               ))}
             </nav>
+            <SoundToggle />
             <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
             {user ? (
               <div className="flex items-center gap-2">
@@ -55,7 +58,7 @@ function Shell() {
         </div>
       </header>
 
-      <main className="relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+      <main key={location.pathname} className="game-page-enter relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/study" element={<Study />} />
@@ -79,5 +82,13 @@ function Shell() {
 }
 
 export default function App() {
-  return <BrowserRouter><AuthProvider><Shell /></AuthProvider></BrowserRouter>;
+  return (
+    <GameFeelProvider>
+      <BrowserRouter>
+        <AuthProvider>
+          <Shell />
+        </AuthProvider>
+      </BrowserRouter>
+    </GameFeelProvider>
+  );
 }

--- a/frontend/src/gameFeel.tsx
+++ b/frontend/src/gameFeel.tsx
@@ -1,22 +1,5 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-
-export type GameSound =
-  | "tap"
-  | "navigate"
-  | "hint"
-  | "reveal"
-  | "success"
-  | "miss"
-  | "skip"
-  | "save"
-  | "publish"
-  | "combo"
-  | "levelUp"
-  | "achievement"
-  | "roomJoin"
-  | "roundStart"
-  | "roundEnd"
-  | "complete";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { GameFeelContext, useGameFeel, type GameSound } from "./gameFeelContext";
 
 type ToneStep = {
   frequency: number;
@@ -26,15 +9,7 @@ type ToneStep = {
   gain: number;
 };
 
-type GameFeelValue = {
-  soundEnabled: boolean;
-  setSoundEnabled: (enabled: boolean) => void;
-  toggleSound: () => void;
-  play: (sound: GameSound) => void;
-};
-
 const SOUND_KEY = "flashquest-sound-enabled";
-const GameFeelContext = createContext<GameFeelValue | null>(null);
 
 const patterns: Record<GameSound, ToneStep[]> = {
   tap: [{ frequency: 330, offsetMs: 0, durationMs: 45, type: "sine", gain: 0.025 }],
@@ -193,12 +168,6 @@ export function GameFeelProvider({ children }: { children: ReactNode }) {
   );
 
   return <GameFeelContext.Provider value={value}>{children}</GameFeelContext.Provider>;
-}
-
-export function useGameFeel(): GameFeelValue {
-  const value = useContext(GameFeelContext);
-  if (!value) throw new Error("useGameFeel must be used inside GameFeelProvider");
-  return value;
 }
 
 export function SoundToggle() {

--- a/frontend/src/gameFeel.tsx
+++ b/frontend/src/gameFeel.tsx
@@ -1,0 +1,220 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+
+export type GameSound =
+  | "tap"
+  | "navigate"
+  | "hint"
+  | "reveal"
+  | "success"
+  | "miss"
+  | "skip"
+  | "save"
+  | "publish"
+  | "combo"
+  | "levelUp"
+  | "achievement"
+  | "roomJoin"
+  | "roundStart"
+  | "roundEnd"
+  | "complete";
+
+type ToneStep = {
+  frequency: number;
+  offsetMs: number;
+  durationMs: number;
+  type: OscillatorType;
+  gain: number;
+};
+
+type GameFeelValue = {
+  soundEnabled: boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  toggleSound: () => void;
+  play: (sound: GameSound) => void;
+};
+
+const SOUND_KEY = "flashquest-sound-enabled";
+const GameFeelContext = createContext<GameFeelValue | null>(null);
+
+const patterns: Record<GameSound, ToneStep[]> = {
+  tap: [{ frequency: 330, offsetMs: 0, durationMs: 45, type: "sine", gain: 0.025 }],
+  navigate: [{ frequency: 390, offsetMs: 0, durationMs: 55, type: "sine", gain: 0.025 }],
+  hint: [
+    { frequency: 520, offsetMs: 0, durationMs: 70, type: "sine", gain: 0.03 },
+    { frequency: 660, offsetMs: 65, durationMs: 90, type: "sine", gain: 0.025 },
+  ],
+  reveal: [
+    { frequency: 440, offsetMs: 0, durationMs: 55, type: "triangle", gain: 0.03 },
+    { frequency: 620, offsetMs: 45, durationMs: 95, type: "triangle", gain: 0.028 },
+  ],
+  success: [
+    { frequency: 523, offsetMs: 0, durationMs: 70, type: "sine", gain: 0.035 },
+    { frequency: 659, offsetMs: 70, durationMs: 80, type: "sine", gain: 0.035 },
+    { frequency: 784, offsetMs: 145, durationMs: 110, type: "sine", gain: 0.03 },
+  ],
+  miss: [
+    { frequency: 250, offsetMs: 0, durationMs: 75, type: "triangle", gain: 0.03 },
+    { frequency: 205, offsetMs: 65, durationMs: 95, type: "triangle", gain: 0.025 },
+  ],
+  skip: [{ frequency: 300, offsetMs: 0, durationMs: 65, type: "triangle", gain: 0.025 }],
+  save: [
+    { frequency: 440, offsetMs: 0, durationMs: 55, type: "sine", gain: 0.028 },
+    { frequency: 587, offsetMs: 55, durationMs: 85, type: "sine", gain: 0.025 },
+  ],
+  publish: [
+    { frequency: 392, offsetMs: 0, durationMs: 65, type: "sine", gain: 0.03 },
+    { frequency: 523, offsetMs: 60, durationMs: 75, type: "sine", gain: 0.03 },
+    { frequency: 659, offsetMs: 125, durationMs: 110, type: "sine", gain: 0.028 },
+  ],
+  combo: [
+    { frequency: 523, offsetMs: 0, durationMs: 55, type: "square", gain: 0.018 },
+    { frequency: 659, offsetMs: 50, durationMs: 55, type: "square", gain: 0.018 },
+    { frequency: 784, offsetMs: 100, durationMs: 85, type: "square", gain: 0.016 },
+  ],
+  levelUp: [
+    { frequency: 392, offsetMs: 0, durationMs: 65, type: "triangle", gain: 0.03 },
+    { frequency: 523, offsetMs: 60, durationMs: 70, type: "triangle", gain: 0.03 },
+    { frequency: 659, offsetMs: 125, durationMs: 80, type: "triangle", gain: 0.03 },
+    { frequency: 784, offsetMs: 195, durationMs: 140, type: "triangle", gain: 0.027 },
+  ],
+  achievement: [
+    { frequency: 659, offsetMs: 0, durationMs: 70, type: "sine", gain: 0.03 },
+    { frequency: 784, offsetMs: 65, durationMs: 80, type: "sine", gain: 0.03 },
+    { frequency: 988, offsetMs: 135, durationMs: 130, type: "sine", gain: 0.025 },
+  ],
+  roomJoin: [
+    { frequency: 440, offsetMs: 0, durationMs: 60, type: "sine", gain: 0.025 },
+    { frequency: 554, offsetMs: 55, durationMs: 90, type: "sine", gain: 0.023 },
+  ],
+  roundStart: [
+    { frequency: 330, offsetMs: 0, durationMs: 55, type: "square", gain: 0.015 },
+    { frequency: 440, offsetMs: 60, durationMs: 80, type: "square", gain: 0.015 },
+  ],
+  roundEnd: [
+    { frequency: 440, offsetMs: 0, durationMs: 65, type: "triangle", gain: 0.025 },
+    { frequency: 330, offsetMs: 60, durationMs: 90, type: "triangle", gain: 0.022 },
+  ],
+  complete: [
+    { frequency: 523, offsetMs: 0, durationMs: 75, type: "sine", gain: 0.032 },
+    { frequency: 659, offsetMs: 70, durationMs: 80, type: "sine", gain: 0.032 },
+    { frequency: 784, offsetMs: 140, durationMs: 90, type: "sine", gain: 0.03 },
+    { frequency: 1047, offsetMs: 220, durationMs: 180, type: "sine", gain: 0.026 },
+  ],
+};
+
+function inferSound(element: HTMLElement): GameSound {
+  const explicit = element.dataset.gameSound as GameSound | undefined;
+  if (explicit && explicit in patterns) return explicit;
+
+  const text = `${element.getAttribute("aria-label") ?? ""} ${element.textContent ?? ""}`.toLowerCase();
+  if (text.includes("hint")) return "hint";
+  if (text.includes("reveal")) return "reveal";
+  if (text.includes("missed") || text.includes("wrong")) return "miss";
+  if (text.includes("got it") || text.includes("correct")) return "success";
+  if (text.includes("skip")) return "skip";
+  if (text.includes("publish")) return "publish";
+  if (text.includes("copy") || text.includes("save") || text.includes("create deck")) return "save";
+  if (element.tagName === "A") return "navigate";
+  return "tap";
+}
+
+function readInitialSoundPreference(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem(SOUND_KEY) !== "false";
+}
+
+export function GameFeelProvider({ children }: { children: ReactNode }) {
+  const [soundEnabled, setSoundEnabledState] = useState(readInitialSoundPreference);
+  const audioRef = useRef<AudioContext | null>(null);
+
+  const getAudioContext = useCallback((): AudioContext | null => {
+    if (typeof window === "undefined" || !window.AudioContext) return null;
+    if (!audioRef.current) audioRef.current = new window.AudioContext();
+    return audioRef.current;
+  }, []);
+
+  const play = useCallback(
+    (sound: GameSound) => {
+      if (!soundEnabled) return;
+      const context = getAudioContext();
+      if (!context) return;
+
+      if (context.state === "suspended") void context.resume();
+      const base = context.currentTime + 0.005;
+      for (const step of patterns[sound]) {
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        const start = base + step.offsetMs / 1000;
+        const end = start + step.durationMs / 1000;
+
+        oscillator.type = step.type;
+        oscillator.frequency.setValueAtTime(step.frequency, start);
+        gain.gain.setValueAtTime(0.0001, start);
+        gain.gain.exponentialRampToValueAtTime(step.gain, start + 0.012);
+        gain.gain.exponentialRampToValueAtTime(0.0001, end);
+        oscillator.connect(gain);
+        gain.connect(context.destination);
+        oscillator.start(start);
+        oscillator.stop(end + 0.01);
+      }
+    },
+    [getAudioContext, soundEnabled]
+  );
+
+  const setSoundEnabled = useCallback((enabled: boolean) => {
+    setSoundEnabledState(enabled);
+    if (typeof window !== "undefined") window.localStorage.setItem(SOUND_KEY, String(enabled));
+  }, []);
+
+  const toggleSound = useCallback(() => {
+    setSoundEnabledState((current) => {
+      const next = !current;
+      if (typeof window !== "undefined") window.localStorage.setItem(SOUND_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Element | null;
+      const interactive = target?.closest<HTMLElement>("[data-game-sound], button, a");
+      if (!interactive || interactive.getAttribute("aria-disabled") === "true") return;
+      if (interactive instanceof HTMLButtonElement && interactive.disabled) return;
+      play(inferSound(interactive));
+    };
+
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [play]);
+
+  const value = useMemo(
+    () => ({ soundEnabled, setSoundEnabled, toggleSound, play }),
+    [soundEnabled, setSoundEnabled, toggleSound, play]
+  );
+
+  return <GameFeelContext.Provider value={value}>{children}</GameFeelContext.Provider>;
+}
+
+export function useGameFeel(): GameFeelValue {
+  const value = useContext(GameFeelContext);
+  if (!value) throw new Error("useGameFeel must be used inside GameFeelProvider");
+  return value;
+}
+
+export function SoundToggle() {
+  const { soundEnabled, toggleSound } = useGameFeel();
+  return (
+    <button
+      type="button"
+      className="game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black text-slate-200"
+      aria-label={soundEnabled ? "Mute game sounds" : "Turn on game sounds"}
+      aria-pressed={soundEnabled}
+      title={soundEnabled ? "Mute FlashQuest sounds" : "Turn on FlashQuest sounds"}
+      data-game-sound="tap"
+      onClick={toggleSound}
+    >
+      <span aria-hidden="true">{soundEnabled ? "🔊" : "🔇"}</span>
+      <span className="hidden xl:inline">{soundEnabled ? "Sound on" : "Sound off"}</span>
+    </button>
+  );
+}

--- a/frontend/src/gameFeelContext.ts
+++ b/frontend/src/gameFeelContext.ts
@@ -1,0 +1,34 @@
+import { createContext, useContext } from "react";
+
+export type GameSound =
+  | "tap"
+  | "navigate"
+  | "hint"
+  | "reveal"
+  | "success"
+  | "miss"
+  | "skip"
+  | "save"
+  | "publish"
+  | "combo"
+  | "levelUp"
+  | "achievement"
+  | "roomJoin"
+  | "roundStart"
+  | "roundEnd"
+  | "complete";
+
+export type GameFeelValue = {
+  soundEnabled: boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  toggleSound: () => void;
+  play: (sound: GameSound) => void;
+};
+
+export const GameFeelContext = createContext<GameFeelValue | null>(null);
+
+export function useGameFeel(): GameFeelValue {
+  const value = useContext(GameFeelContext);
+  if (!value) throw new Error("useGameFeel must be used inside GameFeelProvider");
+  return value;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,6 +11,9 @@
   --deep-saffron: #f48c06;
   --orange: #faa307;
   --amber-flame: #ffba08;
+  --motion-fast: 140ms;
+  --motion-medium: 240ms;
+  --motion-reward: 420ms;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #f8fafc;
   background: var(--ink-black);
@@ -27,6 +30,11 @@ button:disabled { cursor: not-allowed; opacity: .55; }
 a { color: inherit; text-decoration: none; }
 table { border-collapse: collapse; }
 ::selection { background: rgba(255, 186, 8, .33); color: white; }
+
+:where(a, button, input, textarea, select):focus-visible {
+  outline: 2px solid rgba(255, 186, 8, .9);
+  outline-offset: 3px;
+}
 
 .game-shell {
   position: relative;
@@ -50,6 +58,10 @@ table { border-collapse: collapse; }
   mask-image: linear-gradient(to bottom, black, transparent 78%);
 }
 
+.game-page-enter {
+  animation: game-page-enter var(--motion-medium) cubic-bezier(.2, .8, .2, 1) both;
+}
+
 .game-panel {
   border: 1px solid rgba(255, 255, 255, .085);
   border-radius: 1.45rem;
@@ -58,6 +70,7 @@ table { border-collapse: collapse; }
     rgba(3, 7, 30, .72);
   box-shadow: 0 24px 70px rgba(0, 0, 0, .34), inset 0 1px 0 rgba(255, 255, 255, .04);
   backdrop-filter: blur(18px);
+  transition: border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
 .quest-card {
@@ -118,7 +131,8 @@ table { border-collapse: collapse; }
 .game-button {
   border-radius: .95rem;
   font-weight: 900;
-  transition: transform .16s ease, filter .16s ease, box-shadow .16s ease;
+  transition: transform var(--motion-fast) ease, filter var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  touch-action: manipulation;
 }
 .game-button:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.06); }
 .game-button:active:not(:disabled) { transform: translateY(0) scale(.985); }
@@ -132,7 +146,7 @@ table { border-collapse: collapse; }
   color: #f8fafc;
   padding: .72rem .85rem;
   outline: none;
-  transition: border-color .16s ease, box-shadow .16s ease, background .16s ease;
+  transition: border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, background var(--motion-fast) ease;
 }
 .game-input::placeholder,
 .deck-input::placeholder { color: #64748b; }
@@ -155,7 +169,12 @@ select.game-input option { background: var(--ink-black); color: white; }
 .answer-pop { animation: answer-pop .36s cubic-bezier(.2, .9, .3, 1); }
 .wrong-shake { animation: wrong-shake .35s ease; }
 .floaty { animation: floaty 4s ease-in-out infinite; }
-.reward-pop { animation: reward-pop .42s cubic-bezier(.2, .9, .3, 1); }
+.reward-pop { animation: reward-pop var(--motion-reward) cubic-bezier(.2, .9, .3, 1); }
+
+@keyframes game-page-enter {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 @keyframes answer-pop {
   0% { transform: scale(.98); opacity: .72; }
@@ -179,6 +198,11 @@ select.game-input option { background: var(--ink-black); color: white; }
   0% { transform: translateY(8px) scale(.9); opacity: 0; }
   70% { transform: translateY(-2px) scale(1.04); opacity: 1; }
   100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+@media (max-width: 480px) {
+  .game-button { min-height: 2.5rem; }
+  .game-page-enter { transform-origin: top center; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What changed

Lays the reusable sound/motion foundation for issue #25 without mixing visual polish into Library schema work.

### Shared sound system
- Adds one `GameFeelProvider` and semantic sound vocabulary for tap, navigation, hint, reveal, success, miss, skip, save/publish, combo, level-up, achievements, room events, rounds, and completion.
- Uses the browser Web Audio API to synthesize tiny feedback tones instead of shipping audio assets or a sound library.
- Initializes only after interaction; there is no autoplay sound on page load.
- Adds a global Sound on/off control with a persisted preference.
- Existing buttons/links get lightweight feedback through one centralized delegated listener, while future features can opt into explicit `data-game-sound` semantics.

### Shared motion system
- Adds reusable motion timing tokens and a fast route-entry transition across the app shell.
- Keeps existing answer/reward animations and centralizes motion timing.
- Favors transform/opacity and short transitions so interactions remain responsive.
- Preserves the global `prefers-reduced-motion` override.
- Adds clearer focus-visible treatment and touch-friendly button behavior.

### Performance posture
- No new npm dependencies.
- No blocking sound or animation assets.
- No sound required to understand app state.
- No animation blocks navigation or interaction.
- Keeps the 320px mobile floor and avoids adding width-constrained effects.

## Why this is separate
This establishes the app-level primitive that Study, Deck Lab, account flows, the upcoming Library, Arcade, and Quest Rooms can all reuse. Issue #25 should remain open until those later surfaces consume the shared primitives broadly.

Part of #25
Related to #22 and #21.