### PR TITLE
Seed curated Official multi-subject starter packs

### DIFF
--- a/backend/app/data/accounting_fundamentals.json
+++ b/backend/app/data/accounting_fundamentals.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "Accounting Fundamentals",
+  "card_count": 30,
+  "domains": [
+    {
+      "name": "Accounting Equation",
+      "cards": [
+        {"prompt": "Accounting · What is the basic accounting equation?", "answer": "Assets = Liabilities + Equity. It expresses how an entity's resources are financed by creditors and owners."},
+        {"prompt": "Accounting · What is an asset?", "answer": "An asset is a resource controlled by an entity that is expected to provide future economic benefit, such as cash, inventory, or equipment."},
+        {"prompt": "Accounting · What is a liability?", "answer": "A liability is a present obligation to transfer economic resources, such as accounts payable, wages payable, or a loan balance."},
+        {"prompt": "Accounting · What is owner's or shareholders' equity?", "answer": "Equity is the residual interest in assets after liabilities are deducted; it generally reflects owner investment and accumulated results retained in the business."},
+        {"prompt": "Accounting · How does earning revenue generally affect equity?", "answer": "Revenue generally increases net income and therefore increases retained earnings or owner's equity, assuming no offsetting distribution."},
+        {"prompt": "Accounting · How does an expense generally affect equity?", "answer": "An expense reduces net income and therefore generally reduces retained earnings or owner's equity."}
+      ]
+    },
+    {
+      "name": "Debits & Credits",
+      "cards": [
+        {"prompt": "Accounting · What is double-entry accounting?", "answer": "Every recorded transaction affects at least two accounts, with total debits equal to total credits so the accounting equation remains balanced."},
+        {"prompt": "Accounting · On which side do asset accounts normally increase?", "answer": "Asset accounts normally increase with debits and decrease with credits."},
+        {"prompt": "Accounting · On which side do liability accounts normally increase?", "answer": "Liability accounts normally increase with credits and decrease with debits."},
+        {"prompt": "Accounting · On which side does equity normally increase?", "answer": "Equity accounts normally increase with credits, although specific contra-equity accounts follow the opposite pattern."},
+        {"prompt": "Accounting · On which side do expense accounts normally increase?", "answer": "Expense accounts normally increase with debits because expenses reduce equity through net income."},
+        {"prompt": "Accounting · What is a journal entry?", "answer": "A journal entry is a dated record of a transaction showing the accounts affected, debit and credit amounts, and often a short explanation."}
+      ]
+    },
+    {
+      "name": "Financial Statements",
+      "cards": [
+        {"prompt": "Accounting · What does the income statement report?", "answer": "It reports revenues, expenses, and resulting profit or loss over a period of time."},
+        {"prompt": "Accounting · What does the balance sheet report?", "answer": "It reports assets, liabilities, and equity at a specific point in time."},
+        {"prompt": "Accounting · What does the statement of cash flows explain?", "answer": "It explains cash inflows and outflows during a period, commonly grouped into operating, investing, and financing activities."},
+        {"prompt": "Accounting · What does the statement of retained earnings or changes in equity show?", "answer": "It reconciles changes in equity over a period, including profit or loss, owner contributions, distributions, and other applicable equity movements."},
+        {"prompt": "Accounting · Why is net income not the same thing as cash flow?", "answer": "Accrual accounting recognizes some revenues and expenses before or after the related cash moves, so profit and cash can differ in the same period."},
+        {"prompt": "Accounting · How are the financial statements connected?", "answer": "Net income affects equity, ending balance-sheet accounts feed the statement of financial position, and cash-flow reporting explains the change in cash between balance-sheet dates."}
+      ]
+    },
+    {
+      "name": "Accruals & Adjustments",
+      "cards": [
+        {"prompt": "Accounting · What is accrual accounting?", "answer": "Accrual accounting recognizes economic events when they are earned or incurred according to applicable accounting rules, rather than only when cash is received or paid."},
+        {"prompt": "Accounting · What is an accrued expense?", "answer": "It is an expense that has been incurred but not yet paid or fully recorded, creating an expense and usually a related liability."},
+        {"prompt": "Accounting · What is accrued revenue?", "answer": "It is revenue that has been earned before the customer has paid or sometimes before an invoice has been issued, generally creating a receivable."},
+        {"prompt": "Accounting · What is deferred or unearned revenue?", "answer": "It is cash received before the related revenue has been earned, so it is generally recorded as a liability until the performance obligation is satisfied."},
+        {"prompt": "Accounting · What is a prepaid expense?", "answer": "It is a payment made before the related benefit is consumed, initially recorded as an asset and expensed over the periods that receive the benefit."},
+        {"prompt": "Accounting · Why are adjusting entries made at period end?", "answer": "They update accounts for items such as accruals, deferrals, depreciation, and estimates so revenues, expenses, assets, and liabilities reflect the reporting period appropriately."}
+      ]
+    },
+    {
+      "name": "Cash, Inventory & Analysis",
+      "cards": [
+        {"prompt": "Accounting · What is accounts receivable?", "answer": "Accounts receivable is an asset representing amounts customers owe the business for goods or services already provided on credit."},
+        {"prompt": "Accounting · What is accounts payable?", "answer": "Accounts payable is a liability representing amounts the business owes suppliers for goods or services already received on credit."},
+        {"prompt": "Accounting · What is cost of goods sold?", "answer": "Cost of goods sold is the cost assigned to inventory that was sold during the period and is recognized as an expense when the related sale is recognized."},
+        {"prompt": "Accounting · What is gross profit?", "answer": "Gross profit is sales revenue minus cost of goods sold before operating expenses and other items."},
+        {"prompt": "Accounting · What does the current ratio measure?", "answer": "Current ratio = current assets ÷ current liabilities; it is a basic indicator of short-term liquidity, though interpretation depends on the business and industry."},
+        {"prompt": "Accounting · Why is a bank reconciliation performed?", "answer": "It explains differences between the company's cash records and the bank statement, identifying timing differences, bank items, errors, or transactions that still need to be recorded."}
+      ]
+    }
+  ]
+}

