### PR TITLE
Add Library deck metadata foundation

### DIFF
--- a/backend/alembic/versions/d9b0e3f4a5c6_add_library_deck_metadata.py
+++ b/backend/alembic/versions/d9b0e3f4a5c6_add_library_deck_metadata.py
@@ -1,0 +1,95 @@
+"""add library deck metadata
+
+Revision ID: d9b0e3f4a5c6
+Revises: c8a9d2e3f4b5
+Create Date: 2026-08-18
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d9b0e3f4a5c6"
+down_revision: Union[str, Sequence[str], None] = "c8a9d2e3f4b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add Library metadata while keeping existing custom decks private."""
+    op.add_column(
+        "deck",
+        sa.Column("subject", sa.String(), nullable=False, server_default="General"),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("difficulty", sa.String(), nullable=False, server_default="beginner"),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("visibility", sa.String(), nullable=False, server_default="private"),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("tags", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("source_deck_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "deck",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "fk_deck_source_deck_id",
+        "deck",
+        "deck",
+        ["source_deck_id"],
+        ["id"],
+    )
+
+    # Existing rows keep their original creation time as the first update timestamp.
+    op.execute(sa.text("UPDATE deck SET updated_at = created_at WHERE updated_at IS NULL"))
+
+    # Built-in decks are the protected Official catalog. Existing user decks stay private.
+    op.execute(
+        sa.text(
+            "UPDATE deck "
+            "SET visibility = 'public', subject = 'Technology', "
+            "difficulty = 'intermediate', published_at = created_at "
+            "WHERE is_builtin = true"
+        )
+    )
+
+    op.alter_column("deck", "updated_at", nullable=False)
+
+    op.create_index(op.f("ix_deck_subject"), "deck", ["subject"], unique=False)
+    op.create_index(op.f("ix_deck_difficulty"), "deck", ["difficulty"], unique=False)
+    op.create_index(op.f("ix_deck_visibility"), "deck", ["visibility"], unique=False)
+    op.create_index(op.f("ix_deck_published_at"), "deck", ["published_at"], unique=False)
+    op.create_index(op.f("ix_deck_source_deck_id"), "deck", ["source_deck_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Remove Library metadata from decks."""
+    op.drop_index(op.f("ix_deck_source_deck_id"), table_name="deck")
+    op.drop_index(op.f("ix_deck_published_at"), table_name="deck")
+    op.drop_index(op.f("ix_deck_visibility"), table_name="deck")
+    op.drop_index(op.f("ix_deck_difficulty"), table_name="deck")
+    op.drop_index(op.f("ix_deck_subject"), table_name="deck")
+
+    op.drop_constraint("fk_deck_source_deck_id", "deck", type_="foreignkey")
+    op.drop_column("deck", "updated_at")
+    op.drop_column("deck", "source_deck_id")
+    op.drop_column("deck", "published_at")
+    op.drop_column("deck", "tags")
+    op.drop_column("deck", "visibility")
+    op.drop_column("deck", "difficulty")
+    op.drop_column("deck", "subject")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-"""Database and API models for FlashQuest’s reusable study engine."""
+"""Database and API models for FlashQuest's reusable study engine."""
 
 from __future__ import annotations
 
@@ -76,23 +76,39 @@ class DeckBase(SQLModel):
 class DeckCreate(DeckBase):
     """Payload for a verified user to create a custom deck."""
 
+    subject: str = "General"
+    difficulty: str = "beginner"
+    tags: list[str] = Field(default_factory=list)
+
 
 class DeckUpdate(SQLModel):
     title: Optional[str] = None
     description: Optional[str] = None
+    subject: Optional[str] = None
+    difficulty: Optional[str] = None
+    tags: Optional[list[str]] = None
 
 
 class DeckRead(DeckBase):
     id: int
     slug: str
     is_builtin: bool
+    is_official: bool = False
     owner_id: Optional[int]
+    creator_display_name: Optional[str] = None
+    subject: str
+    difficulty: str
+    visibility: str
+    tags: list[str]
+    published_at: Optional[datetime] = None
+    source_deck_id: Optional[int] = None
     card_count: int = 0
     created_at: datetime
+    updated_at: datetime
 
 
 class Deck(SQLModel, table=True):
-    """A topic pack. Built-ins are public; custom decks belong to one user."""
+    """A topic pack that can stay private or become a Library deck."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     owner_id: Optional[int] = Field(
@@ -102,7 +118,21 @@ class Deck(SQLModel, table=True):
     slug: str = Field(index=True, sa_type=sa.String)
     description: str = Field(default="", sa_type=sa.String)
     is_builtin: bool = Field(default=False, index=True, sa_type=sa.Boolean)
+    subject: str = Field(default="General", index=True, sa_type=sa.String)
+    difficulty: str = Field(default="beginner", index=True, sa_type=sa.String)
+    visibility: str = Field(default="private", index=True, sa_type=sa.String)
+    tags: list[str] = Field(
+        default_factory=list,
+        sa_column=sa.Column(sa.JSON, nullable=False),
+    )
+    published_at: Optional[datetime] = Field(
+        default=None, index=True, sa_type=sa.DateTime(timezone=True)
+    )
+    source_deck_id: Optional[int] = Field(
+        default=None, foreign_key="deck.id", index=True, sa_type=sa.Integer
+    )
     created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    updated_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
 
 
 class CardBase(SQLModel):

--- a/backend/app/routers/decks.py
+++ b/backend/app/routers/decks.py
@@ -10,10 +10,21 @@ from sqlalchemy import func
 from sqlmodel import Session, delete, select
 
 from ..db import get_session
-from ..models import Card, Deck, DeckCreate, DeckRead, DeckUpdate, Review, User, UserCard
+from ..models import (
+    Card,
+    Deck,
+    DeckCreate,
+    DeckRead,
+    DeckUpdate,
+    Review,
+    User,
+    UserCard,
+    utc_now,
+)
 from ..security import get_current_user, require_verified_user
 
 router = APIRouter(prefix="/decks", tags=["decks"])
+VALID_DIFFICULTIES = {"beginner", "intermediate", "advanced", "expert"}
 
 
 def _slugify(value: str) -> str:
@@ -31,6 +42,41 @@ def _unique_slug(session: Session, title: str, owner_id: int) -> str:
     return candidate
 
 
+def _clean_subject(value: str) -> str:
+    subject = " ".join(value.strip().split())
+    if not subject:
+        raise HTTPException(status_code=422, detail="Subject cannot be empty")
+    if len(subject) > 80:
+        raise HTTPException(status_code=422, detail="Subject is too long")
+    return subject
+
+
+def _clean_difficulty(value: str) -> str:
+    difficulty = value.strip().lower()
+    if difficulty not in VALID_DIFFICULTIES:
+        raise HTTPException(
+            status_code=422,
+            detail="Difficulty must be beginner, intermediate, advanced, or expert",
+        )
+    return difficulty
+
+
+def _normalize_tags(values: list[str]) -> list[str]:
+    tags: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        tag = " ".join(raw.strip().lower().split())
+        if not tag or tag in seen:
+            continue
+        if len(tag) > 40:
+            raise HTTPException(status_code=422, detail="Tags must be 40 characters or fewer")
+        tags.append(tag)
+        seen.add(tag)
+        if len(tags) > 12:
+            raise HTTPException(status_code=422, detail="A deck can have at most 12 tags")
+    return tags
+
+
 def _card_count(session: Session, deck_id: int) -> int:
     count = session.exec(
         select(func.count()).select_from(Card).where(Card.deck_id == deck_id)
@@ -39,15 +85,29 @@ def _card_count(session: Session, deck_id: int) -> int:
 
 
 def _read(session: Session, deck: Deck) -> DeckRead:
+    creator_display_name = None
+    if deck.owner_id is not None:
+        creator = session.get(User, deck.owner_id)
+        creator_display_name = creator.display_name if creator is not None else None
+
     return DeckRead(
         id=int(deck.id or 0),
         owner_id=deck.owner_id,
+        creator_display_name=creator_display_name,
         title=deck.title,
         slug=deck.slug,
         description=deck.description,
         is_builtin=deck.is_builtin,
+        is_official=deck.is_builtin,
+        subject=deck.subject,
+        difficulty=deck.difficulty,
+        visibility=deck.visibility,
+        tags=list(deck.tags or []),
+        published_at=deck.published_at,
+        source_deck_id=deck.source_deck_id,
         card_count=_card_count(session, int(deck.id or 0)),
         created_at=deck.created_at,
+        updated_at=deck.updated_at,
     )
 
 
@@ -62,7 +122,7 @@ def _owned_deck(session: Session, deck_id: int, user_id: int) -> Deck:
 
 @router.get("/featured", response_model=list[DeckRead])
 def featured_decks(session: Session = Depends(get_session)) -> list[DeckRead]:
-    """Return public starter/demo decks. Platform Engineering is the first one."""
+    """Return public Official starter/demo decks."""
     decks = session.exec(
         select(Deck).where(Deck.is_builtin == True).order_by(Deck.id)  # noqa: E712
     ).all()
@@ -86,7 +146,7 @@ def create_deck(
     user: User = Depends(require_verified_user),
     session: Session = Depends(get_session),
 ) -> DeckRead:
-    """Create an empty reusable study deck for a verified user."""
+    """Create an empty private reusable study deck for a verified user."""
     title = payload.title.strip()
     if len(title) < 2:
         raise HTTPException(status_code=422, detail="Deck title is too short")
@@ -96,6 +156,10 @@ def create_deck(
         slug=_unique_slug(session, title, int(user.id or 0)),
         description=payload.description.strip(),
         is_builtin=False,
+        subject=_clean_subject(payload.subject),
+        difficulty=_clean_difficulty(payload.difficulty),
+        visibility="private",
+        tags=_normalize_tags(payload.tags),
     )
     session.add(deck)
     session.commit()
@@ -110,7 +174,7 @@ def update_deck(
     user: User = Depends(require_verified_user),
     session: Session = Depends(get_session),
 ) -> DeckRead:
-    """Rename or describe an owned deck."""
+    """Update editable metadata for an owned deck without changing visibility."""
     deck = _owned_deck(session, deck_id, int(user.id or 0))
     if payload.title is not None:
         title = payload.title.strip()
@@ -119,6 +183,13 @@ def update_deck(
         deck.title = title
     if payload.description is not None:
         deck.description = payload.description.strip()
+    if payload.subject is not None:
+        deck.subject = _clean_subject(payload.subject)
+    if payload.difficulty is not None:
+        deck.difficulty = _clean_difficulty(payload.difficulty)
+    if payload.tags is not None:
+        deck.tags = _normalize_tags(payload.tags)
+    deck.updated_at = utc_now()
     session.add(deck)
     session.commit()
     session.refresh(deck)
@@ -131,7 +202,7 @@ def copy_featured_deck(
     user: User = Depends(require_verified_user),
     session: Session = Depends(get_session),
 ) -> DeckRead:
-    """Copy a featured deck so a user can customize it safely."""
+    """Copy an Official deck into a private user-owned remix."""
     source = session.get(Deck, deck_id)
     if source is None or not source.is_builtin:
         raise HTTPException(status_code=404, detail="Featured deck not found")
@@ -143,6 +214,11 @@ def copy_featured_deck(
         slug=_unique_slug(session, title, int(user.id or 0)),
         description=source.description,
         is_builtin=False,
+        subject=source.subject,
+        difficulty=source.difficulty,
+        visibility="private",
+        tags=list(source.tags or []),
+        source_deck_id=source.id,
     )
     session.add(target)
     session.flush()

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -1,4 +1,4 @@
-"""Spaced-repetition study routes for featured and user-owned decks."""
+"""Spaced-repetition study routes for Official, shared, and user-owned decks."""
 
 from __future__ import annotations
 
@@ -160,14 +160,18 @@ def _resolve_deck(
     user: User | None,
     demo_session: str | None = None,
 ) -> tuple[Deck, int]:
+    """Resolve a deck and enforce its Library visibility at the study boundary."""
     deck = session.get(Deck, deck_id) if deck_id is not None else _default_featured_deck(session)
     if deck is None:
         raise HTTPException(status_code=404, detail="Deck not found")
-    if not deck.is_builtin:
+
+    shareable = deck.is_builtin or deck.visibility in {"public", "unlisted"}
+    owner = user is not None and deck.owner_id == user.id
+    if not shareable and not owner:
         if user is None:
-            raise HTTPException(status_code=401, detail="Sign in to study this deck")
-        if deck.owner_id != user.id:
-            raise HTTPException(status_code=403, detail="This deck belongs to another account")
+            raise HTTPException(status_code=401, detail="Sign in to study this private deck")
+        raise HTTPException(status_code=403, detail="This deck is private")
+
     user_id = int(user.id or 0) if user is not None else _demo_user_id(demo_session)
     return deck, user_id
 
@@ -194,7 +198,7 @@ def _ensure_progress(session: Session, user_id: int, deck_id: int) -> None:
 
 @router.get("/next")
 def study_next(
-    deck_id: int | None = Query(None, description="Featured or owned deck id"),
+    deck_id: int | None = Query(None, description="Official, shared, or owned deck id"),
     track: str = Query(
         "mixed",
         description="Study track: mixed, concept, or lab",
@@ -208,7 +212,7 @@ def study_next(
     user: User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
 ) -> dict[str, Any]:
-    """Return the next due/new card for a featured or owned deck."""
+    """Return the next due/new card for an accessible deck."""
     if track not in VALID_TRACKS:
         raise HTTPException(status_code=422, detail="invalid study track")
 

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -17,13 +17,16 @@ from typing import Any
 from sqlmodel import Session, select
 
 from .db import engine
-from .models import Card, Deck, UserCard
+from .models import Card, Deck, UserCard, utc_now
 
 DATA_DIR = Path(__file__).parent / "data"
 CONCEPT_DECK_PATH = DATA_DIR / "platform_engineering_cards.json"
 LAB_DECK_PATH = DATA_DIR / "platform_engineering_labs.json"
 PLATFORM_TOPIC = "Platform Engineering"
 PLATFORM_SLUG = "platform-engineering"
+PLATFORM_SUBJECT = "Technology"
+PLATFORM_DIFFICULTY = "intermediate"
+PLATFORM_TAGS = ["platform engineering", "devops", "cloud", "sre"]
 DEMO_USER_ID = 0
 
 
@@ -95,7 +98,7 @@ if len({prompt for prompt, _ in PLATFORM_ENGINEERING_DECK}) != len(
 
 
 def _featured_deck(session: Session) -> Deck:
-    """Create or repair the public featured Platform Engineering deck."""
+    """Create or repair the public Official Platform Engineering deck."""
     deck = session.exec(select(Deck).where(Deck.slug == PLATFORM_SLUG)).first()
     description = (
         "216 Platform Engineering challenges: 144 concepts and 72 hands-on "
@@ -108,16 +111,39 @@ def _featured_deck(session: Session) -> Deck:
             slug=PLATFORM_SLUG,
             description=description,
             is_builtin=True,
+            subject=PLATFORM_SUBJECT,
+            difficulty=PLATFORM_DIFFICULTY,
+            visibility="public",
+            tags=list(PLATFORM_TAGS),
         )
         session.add(deck)
         session.flush()
-    else:
-        deck.owner_id = None
-        deck.title = PLATFORM_TOPIC
-        deck.description = description
-        deck.is_builtin = True
+        deck.published_at = deck.created_at
         session.add(deck)
         session.flush()
+    else:
+        desired = {
+            "owner_id": None,
+            "title": PLATFORM_TOPIC,
+            "description": description,
+            "is_builtin": True,
+            "subject": PLATFORM_SUBJECT,
+            "difficulty": PLATFORM_DIFFICULTY,
+            "visibility": "public",
+            "tags": list(PLATFORM_TAGS),
+        }
+        changed = False
+        for field, value in desired.items():
+            if getattr(deck, field) != value:
+                setattr(deck, field, value)
+                changed = True
+        if deck.published_at is None:
+            deck.published_at = deck.created_at
+            changed = True
+        if changed:
+            deck.updated_at = utc_now()
+            session.add(deck)
+            session.flush()
     return deck
 
 
@@ -196,7 +222,7 @@ def run() -> None:
         result = seed_platform_deck(session)
 
     print(
-        "FlashQuest’s featured Platform Engineering deck ready: "
+        "FlashQuest featured Platform Engineering deck ready: "
         f"{result['deck_size']} cards "
         f"({result['concept_cards']} concepts + {result['lab_cards']} labs; "
         f"{result['inserted_cards']} inserted, "

--- a/backend/tests/test_library_foundation.py
+++ b/backend/tests/test_library_foundation.py
@@ -1,0 +1,124 @@
+"""Library metadata and deck-visibility foundation tests."""
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.security import create_auth_session, hash_password
+
+
+def _verified_headers(session: Session, email: str = "creator@example.com") -> dict[str, str]:
+    user = User(
+        email=email,
+        display_name="Deck Creator",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_created_deck_is_private_and_normalizes_library_metadata(client, sqlite_session: Session):
+    headers = _verified_headers(sqlite_session)
+
+    response = client.post(
+        "/decks",
+        headers=headers,
+        json={
+            "title": "Accounting Basics",
+            "description": "A starter accounting deck",
+            "subject": "  Accounting   ",
+            "difficulty": "BEGINNER",
+            "tags": [" CPA ", "accounting", "CPA", "  fundamentals  "],
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["visibility"] == "private"
+    assert payload["subject"] == "Accounting"
+    assert payload["difficulty"] == "beginner"
+    assert payload["tags"] == ["cpa", "accounting", "fundamentals"]
+    assert payload["is_builtin"] is False
+    assert payload["is_official"] is False
+    assert payload["creator_display_name"] == "Deck Creator"
+    assert payload["published_at"] is None
+    assert payload["source_deck_id"] is None
+
+
+def test_invalid_difficulty_is_rejected(client, sqlite_session: Session):
+    headers = _verified_headers(sqlite_session)
+    response = client.post(
+        "/decks",
+        headers=headers,
+        json={"title": "Odd Deck", "difficulty": "legendary"},
+    )
+    assert response.status_code == 422
+
+
+def test_featured_deck_is_exposed_as_official(client, sqlite_session: Session):
+    deck = Deck(
+        owner_id=None,
+        title="Linux Fundamentals",
+        slug="linux-fundamentals",
+        description="Official test deck",
+        is_builtin=True,
+        subject="Technology",
+        difficulty="beginner",
+        visibility="public",
+        tags=["linux"],
+    )
+    sqlite_session.add(deck)
+    sqlite_session.commit()
+    sqlite_session.refresh(deck)
+
+    response = client.get("/decks/featured")
+    assert response.status_code == 200
+    payload = response.json()[0]
+    assert payload["id"] == deck.id
+    assert payload["is_official"] is True
+    assert payload["visibility"] == "public"
+    assert payload["creator_display_name"] is None
+
+
+def test_copy_of_official_deck_stays_private_and_tracks_source(client, sqlite_session: Session):
+    source = Deck(
+        owner_id=None,
+        title="Docker Fundamentals",
+        slug="docker-fundamentals",
+        description="Official Docker deck",
+        is_builtin=True,
+        subject="Technology",
+        difficulty="beginner",
+        visibility="public",
+        tags=["docker", "containers"],
+    )
+    sqlite_session.add(source)
+    sqlite_session.commit()
+    sqlite_session.refresh(source)
+    sqlite_session.add(
+        Card(
+            deck_id=source.id,
+            word="What is an image?",
+            definition="An immutable filesystem template used to create containers.",
+            topic=source.title,
+            domain="Docker",
+            kind="concept",
+            is_builtin=True,
+        )
+    )
+    sqlite_session.commit()
+
+    headers = _verified_headers(sqlite_session, "remixer@example.com")
+    response = client.post(f"/decks/{source.id}/copy", headers=headers)
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["visibility"] == "private"
+    assert payload["source_deck_id"] == source.id
+    assert payload["subject"] == "Technology"
+    assert payload["difficulty"] == "beginner"
+    assert payload["tags"] == ["docker", "containers"]
+    assert payload["is_official"] is False

--- a/backend/tests/test_library_foundation.py
+++ b/backend/tests/test_library_foundation.py
@@ -20,6 +20,46 @@ def _verified_headers(session: Session, email: str = "creator@example.com") -> d
     return {"Authorization": f"Bearer {token}"}
 
 
+def _community_deck_with_card(session: Session, visibility: str) -> Deck:
+    owner = User(
+        email=f"{visibility}-owner@example.com",
+        display_name=f"{visibility.title()} Creator",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(owner)
+    session.commit()
+    session.refresh(owner)
+
+    deck = Deck(
+        owner_id=owner.id,
+        title=f"{visibility.title()} Community Deck",
+        slug=f"{visibility}-community-deck",
+        description="Visibility boundary test",
+        is_builtin=False,
+        subject="Testing",
+        difficulty="beginner",
+        visibility=visibility,
+        tags=["visibility"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    session.add(
+        Card(
+            deck_id=deck.id,
+            word=f"{visibility} prompt",
+            definition=f"{visibility} answer",
+            topic=deck.title,
+            domain="Testing",
+            kind="concept",
+            is_builtin=False,
+        )
+    )
+    session.commit()
+    return deck
+
+
 def test_created_deck_is_private_and_normalizes_library_metadata(client, sqlite_session: Session):
     headers = _verified_headers(sqlite_session)
 
@@ -122,3 +162,31 @@ def test_copy_of_official_deck_stays_private_and_tracks_source(client, sqlite_se
     assert payload["difficulty"] == "beginner"
     assert payload["tags"] == ["docker", "containers"]
     assert payload["is_official"] is False
+
+
+def test_anonymous_user_can_study_public_community_deck(client, sqlite_session: Session):
+    deck = _community_deck_with_card(sqlite_session, "public")
+    response = client.get(
+        "/study/next",
+        params={"deck_id": deck.id},
+        headers={"X-Demo-Session": "public-browser-session"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_anonymous_user_can_study_unlisted_deck_by_direct_id(client, sqlite_session: Session):
+    deck = _community_deck_with_card(sqlite_session, "unlisted")
+    response = client.get(
+        "/study/next",
+        params={"deck_id": deck.id},
+        headers={"X-Demo-Session": "unlisted-browser-session"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_anonymous_user_cannot_study_private_community_deck(client, sqlite_session: Session):
+    deck = _community_deck_with_card(sqlite_session, "private")
+    response = client.get("/study/next", params={"deck_id": deck.id})
+    assert response.status_code == 401

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,8 @@
 
 export type ISODate = string;
 export type CardKind = "concept" | "lab";
+export type DeckDifficulty = "beginner" | "intermediate" | "advanced" | "expert";
+export type DeckVisibility = "private" | "unlisted" | "public";
 
 export interface UserRead {
   id: number;
@@ -13,12 +15,21 @@ export interface UserRead {
 export interface DeckRead {
   id: number;
   owner_id: number | null;
+  creator_display_name: string | null;
   title: string;
   slug: string;
   description: string;
   is_builtin: boolean;
+  is_official: boolean;
+  subject: string;
+  difficulty: DeckDifficulty | string;
+  visibility: DeckVisibility | string;
+  tags: string[];
+  published_at: ISODate | null;
+  source_deck_id: number | null;
   card_count: number;
   created_at: ISODate;
+  updated_at: ISODate;
 }
 
 export interface CardRead {


### PR DESCRIPTION
## What changed

Completes issue #9 by turning the existing `Deck` model into a Library-ready entity without creating a parallel deck system.

### Schema
- Adds subject, difficulty, visibility, tags, published_at, source_deck_id, and updated_at.
- Adds indexed discovery fields through a new Alembic migration.
- Keeps existing user decks private by default.
- Backfills built-in decks as public/Official.
- Reuses `is_builtin` as the source of truth for Official FlashQuest decks instead of adding a redundant flag.

### API + study access
- Deck reads now expose derived `is_official`, creator display name, Library metadata, and remix/source attribution.
- Deck creation accepts subject/difficulty/tags while still forcing new decks private.
- Deck metadata updates normalize subject/difficulty/tags but do not publish implicitly.
- Copies of Official decks stay private and retain `source_deck_id` plus source metadata.
- Public and unlisted decks are studyable by direct id, including anonymous browser sessions.
- Private decks remain owner-only at the study boundary.
- Frontend `DeckRead` types mirror the new contract.

### Seed
- Platform Engineering is repaired/sealed as an Official public Technology deck with difficulty/tags and a publish timestamp.

### Tests
- Covers private defaults, metadata normalization, invalid difficulty, Official read behavior, source attribution, and public/unlisted/private study visibility boundaries.

## Scope boundary
Public discovery/search belongs in #10; explicit publish/unpublish remains #12.

Closes #9