### PR TITLE
Add creator publishing and community remix controls

### DIFF
--- a/backend/app/routers/decks.py
+++ b/backend/app/routers/decks.py
@@ -30,6 +30,7 @@ VALID_DIFFICULTIES = {"beginner", "intermediate", "advanced", "expert"}
 VALID_LIBRARY_SOURCES = {"all", "official", "community"}
 VALID_LIBRARY_SORTS = {"featured", "newest", "updated", "title"}
 VALID_LIBRARY_KINDS = {"concept", "lab"}
+VALID_PUBLISH_VISIBILITIES = {"public", "unlisted"}
 
 
 def _slugify(value: str) -> str:
@@ -320,18 +321,68 @@ def update_deck(
     return _read(session, deck)
 
 
-@router.post("/{deck_id}/copy", response_model=DeckRead, status_code=201)
-def copy_featured_deck(
+@router.post("/{deck_id}/publish", response_model=DeckRead)
+def publish_deck(
+    deck_id: int,
+    visibility: str = Query("public", pattern="^(public|unlisted)$"),
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> DeckRead:
+    """Explicitly publish an owned deck publicly or by unlisted share link."""
+    deck = _owned_deck(session, deck_id, int(user.id or 0))
+    normalized_visibility = visibility.strip().lower()
+    if normalized_visibility not in VALID_PUBLISH_VISIBILITIES:
+        raise HTTPException(status_code=422, detail="Visibility must be public or unlisted")
+    if _card_count(session, deck_id) < 1:
+        raise HTTPException(status_code=422, detail="Add at least one card before publishing")
+
+    now = utc_now()
+    deck.visibility = normalized_visibility
+    if deck.published_at is None:
+        deck.published_at = now
+    deck.updated_at = now
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return _read(session, deck)
+
+
+@router.post("/{deck_id}/unpublish", response_model=DeckRead)
+def unpublish_deck(
     deck_id: int,
     user: User = Depends(require_verified_user),
     session: Session = Depends(get_session),
 ) -> DeckRead:
-    """Copy an Official deck into a private user-owned remix."""
-    source = session.get(Deck, deck_id)
-    if source is None or not source.is_builtin:
-        raise HTTPException(status_code=404, detail="Featured deck not found")
+    """Remove an owned deck from all public/share-link access."""
+    deck = _owned_deck(session, deck_id, int(user.id or 0))
+    deck.visibility = "private"
+    deck.updated_at = utc_now()
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return _read(session, deck)
 
-    title = f"{source.title} — My Copy"
+
+@router.post("/{deck_id}/copy", response_model=DeckRead, status_code=201)
+def copy_deck(
+    deck_id: int,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> DeckRead:
+    """Copy an accessible deck into a private user-owned remix."""
+    source = session.get(Deck, deck_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    source_is_accessible = (
+        source.is_builtin
+        or source.visibility in {"public", "unlisted"}
+        or source.owner_id == user.id
+    )
+    if not source_is_accessible:
+        # Do not reveal private decks belonging to another creator.
+        raise HTTPException(status_code=404, detail="Deck not found")
+
+    title = f"{source.title} — Remix"
     target = Deck(
         owner_id=user.id,
         title=title,

--- a/backend/tests/test_library_publishing.py
+++ b/backend/tests/test_library_publishing.py
@@ -1,0 +1,168 @@
+"""Creator publishing, unpublishing, and remix behavior."""
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"{suffix}@example.com",
+        display_name=f"Creator {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _owned_deck(session: Session, owner: User, slug: str, *, with_card: bool = True) -> Deck:
+    deck = Deck(
+        owner_id=owner.id,
+        title=f"Deck {slug}",
+        slug=slug,
+        description="Creator publishing test deck",
+        is_builtin=False,
+        subject="Technology",
+        difficulty="beginner",
+        visibility="private",
+        tags=["creator", "test"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    if with_card:
+        session.add(
+            Card(
+                deck_id=deck.id,
+                word=f"{slug} prompt",
+                definition=f"{slug} answer",
+                topic=deck.title,
+                domain="Testing",
+                kind="concept",
+                is_builtin=False,
+            )
+        )
+        session.commit()
+    return deck
+
+
+def test_owner_can_publish_public_deck_into_library(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "public-owner")
+    deck = _owned_deck(sqlite_session, owner, "public-owned-deck")
+
+    response = client.post(
+        f"/decks/{deck.id}/publish",
+        headers=_headers(sqlite_session, owner),
+        params={"visibility": "public"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["visibility"] == "public"
+    assert payload["published_at"] is not None
+
+    library = client.get("/decks/library", params={"q": "public-owned-deck"}).json()
+    assert library["total"] == 1
+    assert library["items"][0]["id"] == deck.id
+
+
+def test_owner_can_publish_unlisted_without_entering_discovery(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "unlisted-owner")
+    deck = _owned_deck(sqlite_session, owner, "unlisted-owned-deck")
+
+    response = client.post(
+        f"/decks/{deck.id}/publish",
+        headers=_headers(sqlite_session, owner),
+        params={"visibility": "unlisted"},
+    )
+    assert response.status_code == 200
+    assert response.json()["visibility"] == "unlisted"
+
+    assert client.get("/decks/library", params={"q": deck.slug}).json()["total"] == 0
+    shared = client.get(f"/decks/shared/{deck.slug}")
+    assert shared.status_code == 200
+    assert shared.json()["id"] == deck.id
+
+
+def test_unpublish_returns_deck_to_private_and_revokes_share_link(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "unpublish-owner")
+    deck = _owned_deck(sqlite_session, owner, "unpublish-owned-deck")
+    headers = _headers(sqlite_session, owner)
+
+    assert client.post(
+        f"/decks/{deck.id}/publish", headers=headers, params={"visibility": "public"}
+    ).status_code == 200
+    response = client.post(f"/decks/{deck.id}/unpublish", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["visibility"] == "private"
+    assert client.get(f"/decks/shared/{deck.slug}").status_code == 404
+    assert client.get("/decks/library", params={"q": deck.slug}).json()["total"] == 0
+
+
+def test_empty_deck_cannot_be_published(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "empty-owner")
+    deck = _owned_deck(sqlite_session, owner, "empty-owned-deck", with_card=False)
+
+    response = client.post(
+        f"/decks/{deck.id}/publish",
+        headers=_headers(sqlite_session, owner),
+        params={"visibility": "public"},
+    )
+    assert response.status_code == 422
+    assert "at least one card" in response.json()["detail"].lower()
+
+
+def test_non_owner_cannot_publish_someone_elses_deck(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "real-owner")
+    stranger = _user(sqlite_session, "stranger")
+    deck = _owned_deck(sqlite_session, owner, "not-yours")
+
+    response = client.post(
+        f"/decks/{deck.id}/publish",
+        headers=_headers(sqlite_session, stranger),
+        params={"visibility": "public"},
+    )
+    assert response.status_code == 403
+
+
+def test_verified_user_can_remix_public_community_deck(client, sqlite_session: Session):
+    creator = _user(sqlite_session, "community-source")
+    source = _owned_deck(sqlite_session, creator, "community-remix-source")
+    source.visibility = "public"
+    sqlite_session.add(source)
+    sqlite_session.commit()
+
+    remixer = _user(sqlite_session, "community-remixer")
+    response = client.post(
+        f"/decks/{source.id}/copy",
+        headers=_headers(sqlite_session, remixer),
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["owner_id"] == remixer.id
+    assert payload["visibility"] == "private"
+    assert payload["source_deck_id"] == source.id
+    assert payload["card_count"] == 1
+    assert payload["title"].endswith("— Remix")
+
+
+def test_private_deck_cannot_be_remixed_by_non_owner(client, sqlite_session: Session):
+    creator = _user(sqlite_session, "private-source-owner")
+    source = _owned_deck(sqlite_session, creator, "private-remix-source")
+    remixer = _user(sqlite_session, "private-remix-stranger")
+
+    response = client.post(
+        f"/decks/{source.id}/copy",
+        headers=_headers(sqlite_session, remixer),
+    )
+    assert response.status_code == 404

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -245,7 +245,30 @@ export async function createDeck(title: string, description = ""): Promise<DeckR
   }
 }
 
-export async function copyFeaturedDeck(deckId: number): Promise<DeckRead> {
+export async function publishDeck(
+  deckId: number,
+  visibility: "public" | "unlisted" = "public"
+): Promise<DeckRead> {
+  try {
+    const { data } = await api.post<DeckRead>(`/decks/${deckId}/publish`, null, {
+      params: { visibility },
+    });
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function unpublishDeck(deckId: number): Promise<DeckRead> {
+  try {
+    const { data } = await api.post<DeckRead>(`/decks/${deckId}/unpublish`);
+    return data;
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function copyDeck(deckId: number): Promise<DeckRead> {
   try {
     const { data } = await api.post<DeckRead>(`/decks/${deckId}/copy`);
     return data;
@@ -253,6 +276,8 @@ export async function copyFeaturedDeck(deckId: number): Promise<DeckRead> {
     throw normalizeError(e);
   }
 }
+
+export const copyFeaturedDeck = copyDeck;
 
 export async function deleteDeck(deckId: number): Promise<void> {
   try {

--- a/frontend/src/pages/LibraryDeck.tsx
+++ b/frontend/src/pages/LibraryDeck.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { copyFeaturedDeck, getSharedDeck } from "../api";
+import { copyDeck, getSharedDeck } from "../api";
 import { useAuth } from "../auth";
 import type { DeckRead } from "../types";
 
@@ -41,15 +41,15 @@ export default function LibraryDeck() {
     };
   }, [slug]);
 
-  async function saveOfficialCopy() {
-    if (!deck || !user || saving || !deck.is_official) return;
+  async function saveCopy() {
+    if (!deck || !user?.is_verified || saving) return;
     setSaving(true);
     setError(null);
     try {
-      const copy = await copyFeaturedDeck(deck.id);
-      navigate(`/study?deck=${copy.id}`);
+      const copy = await copyDeck(deck.id);
+      navigate(`/deck-lab?deck=${copy.id}`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not save this deck");
+      setError(e instanceof Error ? e.message : "Could not remix this deck");
     } finally {
       setSaving(false);
     }
@@ -137,24 +137,22 @@ export default function LibraryDeck() {
                 ⚡ Start studying
               </Link>
 
-              {deck.is_official && user?.is_verified ? (
+              {user?.is_verified ? (
                 <button
                   type="button"
-                  onClick={() => void saveOfficialCopy()}
+                  onClick={() => void saveCopy()}
                   disabled={saving}
                   className="game-button border border-cyan-300/25 bg-cyan-300/[0.08] px-6 py-3 font-black text-cyan-100"
                   data-game-sound="save"
                 >
-                  {saving ? "Saving…" : "📥 Save my own copy"}
+                  {saving ? "Creating remix…" : deck.is_official ? "📥 Save my own copy" : "🧬 Remix to my decks"}
                 </button>
-              ) : deck.is_official && !user ? (
+              ) : !user ? (
                 <Link className="game-button border border-white/10 bg-white/[0.04] px-6 py-3 font-black text-white" to="/login">
                   Sign in to save a copy
                 </Link>
-              ) : deck.is_official && user && !user.is_verified ? (
-                <span className="game-chip px-4 py-3 text-sm font-bold text-slate-300">Verify your email to save copies</span>
               ) : (
-                <span className="game-chip px-4 py-3 text-sm font-bold text-slate-400">🧬 Community remix controls are next</span>
+                <span className="game-chip px-4 py-3 text-sm font-bold text-slate-300">Verify your email to save or remix decks</span>
               )}
             </div>
           </div>
@@ -176,6 +174,12 @@ export default function LibraryDeck() {
               <p className="metric-label">Study access</p>
               <p className="mt-1 text-sm font-bold text-slate-300">{deck.visibility === "unlisted" ? "Anyone with this link" : "Public Library"}</p>
             </div>
+            {deck.source_deck_id && (
+              <div className="border-t border-white/10 pt-4">
+                <p className="metric-label">Lineage</p>
+                <p className="mt-1 text-sm font-bold text-slate-300">🧬 Remix of deck #{deck.source_deck_id}</p>
+              </div>
+            )}
           </aside>
         </div>
       </section>

--- a/frontend/src/pages/MyDecks.tsx
+++ b/frontend/src/pages/MyDecks.tsx
@@ -1,8 +1,31 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { copyFeaturedDeck, createDeck, deleteDeck, getFeaturedDecks, getMyDecks } from "../api";
+import {
+  copyFeaturedDeck,
+  createDeck,
+  deleteDeck,
+  getFeaturedDecks,
+  getMyDecks,
+  publishDeck,
+  unpublishDeck,
+} from "../api";
 import { useAuth } from "../auth";
 import type { DeckRead } from "../types";
+
+type PublishPreview = {
+  deck: DeckRead;
+  visibility: "public" | "unlisted";
+};
+
+function visibilityChip(deck: DeckRead): { icon: string; label: string; className: string } {
+  if (deck.visibility === "public") {
+    return { icon: "🌎", label: "Public", className: "text-emerald-200" };
+  }
+  if (deck.visibility === "unlisted") {
+    return { icon: "🔗", label: "Unlisted", className: "text-violet-200" };
+  }
+  return { icon: "🔒", label: "Private", className: "text-slate-300" };
+}
 
 export default function MyDecks() {
   const { user, loading: authLoading } = useAuth();
@@ -13,8 +36,9 @@ export default function MyDecks() {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [publishPreview, setPublishPreview] = useState<PublishPreview | null>(null);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     if (!user) return;
     setLoading(true);
     setError(null);
@@ -27,12 +51,15 @@ export default function MyDecks() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [user]);
 
   useEffect(() => {
-    if (!authLoading && !user) navigate("/login", { replace: true, state: { from: "/decks" } });
+    if (!authLoading && !user) {
+      navigate("/login", { replace: true, state: { from: "/decks" } });
+      return;
+    }
     if (user) void refresh();
-  }, [user, authLoading]);
+  }, [user, authLoading, navigate, refresh]);
 
   async function onCreate(event: React.FormEvent) {
     event.preventDefault();
@@ -63,6 +90,33 @@ export default function MyDecks() {
     }
   }
 
+  async function confirmPublish() {
+    if (!publishPreview) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await publishDeck(publishPreview.deck.id, publishPreview.visibility);
+      setPublishPreview(null);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not publish deck");
+      setLoading(false);
+    }
+  }
+
+  async function onUnpublish(deck: DeckRead) {
+    if (!confirm(`Make “${deck.title}” private again? Existing public/share links will stop working.`)) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await unpublishDeck(deck.id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not unpublish deck");
+      setLoading(false);
+    }
+  }
+
   async function onDelete(deck: DeckRead) {
     if (!confirm(`Delete “${deck.title}” and all of its cards?`)) return;
     try {
@@ -81,12 +135,53 @@ export default function MyDecks() {
         <div>
           <p className="metric-label">My decks</p>
           <h1 className="mt-2 text-4xl font-black text-white">Make your own quest.</h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">Build a deck for any topic. Add normal concept cards, hands-on lab cards, or mix both.</p>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">Build privately first. When it is ready, publish it to the Library or share it with an unlisted link.</p>
         </div>
         <div className="game-chip px-4 py-2 text-sm font-bold text-slate-300">👋 {user.display_name}</div>
       </section>
 
       {error && <div className="rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-4 text-sm text-rose-200">{error}</div>}
+
+      {publishPreview && (
+        <section className="reward-pop game-panel border-[#faa307]/35 p-5 sm:p-6">
+          <div className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-center">
+            <div>
+              <p className="metric-label">Publish preview</p>
+              <h2 className="mt-2 text-2xl font-black text-white">{publishPreview.deck.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-400">
+                {publishPreview.visibility === "public"
+                  ? "This deck will appear in public Library search and anyone can study or remix it."
+                  : "This deck will stay out of Library search, but anyone with its share link can study or remix it."}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs font-bold">
+                <span className="game-chip px-3 py-1.5 text-slate-300">📚 {publishPreview.deck.card_count} cards</span>
+                <span className="game-chip px-3 py-1.5 text-slate-300">🏷️ {publishPreview.deck.subject}</span>
+                <span className="game-chip px-3 py-1.5 capitalize text-slate-300">⚔️ {publishPreview.deck.difficulty}</span>
+                <span className="game-chip px-3 py-1.5 text-slate-300">{publishPreview.visibility === "public" ? "🌎 Public" : "🔗 Unlisted"}</span>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 lg:flex-col">
+              <button
+                type="button"
+                className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]"
+                disabled={loading}
+                data-game-sound="publish"
+                onClick={() => void confirmPublish()}
+              >
+                {publishPreview.visibility === "public" ? "Publish to Library" : "Create share link"}
+              </button>
+              <button
+                type="button"
+                className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white"
+                disabled={loading}
+                onClick={() => setPublishPreview(null)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
 
       <section className="grid gap-5 lg:grid-cols-[.8fr_1.2fr]">
         <form onSubmit={onCreate} className="game-panel p-6">
@@ -111,31 +206,89 @@ export default function MyDecks() {
             </div>
           </div>
           <div className="mt-5 grid gap-3">
-            {!loading && decks.length === 0 && <div className="rounded-2xl border border-dashed border-white/15 p-6 text-center text-sm text-slate-400">You don’t have a custom deck yet. Make one on the left or copy the Platform Engineering starter deck below.</div>}
-            {decks.map((deck) => (
-              <article key={deck.id} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <h3 className="font-black text-white">{deck.title}</h3>
-                    <p className="mt-1 text-xs leading-5 text-slate-400">{deck.description || "Your custom FlashQuest deck."}</p>
-                    <p className="mt-2 text-xs font-bold text-[#f48c06]">{deck.card_count} cards</p>
+            {!loading && decks.length === 0 && <div className="rounded-2xl border border-dashed border-white/15 p-6 text-center text-sm text-slate-400">You don’t have a custom deck yet. Make one on the left or copy an Official starter deck below.</div>}
+            {decks.map((deck) => {
+              const visibility = visibilityChip(deck);
+              return (
+                <article key={deck.id} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="font-black text-white">{deck.title}</h3>
+                        <span className={`game-chip px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.12em] ${visibility.className}`}>
+                          {visibility.icon} {visibility.label}
+                        </span>
+                        {deck.source_deck_id && <span className="game-chip px-2.5 py-1 text-[10px] font-black text-cyan-200">🧬 Remix</span>}
+                      </div>
+                      <p className="mt-1 text-xs leading-5 text-slate-400">{deck.description || "Your custom FlashQuest deck."}</p>
+                      <div className="mt-2 flex flex-wrap gap-3 text-xs font-bold text-[#f48c06]">
+                        <span>{deck.card_count} cards</span>
+                        <span>{deck.subject}</span>
+                        <span className="capitalize">{deck.difficulty}</span>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <Link className="game-button bg-[#faa307] px-3 py-2 text-xs font-black text-[#370617]" to={`/study?deck=${deck.id}`}>Play</Link>
+                      <Link className="game-button border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-black text-white" to={`/deck-lab?deck=${deck.id}`}>Edit</Link>
+                      {deck.visibility !== "private" && (
+                        <Link className="game-button border border-cyan-300/20 bg-cyan-300/[0.07] px-3 py-2 text-xs font-black text-cyan-100" to={`/library/${encodeURIComponent(deck.slug)}`}>View share page</Link>
+                      )}
+                    </div>
                   </div>
-                  <div className="flex gap-2">
-                    <Link className="game-button bg-[#faa307] px-3 py-2 text-xs font-black text-[#370617]" to={`/study?deck=${deck.id}`}>Play</Link>
-                    <Link className="game-button border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-black text-white" to={`/deck-lab?deck=${deck.id}`}>Edit</Link>
-                    <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/40 px-3 py-2 text-xs font-black text-rose-200" onClick={() => void onDelete(deck)}>Delete</button>
+
+                  <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
+                    <p className="text-xs text-slate-500">
+                      {deck.visibility === "public" && "Visible in Library search."}
+                      {deck.visibility === "unlisted" && "Only people with the link can find this deck."}
+                      {deck.visibility === "private" && "Only you can access this deck."}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {deck.visibility === "private" ? (
+                        <>
+                          <button
+                            type="button"
+                            className="game-button border border-emerald-300/20 bg-emerald-300/[0.07] px-3 py-2 text-xs font-black text-emerald-100"
+                            disabled={loading || deck.card_count < 1 || !user.is_verified}
+                            data-game-sound="publish"
+                            onClick={() => setPublishPreview({ deck, visibility: "public" })}
+                          >
+                            🌎 Publish
+                          </button>
+                          <button
+                            type="button"
+                            className="game-button border border-violet-300/20 bg-violet-300/[0.07] px-3 py-2 text-xs font-black text-violet-100"
+                            disabled={loading || deck.card_count < 1 || !user.is_verified}
+                            data-game-sound="publish"
+                            onClick={() => setPublishPreview({ deck, visibility: "unlisted" })}
+                          >
+                            🔗 Share unlisted
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          type="button"
+                          className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white"
+                          disabled={loading}
+                          onClick={() => void onUnpublish(deck)}
+                        >
+                          🔒 Make private
+                        </button>
+                      )}
+                      <button className="game-button border border-[#d00000]/40 bg-[#6a040f]/40 px-3 py-2 text-xs font-black text-rose-200" onClick={() => void onDelete(deck)}>Delete</button>
+                    </div>
                   </div>
-                </div>
-              </article>
-            ))}
+                </article>
+              );
+            })}
           </div>
         </div>
       </section>
 
       <section className="game-panel p-6">
-        <p className="metric-label">Starter pack</p>
-        <h2 className="mt-2 text-2xl font-black text-white">Want to remix Platform Engineering?</h2>
-        <p className="mt-2 text-sm text-slate-400">The public demo stays protected, but you can copy all 216 cards into your account and customize your copy however you want.</p>
+        <p className="metric-label">Official starter packs</p>
+        <h2 className="mt-2 text-2xl font-black text-white">Want a protected deck as your starting point?</h2>
+        <p className="mt-2 text-sm text-slate-400">Official decks stay protected, but you can remix them into a private copy and customize every card.</p>
         <div className="mt-5 grid gap-3 md:grid-cols-2">
           {featured.map((deck) => (
             <article key={deck.id} className="rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-5">
@@ -143,7 +296,7 @@ export default function MyDecks() {
               <p className="mt-2 text-sm leading-6 text-slate-400">{deck.description}</p>
               <div className="mt-4 flex items-center justify-between gap-3">
                 <span className="text-xs font-bold text-[#ffba08]">{deck.card_count} cards</span>
-                <button className="game-button bg-[#ffba08] px-4 py-2 text-xs font-black text-[#370617]" onClick={() => void onCopy(deck.id)} disabled={loading}>Copy to my decks</button>
+                <button className="game-button bg-[#ffba08] px-4 py-2 text-xs font-black text-[#370617]" onClick={() => void onCopy(deck.id)} disabled={loading}>Remix to my decks</button>
               </div>
             </article>
           ))}


### PR DESCRIPTION
## What changed

Completes the creator-sharing flow for issue #12.

### Explicit publishing
- Adds owner-only `POST /decks/{id}/publish` with Public or Unlisted visibility.
- Requires a verified account and at least one card before publishing.
- Sets the initial publish timestamp once and keeps later updates separate.
- Adds owner-only `POST /decks/{id}/unpublish` to return a deck to Private and revoke public/share-link access.

### Remix / Save a Copy
- Generalizes the existing copy endpoint so Official, Public, Unlisted, and a creator's own decks can be remixed.
- Other users' Private decks return 404 and cannot be copied.
- Every remix is created Private by default.
- Source deck attribution, subject, difficulty, tags, and cards are preserved.
- Library deck detail now offers real Save/Remix actions for both Official and Community decks.

### Creator UX
- Adds a publish preview panel before visibility changes are confirmed.
- Shows card count, subject, difficulty, and exact Public vs Unlisted consequences.
- My Decks now shows Private/Public/Unlisted status, remix lineage, share-page links, Publish, Share unlisted, and Make private controls.
- Reuses shared semantic sound events for publish/save actions.
- Cleans the existing My Decks hook dependency warning while touching that flow.

### Tests
- Public publishing enters Library discovery.
- Unlisted publishing stays out of discovery but works by direct link.
- Unpublish revokes discovery/share access.
- Empty decks cannot publish.
- Non-owners cannot publish.
- Public community decks can be remixed into private attributed copies.
- Other users' private decks cannot be remixed.

Closes #12