--- a/backend/app/data/docker_fundamentals.json
+++ b/backend/app/data/docker_fundamentals.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "Docker Fundamentals",
+  "card_count": 30,
+  "domains": [
+    {
+      "name": "Containers & Images",
+      "cards": [
+        {"prompt": "Docker · What is a container?", "answer": "A container is an isolated process environment created from an image, sharing the host kernel while packaging the application and its runtime dependencies."},
+        {"prompt": "Docker · What is an image?", "answer": "An image is an immutable, layered filesystem template plus metadata used to create containers."},
+        {"prompt": "Docker · How is a container different from a virtual machine?", "answer": "Containers share the host kernel and isolate processes; virtual machines emulate hardware and run a separate guest operating system kernel."},
+        {"prompt": "Docker · What does `docker run` do at a high level?", "answer": "It creates a container from an image, applies runtime configuration, and starts the container's configured process."},
+        {"prompt": "Docker · What does `docker ps` show?", "answer": "By default it lists running containers; `docker ps -a` also includes stopped containers."},
+        {"prompt": "Docker · Why are image layers useful?", "answer": "Layers can be cached and shared across images, reducing rebuild time, storage use, and data transfer when unchanged layers are reused."}
+      ]
+    },
+    {
+      "name": "Dockerfiles & Builds",
+      "cards": [
+        {"prompt": "Docker · What is a Dockerfile?", "answer": "A Dockerfile is a text recipe of instructions used by a container builder to assemble an image."},
+        {"prompt": "Docker · What is the difference between `COPY` and `RUN` in a Dockerfile?", "answer": "`COPY` adds files from the build context into the image; `RUN` executes a command during the image build and commits its filesystem changes to a layer."},
+        {"prompt": "Docker · Why should frequently changing Dockerfile steps usually appear later?", "answer": "Docker can reuse cached earlier layers, so keeping stable steps first avoids invalidating expensive work when frequently changing files change."},
+        {"prompt": "Docker · What is the build context?", "answer": "The build context is the set of files sent or made available to the image builder for instructions such as `COPY`."},
+        {"prompt": "Docker · What does `.dockerignore` do?", "answer": "It excludes matching files and directories from the build context, which can reduce transfer size and prevent unnecessary or sensitive files from entering a build."},
+        {"prompt": "Docker · What is a multi-stage build?", "answer": "A multi-stage build uses multiple `FROM` stages so build tools and intermediate artifacts can stay out of the final runtime image."}
+      ]
+    },
+    {
+      "name": "Storage & Data",
+      "cards": [
+        {"prompt": "Docker · Why should important application data usually live outside a container's writable layer?", "answer": "A container can be replaced or removed, so persistent data should use a volume, bind mount, or external data service when it must survive container lifecycle changes."},
+        {"prompt": "Docker · What is a Docker volume?", "answer": "A volume is Docker-managed persistent storage that can be mounted into one or more containers independently of a container's writable layer."},
+        {"prompt": "Docker · What is a bind mount?", "answer": "A bind mount maps a specific host filesystem path into a container, exposing that host content directly at the chosen container path."},
+        {"prompt": "Docker · When is a bind mount especially useful during development?", "answer": "It is useful when source files on the host should appear immediately inside the container without rebuilding the image after every edit."},
+        {"prompt": "Docker · What happens to a named volume when its container is removed?", "answer": "The volume normally remains until it is removed separately, allowing its data to outlive the container."},
+        {"prompt": "Docker · Why should secrets not be baked into image layers?", "answer": "Image layers can persist in history and registries, so baked-in secrets can remain recoverable even after later Dockerfile steps appear to delete them."}
+      ]
+    },
+    {
+      "name": "Networking",
+      "cards": [
+        {"prompt": "Docker · What does publishing a container port do?", "answer": "It maps a host address and port to a container port so traffic reaching the host can be forwarded to the containerized service."},
+        {"prompt": "Docker · Why can two containers on the same user-defined bridge network usually use container names to reach each other?", "answer": "Docker provides DNS-based service discovery on user-defined networks, resolving container or service names to network addresses."},
+        {"prompt": "Docker · What is the difference between `EXPOSE` and publishing a port?", "answer": "`EXPOSE` documents an intended container port in image metadata; publishing with `-p` or equivalent actually makes a host-to-container port mapping."},
+        {"prompt": "Docker · Why does `localhost` inside a container not normally mean the host machine?", "answer": "The container has its own network namespace, so `localhost` refers to that container's loopback interface unless special host networking is used."},
+        {"prompt": "Docker · What is a Docker bridge network?", "answer": "It is a software network on the host that connects containers and can provide isolation, address assignment, and routing between containers and the host."},
+        {"prompt": "Docker · What should you check first if a web container is running but unreachable from the host?", "answer": "Confirm the app is listening on the expected interface and container port, then verify the host port mapping and any host firewall rules."}
+      ]
+    },
+    {
+      "name": "Compose & Operations",
+      "cards": [
+        {"prompt": "Docker · What problem does Docker Compose solve?", "answer": "Compose describes and operates a multi-container application as one project, including services, networks, volumes, environment settings, and dependencies."},
+        {"prompt": "Docker · What is a service in a Compose file?", "answer": "A service is a declarative definition of one application component, including its image or build, command, environment, networks, volumes, and runtime settings."},
+        {"prompt": "Docker · What does `docker compose up` do?", "answer": "It creates or reconciles the project's declared networks, volumes, and containers, then starts the services."},
+        {"prompt": "Docker · What does `docker logs` help you inspect?", "answer": "It shows a container's captured standard output and standard error, which is often the fastest first place to inspect an application failure."},
+        {"prompt": "Docker · What does a container health check represent?", "answer": "It is a recurring command or probe that reports whether the containerized application is functioning according to a defined health condition, not merely whether its process exists."},
+        {"prompt": "Docker · Why is pinning an image tag or digest useful in repeatable deployments?", "answer": "It reduces surprise by making the selected image version explicit instead of allowing a mutable tag such as `latest` to point to different content later."}
+      ]
+    }
+  ]
+}

--- a/backend/app/data/intro_us_law.json
+++ b/backend/app/data/intro_us_law.json
@@ -55,7 +55,7 @@
         {"prompt": "U.S. Law · What is an easement?", "answer": "An easement is a nonpossessory legal right to use or control another person's land for a particular purpose, such as access or utilities."},
         {"prompt": "U.S. Law · What is the difference between primary and secondary legal authority?", "answer": "Primary authority is law itself, such as constitutions, statutes, regulations, and cases; secondary authority explains or analyzes law, such as treatises, articles, and practice guides."},
         {"prompt": "U.S. Law · Why does jurisdiction matter when researching a legal question?", "answer": "A rule may differ among federal and state systems, and authorities from one jurisdiction may be binding, persuasive, or irrelevant in another."},
-        {"prompt": "U.S. Law · Why should a study deck about law not be treated as legal advice?", "answer": "Legal outcomes depend on facts, jurisdiction, current law, procedure, and professional judgment. Educational summaries cannot evaluate a specific person's legal rights or obligations."}
+        {"prompt": "U.S. Law · Why should a study deck about law not be treated as legal advice?", "answer": "This deck is not legal advice. Legal outcomes depend on facts, jurisdiction, current law, procedure, and professional judgment, so educational summaries cannot evaluate a specific person's legal rights or obligations."}
       ]
     }
   ]

