### PR TITLE
Add searchable public Library discovery API

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -107,6 +107,15 @@ class DeckRead(DeckBase):
     updated_at: datetime
 
 
+class DeckPage(SQLModel):
+    """Stable paginated response for public Library discovery."""
+
+    items: list[DeckRead]
+    total: int
+    page: int
+    page_size: int
+
+
 class Deck(SQLModel, table=True):
     """A topic pack that can stay private or become a Library deck."""
 

--- a/backend/app/routers/decks.py
+++ b/backend/app/routers/decks.py
@@ -1,11 +1,12 @@
-"""Public featured decks and verified-user deck management."""
+"""Public Library discovery and verified-user deck management."""
 
 from __future__ import annotations
 
 import re
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+import sqlalchemy as sa
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
 from sqlmodel import Session, delete, select
 
@@ -14,6 +15,7 @@ from ..models import (
     Card,
     Deck,
     DeckCreate,
+    DeckPage,
     DeckRead,
     DeckUpdate,
     Review,
@@ -25,6 +27,9 @@ from ..security import get_current_user, require_verified_user
 
 router = APIRouter(prefix="/decks", tags=["decks"])
 VALID_DIFFICULTIES = {"beginner", "intermediate", "advanced", "expert"}
+VALID_LIBRARY_SOURCES = {"all", "official", "community"}
+VALID_LIBRARY_SORTS = {"featured", "newest", "updated", "title"}
+VALID_LIBRARY_KINDS = {"concept", "lab"}
 
 
 def _slugify(value: str) -> str:
@@ -118,6 +123,125 @@ def _owned_deck(session: Session, deck_id: int, user_id: int) -> Deck:
     if deck.owner_id != user_id or deck.is_builtin:
         raise HTTPException(status_code=403, detail="You can only change your own decks")
     return deck
+
+
+def _library_filters(
+    q: str | None,
+    subject: str | None,
+    difficulty: str | None,
+    source: str,
+    kind: str | None,
+) -> list[Any]:
+    filters: list[Any] = [Deck.visibility == "public"]
+
+    if q:
+        term = " ".join(q.strip().split())
+        if term:
+            pattern = f"%{term}%"
+            filters.append(
+                sa.or_(
+                    cast(Any, Deck.title).ilike(pattern),
+                    cast(Any, Deck.description).ilike(pattern),
+                    cast(Any, Deck.subject).ilike(pattern),
+                    sa.cast(Deck.tags, sa.String).ilike(pattern),
+                )
+            )
+
+    if subject:
+        normalized_subject = " ".join(subject.strip().split()).lower()
+        if normalized_subject:
+            filters.append(func.lower(Deck.subject) == normalized_subject)
+
+    if difficulty:
+        filters.append(Deck.difficulty == _clean_difficulty(difficulty))
+
+    normalized_source = source.strip().lower()
+    if normalized_source not in VALID_LIBRARY_SOURCES:
+        raise HTTPException(
+            status_code=422,
+            detail="Source must be all, official, or community",
+        )
+    if normalized_source == "official":
+        filters.append(Deck.is_builtin == True)  # noqa: E712
+    elif normalized_source == "community":
+        filters.append(Deck.is_builtin == False)  # noqa: E712
+
+    if kind:
+        normalized_kind = kind.strip().lower()
+        if normalized_kind not in VALID_LIBRARY_KINDS:
+            raise HTTPException(status_code=422, detail="Kind must be concept or lab")
+        matching_deck_ids = select(Card.deck_id).where(Card.kind == normalized_kind)
+        filters.append(cast(Any, Deck.id).in_(matching_deck_ids))
+
+    return filters
+
+
+def _library_order(sort: str) -> list[Any]:
+    normalized_sort = sort.strip().lower()
+    if normalized_sort not in VALID_LIBRARY_SORTS:
+        raise HTTPException(
+            status_code=422,
+            detail="Sort must be featured, newest, updated, or title",
+        )
+
+    if normalized_sort == "title":
+        return [func.lower(Deck.title).asc(), cast(Any, Deck.id).asc()]
+    if normalized_sort == "newest":
+        return [
+            func.coalesce(Deck.published_at, Deck.created_at).desc(),
+            cast(Any, Deck.id).desc(),
+        ]
+    if normalized_sort == "updated":
+        return [cast(Any, Deck.updated_at).desc(), cast(Any, Deck.id).desc()]
+    return [
+        cast(Any, Deck.is_builtin).desc(),
+        func.coalesce(Deck.published_at, Deck.created_at).desc(),
+        cast(Any, Deck.id).asc(),
+    ]
+
+
+@router.get("/library", response_model=DeckPage)
+def library_decks(
+    q: str | None = Query(None, max_length=120),
+    subject: str | None = Query(None, max_length=80),
+    difficulty: str | None = Query(None),
+    source: str = Query("all"),
+    kind: str | None = Query(None),
+    sort: str = Query("featured"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(12, ge=1, le=50),
+    session: Session = Depends(get_session),
+) -> DeckPage:
+    """Return public Library decks with search, filters, and stable pagination."""
+    filters = _library_filters(q, subject, difficulty, source, kind)
+    total = session.exec(
+        select(func.count()).select_from(Deck).where(*filters)
+    ).one()
+    decks = session.exec(
+        select(Deck)
+        .where(*filters)
+        .order_by(*_library_order(sort))
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    ).all()
+    return DeckPage(
+        items=[_read(session, deck) for deck in decks],
+        total=int(total or 0),
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/shared/{slug}", response_model=DeckRead)
+def shared_deck(slug: str, session: Session = Depends(get_session)) -> DeckRead:
+    """Return a public or unlisted deck by direct shareable slug."""
+    deck = session.exec(select(Deck).where(Deck.slug == slug)).first()
+    if deck is None or (
+        not deck.is_builtin and deck.visibility not in {"public", "unlisted"}
+    ):
+        # Hide private deck existence from unauthenticated/share-link callers.
+        raise HTTPException(status_code=404, detail="Deck not found")
+    return _read(session, deck)
 
 
 @router.get("/featured", response_model=list[DeckRead])

--- a/backend/tests/test_library_discovery.py
+++ b/backend/tests/test_library_discovery.py
@@ -1,0 +1,254 @@
+"""Public Library search, filtering, pagination, and share-link tests."""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.security import hash_password
+
+
+def _community_user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"creator-{suffix}@example.com",
+        display_name=f"Creator {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _deck(
+    session: Session,
+    *,
+    slug: str,
+    title: str,
+    visibility: str = "public",
+    subject: str = "Technology",
+    difficulty: str = "beginner",
+    is_builtin: bool = False,
+    tags: list[str] | None = None,
+    kind: str = "concept",
+    published_offset_minutes: int = 0,
+) -> Deck:
+    owner = None if is_builtin else _community_user(session, slug)
+    published = datetime.now(timezone.utc) + timedelta(minutes=published_offset_minutes)
+    deck = Deck(
+        owner_id=None if owner is None else owner.id,
+        title=title,
+        slug=slug,
+        description=f"Description for {title}",
+        is_builtin=is_builtin,
+        subject=subject,
+        difficulty=difficulty,
+        visibility=visibility,
+        tags=tags or [],
+        published_at=published if visibility == "public" else None,
+        updated_at=published,
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    session.add(
+        Card(
+            deck_id=deck.id,
+            word=f"{title} prompt",
+            definition=f"{title} answer",
+            topic=title,
+            domain=subject,
+            kind=kind,
+            is_builtin=is_builtin,
+        )
+    )
+    session.commit()
+    return deck
+
+
+def test_library_lists_only_public_decks(client, sqlite_session: Session):
+    official = _deck(
+        sqlite_session,
+        slug="official-linux",
+        title="Linux Fundamentals",
+        is_builtin=True,
+        tags=["linux"],
+    )
+    community = _deck(
+        sqlite_session,
+        slug="community-accounting",
+        title="Accounting Basics",
+        subject="Accounting",
+        tags=["ledger"],
+    )
+    _deck(
+        sqlite_session,
+        slug="unlisted-study-pack",
+        title="Unlisted Study Pack",
+        visibility="unlisted",
+    )
+    _deck(
+        sqlite_session,
+        slug="private-study-pack",
+        title="Private Study Pack",
+        visibility="private",
+    )
+
+    response = client.get("/decks/library")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert {item["id"] for item in payload["items"]} == {official.id, community.id}
+    assert payload["items"][0]["is_official"] is True
+
+
+def test_library_search_matches_title_subject_description_and_tags(client, sqlite_session: Session):
+    docker = _deck(
+        sqlite_session,
+        slug="docker-foundations",
+        title="Container Foundations",
+        subject="Technology",
+        tags=["docker", "containers"],
+    )
+    _deck(
+        sqlite_session,
+        slug="accounting-foundations",
+        title="Accounting Foundations",
+        subject="Accounting",
+        tags=["ledger"],
+    )
+
+    by_tag = client.get("/decks/library", params={"q": "docker"}).json()
+    assert by_tag["total"] == 1
+    assert by_tag["items"][0]["id"] == docker.id
+
+    by_subject = client.get("/decks/library", params={"q": "technology"}).json()
+    assert by_subject["total"] == 1
+    assert by_subject["items"][0]["id"] == docker.id
+
+    by_description = client.get("/decks/library", params={"q": "Container Foundations"}).json()
+    assert by_description["total"] == 1
+    assert by_description["items"][0]["id"] == docker.id
+
+
+def test_library_filters_source_subject_difficulty_and_kind(client, sqlite_session: Session):
+    official = _deck(
+        sqlite_session,
+        slug="official-platform",
+        title="Platform Engineering",
+        is_builtin=True,
+        subject="Technology",
+        difficulty="intermediate",
+        kind="lab",
+    )
+    community = _deck(
+        sqlite_session,
+        slug="community-linux",
+        title="Linux for Beginners",
+        subject="Technology",
+        difficulty="beginner",
+        kind="concept",
+    )
+    _deck(
+        sqlite_session,
+        slug="community-math",
+        title="Algebra Basics",
+        subject="Mathematics",
+        difficulty="beginner",
+        kind="concept",
+    )
+
+    official_result = client.get("/decks/library", params={"source": "official"}).json()
+    assert [item["id"] for item in official_result["items"]] == [official.id]
+
+    community_result = client.get("/decks/library", params={"source": "community"}).json()
+    assert community.id in {item["id"] for item in community_result["items"]}
+    assert all(item["is_official"] is False for item in community_result["items"])
+
+    filtered = client.get(
+        "/decks/library",
+        params={
+            "subject": "technology",
+            "difficulty": "beginner",
+            "kind": "concept",
+            "source": "community",
+        },
+    ).json()
+    assert filtered["total"] == 1
+    assert filtered["items"][0]["id"] == community.id
+
+
+def test_library_pagination_and_sort_are_stable(client, sqlite_session: Session):
+    newest = _deck(
+        sqlite_session,
+        slug="newest-community",
+        title="Zulu Newest",
+        published_offset_minutes=3,
+    )
+    _deck(
+        sqlite_session,
+        slug="middle-community",
+        title="Mike Middle",
+        published_offset_minutes=2,
+    )
+    oldest = _deck(
+        sqlite_session,
+        slug="oldest-community",
+        title="Alpha Oldest",
+        published_offset_minutes=1,
+    )
+
+    first = client.get(
+        "/decks/library",
+        params={"sort": "newest", "page": 1, "page_size": 2},
+    ).json()
+    second = client.get(
+        "/decks/library",
+        params={"sort": "newest", "page": 2, "page_size": 2},
+    ).json()
+
+    assert first["total"] == 3
+    assert first["page"] == 1 and first["page_size"] == 2
+    assert first["items"][0]["id"] == newest.id
+    assert len(first["items"]) == 2
+    assert [item["id"] for item in second["items"]] == [oldest.id]
+
+
+def test_shared_detail_allows_public_and_unlisted_but_hides_private(client, sqlite_session: Session):
+    public = _deck(
+        sqlite_session,
+        slug="public-share",
+        title="Public Share",
+        visibility="public",
+    )
+    unlisted = _deck(
+        sqlite_session,
+        slug="unlisted-share",
+        title="Unlisted Share",
+        visibility="unlisted",
+    )
+    _deck(
+        sqlite_session,
+        slug="private-share",
+        title="Private Share",
+        visibility="private",
+    )
+
+    public_response = client.get(f"/decks/shared/{public.slug}")
+    assert public_response.status_code == 200
+    assert public_response.json()["id"] == public.id
+
+    unlisted_response = client.get(f"/decks/shared/{unlisted.slug}")
+    assert unlisted_response.status_code == 200
+    assert unlisted_response.json()["id"] == unlisted.id
+
+    private_response = client.get("/decks/shared/private-share")
+    assert private_response.status_code == 404
+
+
+def test_library_rejects_invalid_filter_values(client):
+    assert client.get("/decks/library", params={"source": "mystery"}).status_code == 422
+    assert client.get("/decks/library", params={"difficulty": "legendary"}).status_code == 422
+    assert client.get("/decks/library", params={"kind": "video"}).status_code == 422
+    assert client.get("/decks/library", params={"sort": "popular-ish"}).status_code == 422

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,7 +4,9 @@ import type {
   CardAdminRead,
   CardRead,
   CreateCardPayload,
+  DeckPage,
   DeckRead,
+  LibraryDeckFilters,
   LoginPayload,
   LoginResponse,
   SignupPayload,
@@ -190,6 +192,35 @@ export async function logout(): Promise<void> {
 export async function getFeaturedDecks(): Promise<DeckRead[]> {
   try {
     const { data } = await api.get<DeckRead[]>("/decks/featured");
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function getLibraryDecks(filters: LibraryDeckFilters = {}): Promise<DeckPage> {
+  try {
+    const { data } = await api.get<DeckPage>("/decks/library", {
+      params: {
+        q: filters.q || undefined,
+        subject: filters.subject || undefined,
+        difficulty: filters.difficulty || undefined,
+        source: filters.source || undefined,
+        kind: filters.kind || undefined,
+        sort: filters.sort || undefined,
+        page: filters.page,
+        page_size: filters.page_size,
+      },
+    });
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function getSharedDeck(slug: string): Promise<DeckRead> {
+  try {
+    const { data } = await api.get<DeckRead>(`/decks/shared/${encodeURIComponent(slug)}`);
     return data;
   } catch (e) {
     throw normalizeError(e);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,8 @@ export type ISODate = string;
 export type CardKind = "concept" | "lab";
 export type DeckDifficulty = "beginner" | "intermediate" | "advanced" | "expert";
 export type DeckVisibility = "private" | "unlisted" | "public";
+export type LibrarySource = "all" | "official" | "community";
+export type LibrarySort = "featured" | "newest" | "updated" | "title";
 
 export interface UserRead {
   id: number;
@@ -30,6 +32,24 @@ export interface DeckRead {
   card_count: number;
   created_at: ISODate;
   updated_at: ISODate;
+}
+
+export interface DeckPage {
+  items: DeckRead[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface LibraryDeckFilters {
+  q?: string;
+  subject?: string;
+  difficulty?: DeckDifficulty;
+  source?: LibrarySource;
+  kind?: CardKind;
+  sort?: LibrarySort;
+  page?: number;
+  page_size?: number;
 }
 
 export interface CardRead {


### PR DESCRIPTION
## What changed

Completes the public discovery API foundation for issue #10.

### Public Library discovery
- Adds `GET /decks/library` with a stable paginated `DeckPage` response.
- Searches title, description, subject, and JSON tags.
- Filters by subject, difficulty, Official/community source, and card kind.
- Supports stable `featured`, `newest`, `updated`, and `title` sorting.
- Pagination defaults to 12 and is capped at 50.
- Only `public` decks appear in discovery. Private and unlisted decks are excluded server-side.

### Shareable deck detail
- Adds `GET /decks/shared/{slug}` for direct links.
- Public and unlisted decks can be fetched by direct slug.
- Private decks return 404 so their existence is not leaked.

### Frontend contract
- Adds Library filter/sort/page types.
- Adds `getLibraryDecks()` and `getSharedDeck()` API helpers for the upcoming Library UI.

### Tests
- Public-only discovery boundaries.
- Search across tags/title/subject/description.
- Source/subject/difficulty/kind filters.
- Stable pagination/sorting.
- Public/unlisted share links and private 404 behavior.
- Invalid filter validation.

Closes #10