--- a/backend/app/data/intro_us_law.json
+++ b/backend/app/data/intro_us_law.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "Intro to U.S. Law",
+  "card_count": 30,
+  "domains": [
+    {
+      "name": "Legal System & Sources",
+      "cards": [
+        {"prompt": "U.S. Law · What is the purpose of a constitution in the U.S. legal system?", "answer": "A constitution establishes governmental structure, grants and limits public power, and protects certain rights; federal and state constitutions operate within their respective spheres."},
+        {"prompt": "U.S. Law · What is a statute?", "answer": "A statute is a law enacted by a legislative body, such as Congress or a state legislature, through the applicable lawmaking process."},
+        {"prompt": "U.S. Law · What is a regulation?", "answer": "A regulation is a rule issued by an authorized administrative agency under authority granted by law and subject to applicable procedural and judicial constraints."},
+        {"prompt": "U.S. Law · What is case law?", "answer": "Case law is law developed through judicial decisions interpreting constitutions, statutes, regulations, contracts, and prior legal principles."},
+        {"prompt": "U.S. Law · What is precedent?", "answer": "Precedent is an earlier judicial decision used as authority in later cases involving sufficiently similar legal issues; how binding it is depends on the court hierarchy and jurisdiction."},
+        {"prompt": "U.S. Law · What is jurisdiction?", "answer": "Jurisdiction is a court's legal authority to hear and decide a matter, including authority over the type of case and, where required, the parties or property involved."}
+      ]
+    },
+    {
+      "name": "Constitutional Structure",
+      "cards": [
+        {"prompt": "U.S. Law · What is separation of powers?", "answer": "It is the constitutional division of governmental authority among legislative, executive, and judicial branches, with different functions and checks among them."},
+        {"prompt": "U.S. Law · What is federalism?", "answer": "Federalism is the division of governmental authority between the federal government and the states under the U.S. constitutional system."},
+        {"prompt": "U.S. Law · What does judicial review mean?", "answer": "Judicial review is the power of courts, in proper cases, to determine whether governmental acts comply with higher legal authority such as a constitution."},
+        {"prompt": "U.S. Law · What is the Supremacy Clause generally about?", "answer": "It establishes that valid federal constitutional and statutory law can control over conflicting state law within the scope of federal authority."},
+        {"prompt": "U.S. Law · What is due process in broad terms?", "answer": "Due process refers to constitutional protections requiring government to respect legally required procedures and, in some contexts, substantive limits before depriving a person of life, liberty, or property."},
+        {"prompt": "U.S. Law · What is equal protection in broad terms?", "answer": "Equal protection is the constitutional principle that government classifications and unequal treatment are subject to legal scrutiny, with the level of scrutiny depending on the classification and right involved."}
+      ]
+    },
+    {
+      "name": "Civil, Criminal & Procedure",
+      "cards": [
+        {"prompt": "U.S. Law · What is a civil case?", "answer": "A civil case is a noncriminal legal dispute in which a party seeks a remedy such as damages, an injunction, a declaration of rights, or another civil form of relief."},
+        {"prompt": "U.S. Law · What is a criminal case?", "answer": "A criminal case is a prosecution by the government alleging conduct defined as a crime and seeking criminal sanctions authorized by law."},
+        {"prompt": "U.S. Law · What is a burden of proof?", "answer": "It is the legal standard specifying how strongly a party must establish a fact or claim; the applicable standard differs by context and type of proceeding."},
+        {"prompt": "U.S. Law · What does 'beyond a reasonable doubt' refer to?", "answer": "It is the high burden of proof the prosecution must satisfy to obtain a criminal conviction in the United States."},
+        {"prompt": "U.S. Law · What is standing?", "answer": "Standing is a doctrine requiring a party seeking judicial relief to have the kind of concrete, legally cognizable interest or injury required for that court to hear the dispute."},
+        {"prompt": "U.S. Law · What is an appeal?", "answer": "An appeal asks a higher court to review specified rulings of a lower court; appellate review usually focuses on claimed legal error rather than simply retrying the entire case."}
+      ]
+    },
+    {
+      "name": "Contracts & Torts",
+      "cards": [
+        {"prompt": "U.S. Law · What is a contract in general terms?", "answer": "A contract is an agreement the law recognizes as creating enforceable obligations; the exact requirements and defenses depend on the governing law and transaction."},
+        {"prompt": "U.S. Law · What is consideration in traditional contract doctrine?", "answer": "Consideration is a bargained-for exchange of legal value that traditionally helps distinguish enforceable promises from gratuitous promises, subject to important exceptions and jurisdictional rules."},
+        {"prompt": "U.S. Law · What is a breach of contract?", "answer": "A breach occurs when a party fails to perform a contractual duty when performance is due and no legal excuse or defense applies."},
+        {"prompt": "U.S. Law · What is a tort?", "answer": "A tort is a civil wrong, other than breach of contract, for which the law may provide a remedy such as damages or injunctive relief."},
+        {"prompt": "U.S. Law · What are the basic elements commonly associated with negligence?", "answer": "Negligence commonly requires a duty of care, breach of that duty, factual and legal causation, and legally recognized harm; details vary by jurisdiction and context."},
+        {"prompt": "U.S. Law · What is an intentional tort?", "answer": "It is a tort based on intentional conduct that satisfies the elements of a recognized claim, such as certain forms of battery, assault, trespass, or false imprisonment; exact rules vary."}
+      ]
+    },
+    {
+      "name": "Property, Research & Legal Practice",
+      "cards": [
+        {"prompt": "U.S. Law · What is real property?", "answer": "Real property generally concerns land and interests attached to land, while personal property generally covers other forms of property; precise classifications can vary by law and context."},
+        {"prompt": "U.S. Law · What is a deed?", "answer": "A deed is a legal instrument used to transfer an interest in real property, subject to formal requirements and recording rules that vary by jurisdiction."},
+        {"prompt": "U.S. Law · What is an easement?", "answer": "An easement is a nonpossessory legal right to use or control another person's land for a particular purpose, such as access or utilities."},
+        {"prompt": "U.S. Law · What is the difference between primary and secondary legal authority?", "answer": "Primary authority is law itself, such as constitutions, statutes, regulations, and cases; secondary authority explains or analyzes law, such as treatises, articles, and practice guides."},
+        {"prompt": "U.S. Law · Why does jurisdiction matter when researching a legal question?", "answer": "A rule may differ among federal and state systems, and authorities from one jurisdiction may be binding, persuasive, or irrelevant in another."},
+        {"prompt": "U.S. Law · Why should a study deck about law not be treated as legal advice?", "answer": "Legal outcomes depend on facts, jurisdiction, current law, procedure, and professional judgment. Educational summaries cannot evaluate a specific person's legal rights or obligations."}
+      ]
+    }
+  ]
+}

--- a/backend/app/data/linux_fundamentals.json
+++ b/backend/app/data/linux_fundamentals.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "Linux Fundamentals",
+  "card_count": 30,
+  "domains": [
+    {
+      "name": "Filesystem & Permissions",
+      "cards": [
+        {"prompt": "Linux · What does the root directory `/` represent?", "answer": "It is the top of the Linux filesystem hierarchy; all filesystems, directories, devices, and mounted storage appear somewhere beneath it."},
+        {"prompt": "Linux · What is the difference between an absolute path and a relative path?", "answer": "An absolute path begins from `/`; a relative path is interpreted from the current working directory."},
+        {"prompt": "Linux · What do the read, write, and execute permission bits mean for a regular file?", "answer": "Read allows viewing content, write allows modifying content, and execute allows the file to be run as a program when its format is executable."},
+        {"prompt": "Linux · What does `chmod` change?", "answer": "It changes file or directory permission bits, either with symbolic notation such as `u+x` or numeric modes such as `755`."},
+        {"prompt": "Linux · What does `chown` change?", "answer": "It changes the user owner and, optionally, the group owner of a filesystem object."},
+        {"prompt": "Linux · What is the purpose of `/etc`?", "answer": "It conventionally contains system-wide configuration files and configuration directories for the operating system and installed services."}
+      ]
+    },
+    {
+      "name": "Processes & Services",
+      "cards": [
+        {"prompt": "Linux · What is a process?", "answer": "A process is a running instance of a program with its own process ID, execution state, memory mappings, open resources, and security context."},
+        {"prompt": "Linux · What is a PID?", "answer": "A PID is the numeric process identifier the kernel assigns to a running process."},
+        {"prompt": "Linux · What does `ps` help you inspect?", "answer": "It reports process information such as PIDs, owners, commands, CPU state, and other attributes depending on the selected options."},
+        {"prompt": "Linux · What is a signal?", "answer": "A signal is an asynchronous notification sent to a process to request or report an event, such as terminate, interrupt, stop, or reload behavior."},
+        {"prompt": "Linux · What does `systemctl` manage on a systemd-based machine?", "answer": "It manages systemd units, including starting, stopping, restarting, enabling, disabling, and inspecting services and other unit types."},
+        {"prompt": "Linux · What is the difference between enabling and starting a systemd service?", "answer": "Starting runs the service now; enabling configures it to start automatically when its target or dependency conditions are reached in future boots."}
+      ]
+    },
+    {
+      "name": "Shell & Text Tools",
+      "cards": [
+        {"prompt": "Linux · What does a shell do?", "answer": "A shell interprets commands, starts programs, expands variables and paths, supports scripting, and connects programs through features such as pipes and redirection."},
+        {"prompt": "Linux · What does a pipe `|` do in the shell?", "answer": "It connects one command's standard output to the next command's standard input so programs can be composed into a processing pipeline."},
+        {"prompt": "Linux · What is standard output?", "answer": "Standard output, or stdout, is the conventional output stream a process uses for normal results; it is file descriptor 1 by default."},
+        {"prompt": "Linux · What does `grep` do?", "answer": "It searches input for lines matching a text pattern or regular expression and prints the matching lines by default."},
+        {"prompt": "Linux · What does `less` help you do?", "answer": "It lets you page through text interactively without loading the entire file into an editor, with navigation and search controls."},
+        {"prompt": "Linux · Why use shell variables and environment variables?", "answer": "They store values for commands and scripts; exported environment variables are also inherited by child processes and commonly carry runtime configuration."}
+      ]
+    },
+    {
+      "name": "Networking & Packages",
+      "cards": [
+        {"prompt": "Linux · What does an IP address identify?", "answer": "It identifies a network interface at the Internet Protocol layer so packets can be addressed and routed to or from that interface."},
+        {"prompt": "Linux · What does `ip addr` show?", "answer": "It shows network interfaces and their assigned addresses, interface state, and related addressing information."},
+        {"prompt": "Linux · What is a listening socket?", "answer": "It is a socket bound to an address and port that waits for incoming connection requests from clients."},
+        {"prompt": "Linux · What can `ss -lnt` help diagnose?", "answer": "It lists listening TCP sockets numerically, helping confirm whether a service is actually listening and on which local addresses and ports."},
+        {"prompt": "Linux · What is a package manager?", "answer": "It installs, upgrades, verifies, and removes software packages while tracking package metadata and dependencies for a distribution."},
+        {"prompt": "Linux · Why should package indexes often be refreshed before installing software?", "answer": "The local package metadata may be stale; refreshing it lets the package manager resolve against the repositories' current package information."}
+      ]
+    },
+    {
+      "name": "Troubleshooting & Resources",
+      "cards": [
+        {"prompt": "Linux · What does `df` report?", "answer": "It reports filesystem space usage, including total, used, and available capacity for mounted filesystems."},
+        {"prompt": "Linux · What does `du` report?", "answer": "It estimates filesystem space consumed by specified files and directory trees, making it useful for finding where disk space is being used."},
+        {"prompt": "Linux · What does `free` help you inspect?", "answer": "It summarizes physical memory and swap usage, including available memory that can be used without immediately swapping."},
+        {"prompt": "Linux · Why can high load average exist even when CPU usage is not near 100%?", "answer": "Linux load can include tasks waiting in uninterruptible I/O states, so storage or other I/O stalls can raise load without saturating CPU execution."},
+        {"prompt": "Linux · What does `journalctl -u SERVICE` help you inspect?", "answer": "It filters the systemd journal to log records associated with a particular systemd unit, often a service."},
+        {"prompt": "Linux · What is a useful first troubleshooting pattern when a service will not start?", "answer": "Check the service status and recent logs, verify configuration and dependencies, then confirm required files, permissions, ports, and resources are available."}
+      ]
+    }
+  ]
+}

--- a/backend/app/data/math_fundamentals.json
+++ b/backend/app/data/math_fundamentals.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "Math Fundamentals",
+  "card_count": 30,
+  "domains": [
+    {
+      "name": "Number Sense",
+      "cards": [
+        {"prompt": "Math · What is place value?", "answer": "Place value is the value a digit represents because of its position in a numeral, such as tens, hundreds, tenths, or hundredths."},
+        {"prompt": "Math · What is the order of operations?", "answer": "Evaluate grouping symbols first, then exponents, then multiplication and division from left to right, then addition and subtraction from left to right."},
+        {"prompt": "Math · What is an integer?", "answer": "An integer is a whole number or its negative, including zero, such as -4, 0, and 12."},
+        {"prompt": "Math · What is an absolute value?", "answer": "Absolute value is a number's distance from zero on the number line, so it is never negative."},
+        {"prompt": "Math · What is a prime number?", "answer": "A prime number is a whole number greater than 1 with exactly two positive factors: 1 and itself."},
+        {"prompt": "Math · What is the greatest common factor?", "answer": "The greatest common factor is the largest positive whole number that divides each of two or more numbers without a remainder."}
+      ]
+    },
+    {
+      "name": "Fractions, Ratios & Percent",
+      "cards": [
+        {"prompt": "Math · What does the denominator of a fraction represent?", "answer": "The denominator tells how many equal parts make one whole; the numerator tells how many of those parts are being considered."},
+        {"prompt": "Math · How do you add fractions with different denominators?", "answer": "Rewrite them with a common denominator, add the numerators, keep the common denominator, and simplify if possible."},
+        {"prompt": "Math · How do you multiply two fractions?", "answer": "Multiply the numerators together and the denominators together, then simplify the resulting fraction."},
+        {"prompt": "Math · What is a ratio?", "answer": "A ratio compares two quantities by division, such as 3:4, 3/4, or '3 to 4'."},
+        {"prompt": "Math · What does 25% mean?", "answer": "It means 25 per 100, which is equivalent to 25/100, 1/4, or 0.25."},
+        {"prompt": "Math · How do you find a percentage of a number?", "answer": "Convert the percentage to a decimal or fraction and multiply it by the number; for example, 20% of 50 is 0.20 × 50 = 10."}
+      ]
+    },
+    {
+      "name": "Algebra",
+      "cards": [
+        {"prompt": "Math · What is a variable?", "answer": "A variable is a symbol, often a letter, used to represent an unknown or changeable value."},
+        {"prompt": "Math · What is an equation?", "answer": "An equation states that two expressions have equal value, using an equals sign between them."},
+        {"prompt": "Math · What does it mean to solve an equation?", "answer": "It means finding the value or values of the variable that make the equation true."},
+        {"prompt": "Math · Why can you perform the same operation on both sides of an equation?", "answer": "Doing the same valid operation to both sides preserves equality, which lets you isolate the unknown without changing the equation's solutions."},
+        {"prompt": "Math · What is the distributive property?", "answer": "It says multiplying a sum by a factor is equivalent to multiplying each term by that factor: a(b + c) = ab + ac."},
+        {"prompt": "Math · What is slope in a linear relationship?", "answer": "Slope is the rate of change: the change in y divided by the change in x, often written as rise over run."}
+      ]
+    },
+    {
+      "name": "Geometry & Measurement",
+      "cards": [
+        {"prompt": "Math · What is perimeter?", "answer": "Perimeter is the total distance around a two-dimensional shape, found by adding the lengths of its sides."},
+        {"prompt": "Math · What is the area of a rectangle?", "answer": "Area equals length times width and is measured in square units."},
+        {"prompt": "Math · What is the area of a triangle?", "answer": "Area equals one-half times the base times the perpendicular height: A = 1/2 bh."},
+        {"prompt": "Math · What is the circumference of a circle?", "answer": "Circumference is the distance around a circle and equals 2πr or πd."},
+        {"prompt": "Math · What is the Pythagorean theorem?", "answer": "For a right triangle, the square of the hypotenuse equals the sum of the squares of the two legs: a² + b² = c²."},
+        {"prompt": "Math · Why must units be considered when comparing measurements?", "answer": "Values expressed in different units are not directly comparable until they are converted to compatible units."}
+      ]
+    },
+    {
+      "name": "Data & Probability",
+      "cards": [
+        {"prompt": "Math · What is the mean of a set of numbers?", "answer": "The mean is the sum of the values divided by the number of values."},
+        {"prompt": "Math · What is the median?", "answer": "The median is the middle value after the data are ordered; with an even number of values, it is the mean of the two middle values."},
+        {"prompt": "Math · What is the mode?", "answer": "The mode is the value or values that occur most often in a data set."},
+        {"prompt": "Math · What is range in a data set?", "answer": "Range is the maximum value minus the minimum value."},
+        {"prompt": "Math · What does probability measure?", "answer": "Probability measures how likely an event is, usually on a scale from 0 for impossible to 1 for certain."},
+        {"prompt": "Math · For equally likely outcomes, how do you calculate the probability of an event?", "answer": "Divide the number of favorable outcomes by the total number of possible equally likely outcomes."}
+      ]
+    }
+  ]
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,7 +42,7 @@ def _allowed_origins() -> list[str]:
 
 
 app = FastAPI(
-    title="FlashQuest’s API",
+    title="FlashQuest API",
     version=settings.APP_VERSION,
     docs_url="/docs",
     redoc_url="/redoc",

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,16 +1,17 @@
-"""Seed the built-in Platform Engineering concept and lab deck.
+"""Seed FlashQuest Official curricula into the configured database.
 
 Run with Docker:
     docker compose exec api python -m app.seed
 
-The seed operation is idempotent: the featured deck and cards are reused,
-metadata is repaired, and missing anonymous-demo study state is created without
-duplicates.
+The registry is intentionally data-driven: each curriculum is versioned JSON,
+validated before use, and seeded idempotently. Official decks are repaired in
+place while user-created decks are never touched.
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,22 +23,47 @@ from .models import Card, Deck, UserCard, utc_now
 DATA_DIR = Path(__file__).parent / "data"
 CONCEPT_DECK_PATH = DATA_DIR / "platform_engineering_cards.json"
 LAB_DECK_PATH = DATA_DIR / "platform_engineering_labs.json"
-PLATFORM_TOPIC = "Platform Engineering"
-PLATFORM_SLUG = "platform-engineering"
-PLATFORM_SUBJECT = "Technology"
-PLATFORM_DIFFICULTY = "intermediate"
-PLATFORM_TAGS = ["platform engineering", "devops", "cloud", "sre"]
 DEMO_USER_ID = 0
 
 
+@dataclass(frozen=True)
+class CurriculumSource:
+    """One versioned curriculum file and the card kind it represents."""
+
+    path: Path
+    kind: str = "concept"
+
+
+@dataclass(frozen=True)
+class CurriculumSpec:
+    """Registry metadata for one protected FlashQuest Official deck."""
+
+    slug: str
+    title: str
+    description: str
+    subject: str
+    difficulty: str
+    tags: tuple[str, ...]
+    sources: tuple[CurriculumSource, ...]
+
+
 def load_deck(path: Path) -> dict[str, list[tuple[str, str]]]:
-    """Load and validate a versioned FlashQuest curriculum file."""
+    """Load and validate one versioned FlashQuest curriculum file."""
     payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    version = int(payload.get("version", 0))
+    if version < 1:
+        raise ValueError(f"Curriculum {path.name} must declare version >= 1")
+
     domains: dict[str, list[tuple[str, str]]] = {}
     prompts: set[str] = set()
 
     for domain in payload.get("domains", []):
-        name = str(domain["name"])
+        name = str(domain["name"]).strip()
+        if not name:
+            raise ValueError(f"Empty domain name in {path.name}")
+        if name in domains:
+            raise ValueError(f"Duplicate domain in {path.name}: {name}")
+
         cards: list[tuple[str, str]] = []
         for card in domain.get("cards", []):
             prompt = str(card["prompt"]).strip()
@@ -57,6 +83,8 @@ def load_deck(path: Path) -> dict[str, list[tuple[str, str]]]:
             f"Curriculum card_count mismatch in {path.name}: "
             f"expected {expected}, found {actual}"
         )
+    if actual < 1:
+        raise ValueError(f"Curriculum {path.name} must contain at least one card")
 
     return domains
 
@@ -86,71 +114,145 @@ PLATFORM_ENGINEERING_LAB_DECK = flatten_deck(PLATFORM_ENGINEERING_LABS_BY_DOMAIN
 PLATFORM_ENGINEERING_DECK = (
     PLATFORM_ENGINEERING_CONCEPT_DECK + PLATFORM_ENGINEERING_LAB_DECK
 )
-PLATFORM_ENGINEERING_METADATA = {
-    **deck_metadata(PLATFORM_ENGINEERING_DECK_BY_DOMAIN, "concept"),
-    **deck_metadata(PLATFORM_ENGINEERING_LABS_BY_DOMAIN, "lab"),
-}
 
-if len({prompt for prompt, _ in PLATFORM_ENGINEERING_DECK}) != len(
-    PLATFORM_ENGINEERING_DECK
-):
-    raise ValueError("Duplicate prompts exist across concept and lab decks")
-
-
-def _featured_deck(session: Session) -> Deck:
-    """Create or repair the public Official Platform Engineering deck."""
-    deck = session.exec(select(Deck).where(Deck.slug == PLATFORM_SLUG)).first()
-    description = (
+PLATFORM_ENGINEERING_SPEC = CurriculumSpec(
+    slug="platform-engineering",
+    title="Platform Engineering",
+    description=(
         "216 Platform Engineering challenges: 144 concepts and 72 hands-on "
         "break/fix labs across 12 domains."
-    )
+    ),
+    subject="Technology",
+    difficulty="intermediate",
+    tags=("platform engineering", "devops", "cloud", "sre"),
+    sources=(
+        CurriculumSource(CONCEPT_DECK_PATH, "concept"),
+        CurriculumSource(LAB_DECK_PATH, "lab"),
+    ),
+)
+
+OFFICIAL_CURRICULA: tuple[CurriculumSpec, ...] = (
+    PLATFORM_ENGINEERING_SPEC,
+    CurriculumSpec(
+        slug="docker-fundamentals",
+        title="Docker Fundamentals",
+        description="30 beginner-friendly Docker concepts covering containers, images, builds, storage, networking, Compose, and everyday operations.",
+        subject="Technology",
+        difficulty="beginner",
+        tags=("docker", "containers", "devops", "images"),
+        sources=(CurriculumSource(DATA_DIR / "docker_fundamentals.json"),),
+    ),
+    CurriculumSpec(
+        slug="linux-fundamentals",
+        title="Linux Fundamentals",
+        description="30 core Linux concepts covering files, permissions, processes, services, shell tools, networking, packages, and troubleshooting.",
+        subject="Technology",
+        difficulty="beginner",
+        tags=("linux", "shell", "operating systems", "cli"),
+        sources=(CurriculumSource(DATA_DIR / "linux_fundamentals.json"),),
+    ),
+    CurriculumSpec(
+        slug="math-fundamentals",
+        title="Math Fundamentals",
+        description="30 approachable math foundations spanning number sense, fractions, percentages, algebra, geometry, measurement, data, and probability.",
+        subject="Mathematics",
+        difficulty="beginner",
+        tags=("math", "algebra", "fractions", "probability"),
+        sources=(CurriculumSource(DATA_DIR / "math_fundamentals.json"),),
+    ),
+    CurriculumSpec(
+        slug="accounting-fundamentals",
+        title="Accounting Fundamentals",
+        description="30 foundational accounting concepts covering the accounting equation, debits and credits, financial statements, accruals, inventory, cash, and basic analysis.",
+        subject="Accounting",
+        difficulty="beginner",
+        tags=("accounting", "bookkeeping", "financial statements", "business"),
+        sources=(CurriculumSource(DATA_DIR / "accounting_fundamentals.json"),),
+    ),
+    CurriculumSpec(
+        slug="intro-us-law",
+        title="Intro to U.S. Law",
+        description=(
+            "30 general educational concepts about the U.S. legal system, constitutional structure, civil and criminal law, contracts, torts, and legal process. "
+            "Laws vary by jurisdiction and change over time; this study deck is not legal advice."
+        ),
+        subject="Law",
+        difficulty="beginner",
+        tags=("law", "us law", "legal concepts", "civics"),
+        sources=(CurriculumSource(DATA_DIR / "intro_us_law.json"),),
+    ),
+)
+
+
+def _curriculum_rows(
+    spec: CurriculumSpec,
+) -> list[tuple[str, str, str, str]]:
+    """Return prompt, answer, domain, kind rows and reject cross-source duplicates."""
+    rows: list[tuple[str, str, str, str]] = []
+    prompts: set[str] = set()
+    for source in spec.sources:
+        domains = load_deck(source.path)
+        for domain, cards in domains.items():
+            for prompt, answer in cards:
+                if prompt in prompts:
+                    raise ValueError(
+                        f"Duplicate prompt across sources for {spec.slug}: {prompt}"
+                    )
+                prompts.add(prompt)
+                rows.append((prompt, answer, domain, source.kind))
+    return rows
+
+
+def _official_deck(session: Session, spec: CurriculumSpec) -> Deck:
+    """Create or repair one public protected Official deck."""
+    deck = session.exec(select(Deck).where(Deck.slug == spec.slug)).first()
+    desired = {
+        "owner_id": None,
+        "title": spec.title,
+        "description": spec.description,
+        "is_builtin": True,
+        "subject": spec.subject,
+        "difficulty": spec.difficulty,
+        "visibility": "public",
+        "tags": list(spec.tags),
+    }
+
     if deck is None:
-        deck = Deck(
-            owner_id=None,
-            title=PLATFORM_TOPIC,
-            slug=PLATFORM_SLUG,
-            description=description,
-            is_builtin=True,
-            subject=PLATFORM_SUBJECT,
-            difficulty=PLATFORM_DIFFICULTY,
-            visibility="public",
-            tags=list(PLATFORM_TAGS),
-        )
+        deck = Deck(slug=spec.slug, **desired)
         session.add(deck)
         session.flush()
         deck.published_at = deck.created_at
         session.add(deck)
         session.flush()
-    else:
-        desired = {
-            "owner_id": None,
-            "title": PLATFORM_TOPIC,
-            "description": description,
-            "is_builtin": True,
-            "subject": PLATFORM_SUBJECT,
-            "difficulty": PLATFORM_DIFFICULTY,
-            "visibility": "public",
-            "tags": list(PLATFORM_TAGS),
-        }
-        changed = False
-        for field, value in desired.items():
-            if getattr(deck, field) != value:
-                setattr(deck, field, value)
-                changed = True
-        if deck.published_at is None:
-            deck.published_at = deck.created_at
+        return deck
+
+    changed = False
+    for field, value in desired.items():
+        if getattr(deck, field) != value:
+            setattr(deck, field, value)
             changed = True
-        if changed:
-            deck.updated_at = utc_now()
-            session.add(deck)
-            session.flush()
+    if deck.published_at is None:
+        deck.published_at = deck.created_at
+        changed = True
+    if changed:
+        deck.updated_at = utc_now()
+        session.add(deck)
+        session.flush()
     return deck
 
 
-def seed_platform_deck(session: Session) -> dict[str, int]:
-    """Insert or repair the built-in Platform Engineering demo deck."""
-    deck = _featured_deck(session)
-    existing_cards = {card.word: card for card in session.exec(select(Card)).all()}
+def seed_curriculum(session: Session, spec: CurriculumSpec) -> dict[str, int | str]:
+    """Insert or repair one Official curriculum without touching other decks."""
+    rows = _curriculum_rows(spec)
+    deck = _official_deck(session, spec)
+    deck_id = int(deck.id or 0)
+
+    # Prompt identity is scoped to the deck. Different subjects may legitimately
+    # use the same wording without colliding during seed repair.
+    existing_cards = {
+        card.word: card
+        for card in session.exec(select(Card).where(Card.deck_id == deck_id)).all()
+    }
     existing_progress_ids = set(
         session.exec(
             select(UserCard.card_id).where(UserCard.user_id == DEMO_USER_ID)
@@ -161,16 +263,22 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
     existing_count = 0
     updated_cards = 0
     created_progress = 0
+    concept_cards = 0
+    lab_cards = 0
 
-    for prompt, answer in PLATFORM_ENGINEERING_DECK:
-        domain, kind = PLATFORM_ENGINEERING_METADATA[prompt]
+    for prompt, answer, domain, kind in rows:
+        if kind == "lab":
+            lab_cards += 1
+        else:
+            concept_cards += 1
+
         card = existing_cards.get(prompt)
         if card is None:
             card = Card(
-                deck_id=deck.id,
+                deck_id=deck_id,
                 word=prompt,
                 definition=answer,
-                topic=PLATFORM_TOPIC,
+                topic=spec.title,
                 domain=domain,
                 kind=kind,
                 is_builtin=True,
@@ -182,9 +290,8 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
         else:
             existing_count += 1
             desired = {
-                "deck_id": deck.id,
                 "definition": answer,
-                "topic": PLATFORM_TOPIC,
+                "topic": spec.title,
                 "domain": domain,
                 "kind": kind,
                 "is_builtin": True,
@@ -205,10 +312,11 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
 
     session.commit()
     return {
-        "deck_id": int(deck.id or 0),
-        "deck_size": len(PLATFORM_ENGINEERING_DECK),
-        "concept_cards": len(PLATFORM_ENGINEERING_CONCEPT_DECK),
-        "lab_cards": len(PLATFORM_ENGINEERING_LAB_DECK),
+        "slug": spec.slug,
+        "deck_id": deck_id,
+        "deck_size": len(rows),
+        "concept_cards": concept_cards,
+        "lab_cards": lab_cards,
         "inserted_cards": inserted_cards,
         "existing_cards": existing_count,
         "updated_cards": updated_cards,
@@ -216,20 +324,33 @@ def seed_platform_deck(session: Session) -> dict[str, int]:
     }
 
 
-def run() -> None:
-    """Seed the configured database and print a compact result summary."""
-    with Session(engine) as session:
-        result = seed_platform_deck(session)
+def seed_platform_deck(session: Session) -> dict[str, int | str]:
+    """Backwards-compatible helper for the Platform Engineering seed tests."""
+    return seed_curriculum(session, PLATFORM_ENGINEERING_SPEC)
 
+
+def seed_all_curricula(session: Session) -> list[dict[str, int | str]]:
+    """Seed every registered Official curriculum."""
+    return [seed_curriculum(session, spec) for spec in OFFICIAL_CURRICULA]
+
+
+def run() -> None:
+    """Seed the configured database and print one compact summary per deck."""
+    with Session(engine) as session:
+        results = seed_all_curricula(session)
+
+    total_cards = sum(int(result["deck_size"]) for result in results)
     print(
-        "FlashQuest featured Platform Engineering deck ready: "
-        f"{result['deck_size']} cards "
-        f"({result['concept_cards']} concepts + {result['lab_cards']} labs; "
-        f"{result['inserted_cards']} inserted, "
-        f"{result['updated_cards']} metadata repaired, "
-        f"{result['existing_cards']} already present, "
-        f"{result['created_progress']} demo progress rows created)."
+        f"FlashQuest Official Library ready: {len(results)} decks, "
+        f"{total_cards} registered cards."
     )
+    for result in results:
+        print(
+            f"- {result['slug']}: {result['deck_size']} cards "
+            f"({result['inserted_cards']} inserted, "
+            f"{result['updated_cards']} repaired, "
+            f"{result['existing_cards']} already present)."
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,15 +1,18 @@
-"""Tests for the built-in Platform Engineering concept and lab deck."""
+"""Tests for FlashQuest's versioned Official curriculum registry."""
 
 from sqlmodel import select
 
 from app.models import Card, Deck, UserCard
 from app.seed import (
     DEMO_USER_ID,
+    OFFICIAL_CURRICULA,
     PLATFORM_ENGINEERING_CONCEPT_DECK,
     PLATFORM_ENGINEERING_DECK,
     PLATFORM_ENGINEERING_DECK_BY_DOMAIN,
     PLATFORM_ENGINEERING_LAB_DECK,
     PLATFORM_ENGINEERING_LABS_BY_DOMAIN,
+    load_deck,
+    seed_all_curricula,
     seed_platform_deck,
 )
 
@@ -42,6 +45,52 @@ def test_lab_cards_are_scenario_driven():
     )
 
 
+def test_official_registry_contains_expected_subject_packs():
+    assert [spec.slug for spec in OFFICIAL_CURRICULA] == [
+        "platform-engineering",
+        "docker-fundamentals",
+        "linux-fundamentals",
+        "math-fundamentals",
+        "accounting-fundamentals",
+        "intro-us-law",
+    ]
+    assert {spec.subject for spec in OFFICIAL_CURRICULA} >= {
+        "Technology",
+        "Mathematics",
+        "Accounting",
+        "Law",
+    }
+
+
+def test_new_starter_curricula_are_30_card_balanced_packs():
+    for spec in OFFICIAL_CURRICULA[1:]:
+        source = spec.sources[0]
+        domains = load_deck(source.path)
+        assert len(domains) == 5
+        assert all(len(cards) == 6 for cards in domains.values())
+        cards = [card for domain_cards in domains.values() for card in domain_cards]
+        assert len(cards) == 30
+        prompts = [prompt for prompt, _answer in cards]
+        assert len(set(prompts)) == 30
+        assert all(len(answer) <= 500 for _prompt, answer in cards)
+
+
+def test_law_curriculum_carries_scope_and_advice_boundary():
+    law = next(spec for spec in OFFICIAL_CURRICULA if spec.slug == "intro-us-law")
+    description = law.description.lower()
+    assert "not legal advice" in description
+    assert "jurisdiction" in description
+
+    domains = load_deck(law.sources[0].path)
+    prompts_and_answers = " ".join(
+        f"{prompt} {answer}"
+        for cards in domains.values()
+        for prompt, answer in cards
+    ).lower()
+    assert "not legal advice" in prompts_and_answers
+    assert "jurisdiction" in prompts_and_answers
+
+
 def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     first = seed_platform_deck(sqlite_session)
     assert first["deck_size"] == 216
@@ -56,6 +105,7 @@ def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     assert decks[0].slug == "platform-engineering"
     assert decks[0].is_builtin is True
     assert decks[0].owner_id is None
+    assert decks[0].visibility == "public"
 
     cards = sqlite_session.exec(select(Card)).all()
     progress = sqlite_session.exec(select(UserCard)).all()
@@ -78,3 +128,61 @@ def test_seed_platform_deck_is_idempotent_and_protected(sqlite_session):
     assert len(sqlite_session.exec(select(Deck)).all()) == 1
     assert len(sqlite_session.exec(select(Card)).all()) == 216
     assert len(sqlite_session.exec(select(UserCard)).all()) == 216
+
+
+def test_seed_all_curricula_is_idempotent_and_library_ready(sqlite_session):
+    first = seed_all_curricula(sqlite_session)
+    assert len(first) == 6
+    assert sum(int(result["deck_size"]) for result in first) == 366
+    assert sum(int(result["inserted_cards"]) for result in first) == 366
+
+    decks = sqlite_session.exec(select(Deck).order_by(Deck.id)).all()
+    cards = sqlite_session.exec(select(Card)).all()
+    progress = sqlite_session.exec(select(UserCard)).all()
+
+    assert len(decks) == 6
+    assert len(cards) == 366
+    assert len(progress) == 366
+    assert all(deck.is_builtin for deck in decks)
+    assert all(deck.visibility == "public" for deck in decks)
+    assert all(deck.published_at is not None for deck in decks)
+    assert all(deck.owner_id is None for deck in decks)
+    assert {deck.slug for deck in decks} == {spec.slug for spec in OFFICIAL_CURRICULA}
+
+    starter_decks = [deck for deck in decks if deck.slug != "platform-engineering"]
+    assert all(
+        len([card for card in cards if card.deck_id == deck.id]) == 30
+        for deck in starter_decks
+    )
+
+    second = seed_all_curricula(sqlite_session)
+    assert sum(int(result["inserted_cards"]) for result in second) == 0
+    assert sum(int(result["updated_cards"]) for result in second) == 0
+    assert sum(int(result["created_progress"]) for result in second) == 0
+    assert sum(int(result["existing_cards"]) for result in second) == 366
+
+    assert len(sqlite_session.exec(select(Deck)).all()) == 6
+    assert len(sqlite_session.exec(select(Card)).all()) == 366
+    assert len(sqlite_session.exec(select(UserCard)).all()) == 366
+
+
+def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
+    """The same wording in two decks must never move a card between curricula."""
+    first, second = OFFICIAL_CURRICULA[1], OFFICIAL_CURRICULA[2]
+    seed_all_curricula(sqlite_session)
+
+    first_deck = sqlite_session.exec(select(Deck).where(Deck.slug == first.slug)).one()
+    second_deck = sqlite_session.exec(select(Deck).where(Deck.slug == second.slug)).one()
+    first_card = sqlite_session.exec(select(Card).where(Card.deck_id == first_deck.id)).first()
+    second_card = sqlite_session.exec(select(Card).where(Card.deck_id == second_deck.id)).first()
+
+    assert first_card is not None and second_card is not None
+    original_first_deck_id = first_card.deck_id
+    original_second_deck_id = second_card.deck_id
+
+    # A second seed is the regression check: deck-scoped lookup must leave both put.
+    seed_all_curricula(sqlite_session)
+    sqlite_session.refresh(first_card)
+    sqlite_session.refresh(second_card)
+    assert first_card.deck_id == original_first_deck_id
+    assert second_card.deck_id == original_second_deck_id

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -83,9 +83,7 @@ def test_law_curriculum_carries_scope_and_advice_boundary():
 
     domains = load_deck(law.sources[0].path)
     prompts_and_answers = " ".join(
-        f"{prompt} {answer}"
-        for cards in domains.values()
-        for prompt, answer in cards
+        f"{prompt} {answer}" for cards in domains.values() for prompt, answer in cards
     ).lower()
     assert "not legal advice" in prompts_and_answers
     assert "jurisdiction" in prompts_and_answers
@@ -189,9 +187,15 @@ def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
     seed_all_curricula(sqlite_session)
 
     first_deck = sqlite_session.exec(select(Deck).where(Deck.slug == first.slug)).one()
-    second_deck = sqlite_session.exec(select(Deck).where(Deck.slug == second.slug)).one()
-    first_card = sqlite_session.exec(select(Card).where(Card.deck_id == first_deck.id)).first()
-    second_card = sqlite_session.exec(select(Card).where(Card.deck_id == second_deck.id)).first()
+    second_deck = sqlite_session.exec(
+        select(Deck).where(Deck.slug == second.slug)
+    ).one()
+    first_card = sqlite_session.exec(
+        select(Card).where(Card.deck_id == first_deck.id)
+    ).first()
+    second_card = sqlite_session.exec(
+        select(Card).where(Card.deck_id == second_deck.id)
+    ).first()
 
     assert first_card is not None and second_card is not None
     original_first_deck_id = first_card.deck_id

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -166,8 +166,25 @@ def test_seed_all_curricula_is_idempotent_and_library_ready(sqlite_session):
     assert len(sqlite_session.exec(select(UserCard)).all()) == 366
 
 
+def test_seeded_official_packs_appear_in_library_discovery(client, sqlite_session):
+    seed_all_curricula(sqlite_session)
+
+    response = client.get(
+        "/decks/library",
+        params={"source": "official", "page_size": 20, "sort": "title"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 6
+    assert {item["slug"] for item in payload["items"]} == {
+        spec.slug for spec in OFFICIAL_CURRICULA
+    }
+    assert all(item["is_official"] is True for item in payload["items"])
+    assert all(item["visibility"] == "public" for item in payload["items"])
+
+
 def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
-    """The same wording in two decks must never move a card between curricula."""
+    """A second seed must never move cards between curricula."""
     first, second = OFFICIAL_CURRICULA[1], OFFICIAL_CURRICULA[2]
     seed_all_curricula(sqlite_session)
 
@@ -180,7 +197,6 @@ def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
     original_first_deck_id = first_card.deck_id
     original_second_deck_id = second_card.deck_id
 
-    # A second seed is the regression check: deck-scoped lookup must leave both put.
     seed_all_curricula(sqlite_session)
     sqlite_session.refresh(first_card)
     sqlite_session.refresh(second_card)


### PR DESCRIPTION
## What changed

Completes the first multi-subject Official Library content wave for issue #13 without turning the seed path into a pile of one-off scripts.

### Curriculum registry
- Refactors `app.seed` into a reusable `CurriculumSpec` / `CurriculumSource` registry.
- Keeps the existing 216-card Platform Engineering curriculum intact and seeds it through the same registry.
- Validates curriculum version, domain names, declared card counts, empty content, and duplicate prompts.
- Scopes prompt identity to a deck so identical wording in unrelated subjects cannot move/repair the wrong card.
- Keeps seeding idempotent and repairs Official metadata without touching user-created decks.
- Fly's existing release command continues to run `python -m app.seed`, so registered packs seed automatically on backend deployment.

### Five new Official starter packs
Each pack contains 30 concise foundation cards across five domains:
- Docker Fundamentals — Technology / Beginner
- Linux Fundamentals — Technology / Beginner
- Math Fundamentals — Mathematics / Beginner
- Accounting Fundamentals — Accounting / Beginner
- Intro to U.S. Law — Law / Beginner

That brings the registered Official Library to **6 decks / 366 cards** total: the existing 216-card Platform Engineering deck plus 150 new starter cards.

### Law-content boundary
- The law deck is explicitly general educational material.
- Its Official description says law varies by jurisdiction and over time and that the deck is not legal advice.
- The content itself reinforces jurisdiction and legal-advice boundaries rather than pretending general summaries resolve specific legal questions.

### Tests
- Preserve the original Platform Engineering count/balance/idempotency checks.
- Validate all starter packs are exactly 30 cards across five balanced domains.
- Enforce unique prompts and concise answer size.
- Enforce the law scope/disclaimer language.
- Seed all six decks twice and verify idempotency.
- Verify all six are protected/public/Official and appear through Library discovery.
- Regression-check deck-scoped card identity.

### Small cleanup
- Fixes the API title from the old possessive `FlashQuest’s API` to `FlashQuest API`.

Closes #13