### PR TITLE
Add reusable Arcade activity runtime contract

### DIFF
--- a/backend/app/activities.py
+++ b/backend/app/activities.py
@@ -1,0 +1,366 @@
+"""Reusable FlashQuest Arcade activity runtime.
+
+This module intentionally has no database or transport dependency. Deck/Card
+persistence supplies learning content, an activity adapter transforms that
+content into a deterministic runtime, and solo/Quest Room hosts consume the
+same phase-safe public state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Iterable
+
+from pydantic import BaseModel, Field
+
+
+class ActivityType(str, Enum):
+    """Activity families supported by the shared runtime contract."""
+
+    BLITZ = "blitz"
+    MATCH = "match"
+    SORT = "sort"
+    ORDER = "order"
+    RECALL = "recall"
+    DEBUG = "debug"
+    STORY = "story"
+    BOSS = "boss"
+
+
+class ActivityMode(str, Enum):
+    """Where an activity runtime is being hosted."""
+
+    SOLO = "solo"
+    ROOM = "room"
+
+
+class ActivityPhase(str, Enum):
+    """Server/runtime-controlled activity lifecycle."""
+
+    LOBBY = "lobby"
+    PROMPT = "prompt"
+    HINT = "hint"
+    LOCKED = "locked"
+    REVEAL = "reveal"
+    RESULT = "result"
+    COMPLETE = "complete"
+
+
+class TimerPolicy(str, Enum):
+    """Whether an activity requires time pressure."""
+
+    NONE = "none"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
+
+
+class ActivityDefinition(BaseModel):
+    """Stable capabilities and content requirements for one activity type."""
+
+    id: str
+    version: int = Field(default=1, ge=1)
+    type: ActivityType
+    title: str
+    description: str
+    min_cards: int = Field(ge=1)
+    max_cards: int = Field(ge=1)
+    compatible_kinds: tuple[str, ...] = ("concept", "lab")
+    timer_policy: TimerPolicy = TimerPolicy.OPTIONAL
+    supports_hints: bool = False
+    supports_reveal: bool = True
+    supports_teams: bool = False
+    supports_late_join: bool = True
+    score_rule: str = "correct-answer"
+
+
+class ActivityCard(BaseModel):
+    """Transport-neutral learning content consumed by activity adapters."""
+
+    id: int
+    word: str
+    definition: str
+    domain: str = "General"
+    kind: str = "concept"
+
+
+class ActivityParticipantState(BaseModel):
+    """Per-participant game state; durable mastery remains outside this model."""
+
+    participant_id: str
+    score: int = 0
+    streak: int = 0
+    response: str | None = None
+    confidence: int | None = Field(default=None, ge=1, le=5)
+    round_complete: bool = False
+
+
+class ActivityEvent(BaseModel):
+    """Explicit activity transition/event suitable for local or room transport."""
+
+    type: str
+    participant_id: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ActivityPublicState(BaseModel):
+    """Phase-safe state that may be sent to a browser or room participant."""
+
+    session_id: str
+    definition: ActivityDefinition
+    mode: ActivityMode
+    phase: ActivityPhase
+    deck_id: int
+    card_ids: list[int]
+    round_index: int
+    total_rounds: int
+    seed: int
+    payload: dict[str, Any]
+    reveal: dict[str, Any] | None = None
+    participants: list[ActivityParticipantState] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ActivityRound:
+    """Internal round data. Answer-bearing fields never serialize directly."""
+
+    payload: dict[str, Any]
+    reveal: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ActivityRuntime:
+    """Internal runtime shared by solo and future room synchronization hosts."""
+
+    session_id: str
+    definition: ActivityDefinition
+    mode: ActivityMode
+    phase: ActivityPhase
+    deck_id: int
+    card_ids: tuple[int, ...]
+    seed: int
+    rounds: tuple[_ActivityRound, ...]
+    round_index: int = 0
+    participants: tuple[ActivityParticipantState, ...] = ()
+
+
+BLITZ_DEFINITION = ActivityDefinition(
+    id="multiple-choice-blitz",
+    type=ActivityType.BLITZ,
+    title="Multiple-Choice Blitz",
+    description="Pick the best answer from shuffled deck-based choices.",
+    min_cards=4,
+    max_cards=20,
+    timer_policy=TimerPolicy.OPTIONAL,
+    supports_hints=False,
+    supports_teams=True,
+)
+
+MATCH_DEFINITION = ActivityDefinition(
+    id="match-quest",
+    type=ActivityType.MATCH,
+    title="Match Quest",
+    description="Match prompts to their definitions from the same deck.",
+    min_cards=3,
+    max_cards=10,
+    timer_policy=TimerPolicy.OPTIONAL,
+    supports_hints=False,
+    supports_teams=True,
+)
+
+ACTIVITY_DEFINITIONS: dict[ActivityType, ActivityDefinition] = {
+    ActivityType.BLITZ: BLITZ_DEFINITION,
+    ActivityType.MATCH: MATCH_DEFINITION,
+}
+
+
+def _stable_seed(deck_id: int, activity_type: ActivityType, card_ids: Iterable[int]) -> int:
+    """Derive a reproducible seed when a caller does not supply one."""
+    material = f"{deck_id}:{activity_type.value}:{','.join(str(value) for value in card_ids)}"
+    digest = hashlib.blake2b(material.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big")
+
+
+def _validate_cards(
+    definition: ActivityDefinition, cards: Iterable[ActivityCard]
+) -> list[ActivityCard]:
+    """Normalize and validate content against an activity definition."""
+    rows = list(cards)
+    unique: dict[int, ActivityCard] = {card.id: card for card in rows}
+    rows = list(unique.values())
+    if len(rows) < definition.min_cards:
+        raise ValueError(
+            f"{definition.title} needs at least {definition.min_cards} unique cards"
+        )
+    if any(card.kind not in definition.compatible_kinds for card in rows):
+        raise ValueError(f"{definition.title} received an incompatible card kind")
+    return rows
+
+
+def _session_id(
+    deck_id: int, activity_type: ActivityType, seed: int, mode: ActivityMode
+) -> str:
+    """Create a compact deterministic runtime id useful for replay/debug tests."""
+    material = f"{deck_id}:{activity_type.value}:{seed}:{mode.value}"
+    return hashlib.blake2b(material.encode("utf-8"), digest_size=10).hexdigest()
+
+
+def _build_blitz_rounds(
+    cards: list[ActivityCard], rng: random.Random, round_count: int
+) -> tuple[_ActivityRound, ...]:
+    """Build deterministic multiple-choice rounds with phase-safe payloads."""
+    order = cards[:]
+    rng.shuffle(order)
+    rounds: list[_ActivityRound] = []
+    for target in order[:round_count]:
+        distractor_pool = [card for card in cards if card.id != target.id]
+        distractors = rng.sample(distractor_pool, k=min(3, len(distractor_pool)))
+        options = [target, *distractors]
+        rng.shuffle(options)
+        choices = [
+            {"id": f"card-{card.id}", "text": card.definition} for card in options
+        ]
+        rounds.append(
+            _ActivityRound(
+                payload={
+                    "card_id": target.id,
+                    "prompt": target.word,
+                    "domain": target.domain,
+                    "kind": target.kind,
+                    "choices": choices,
+                },
+                reveal={
+                    "card_id": target.id,
+                    "correct_choice_id": f"card-{target.id}",
+                    "answer": target.definition,
+                },
+            )
+        )
+    return tuple(rounds)
+
+
+def _build_match_rounds(
+    cards: list[ActivityCard], rng: random.Random, pair_count: int
+) -> tuple[_ActivityRound, ...]:
+    """Build one matching board per round without exposing its answer map early."""
+    selected = cards[:]
+    rng.shuffle(selected)
+    selected = selected[:pair_count]
+    prompts = [
+        {
+            "card_id": card.id,
+            "prompt": card.word,
+            "domain": card.domain,
+            "kind": card.kind,
+        }
+        for card in selected
+    ]
+    choices = [
+        {"id": f"card-{card.id}", "text": card.definition} for card in selected
+    ]
+    rng.shuffle(choices)
+    answer_map = {str(card.id): f"card-{card.id}" for card in selected}
+    return (
+        _ActivityRound(
+            payload={"prompts": prompts, "choices": choices},
+            reveal={"answer_map": answer_map},
+        ),
+    )
+
+
+def build_activity_runtime(
+    *,
+    activity_type: ActivityType,
+    deck_id: int,
+    cards: Iterable[ActivityCard],
+    mode: ActivityMode = ActivityMode.SOLO,
+    seed: int | None = None,
+    round_count: int = 5,
+) -> ActivityRuntime:
+    """Build a deterministic solo or room-hosted runtime from the same content."""
+    if activity_type not in ACTIVITY_DEFINITIONS:
+        raise ValueError(f"No v1 adapter exists for activity type: {activity_type.value}")
+    definition = ACTIVITY_DEFINITIONS[activity_type]
+    rows = _validate_cards(definition, cards)
+    rows = rows[: definition.max_cards]
+    resolved_seed = seed if seed is not None else _stable_seed(
+        deck_id, activity_type, [card.id for card in rows]
+    )
+    rng = random.Random(resolved_seed)
+
+    if activity_type == ActivityType.BLITZ:
+        rounds = _build_blitz_rounds(
+            rows, rng, min(max(1, round_count), len(rows), definition.max_cards)
+        )
+    elif activity_type == ActivityType.MATCH:
+        rounds = _build_match_rounds(
+            rows, rng, min(max(definition.min_cards, round_count), len(rows))
+        )
+    else:  # pragma: no cover - guarded by the registry above
+        raise ValueError(f"No adapter for activity type: {activity_type.value}")
+
+    return ActivityRuntime(
+        session_id=_session_id(deck_id, activity_type, resolved_seed, mode),
+        definition=definition,
+        mode=mode,
+        phase=ActivityPhase.PROMPT,
+        deck_id=deck_id,
+        card_ids=tuple(card.id for card in rows),
+        seed=resolved_seed,
+        rounds=rounds,
+    )
+
+
+def public_activity_state(runtime: ActivityRuntime) -> ActivityPublicState:
+    """Serialize only data safe for the runtime's current phase."""
+    if runtime.phase == ActivityPhase.COMPLETE:
+        payload: dict[str, Any] = {}
+        reveal = None
+    else:
+        current = runtime.rounds[runtime.round_index]
+        payload = current.payload
+        reveal = current.reveal if runtime.phase in {
+            ActivityPhase.REVEAL,
+            ActivityPhase.RESULT,
+        } else None
+
+    return ActivityPublicState(
+        session_id=runtime.session_id,
+        definition=runtime.definition,
+        mode=runtime.mode,
+        phase=runtime.phase,
+        deck_id=runtime.deck_id,
+        card_ids=list(runtime.card_ids),
+        round_index=runtime.round_index,
+        total_rounds=len(runtime.rounds),
+        seed=runtime.seed,
+        payload=payload,
+        reveal=reveal,
+        participants=list(runtime.participants),
+    )
+
+
+def apply_activity_event(runtime: ActivityRuntime, event: ActivityEvent) -> ActivityRuntime:
+    """Apply a minimal deterministic lifecycle transition used by solo/room hosts."""
+    if event.type == "round.locked":
+        return replace(runtime, phase=ActivityPhase.LOCKED)
+    if event.type == "answer.revealed":
+        if runtime.phase not in {ActivityPhase.PROMPT, ActivityPhase.LOCKED}:
+            raise ValueError("answer.revealed is only valid during prompt/locked phases")
+        return replace(runtime, phase=ActivityPhase.REVEAL)
+    if event.type == "round.completed":
+        if runtime.phase not in {ActivityPhase.REVEAL, ActivityPhase.RESULT}:
+            raise ValueError("round.completed requires a revealed round")
+        next_index = runtime.round_index + 1
+        if next_index >= len(runtime.rounds):
+            return replace(runtime, phase=ActivityPhase.COMPLETE)
+        return replace(
+            runtime,
+            round_index=next_index,
+            phase=ActivityPhase.PROMPT,
+        )
+    if event.type == "session.completed":
+        return replace(runtime, phase=ActivityPhase.COMPLETE)
+    raise ValueError(f"Unsupported activity event: {event.type}")

--- a/backend/tests/test_activities.py
+++ b/backend/tests/test_activities.py
@@ -1,0 +1,185 @@
+"""Contract tests for solo and Quest Room-hosted Arcade activities."""
+
+import json
+
+import pytest
+
+from app.activities import (
+    ActivityCard,
+    ActivityEvent,
+    ActivityMode,
+    ActivityPhase,
+    ActivityType,
+    apply_activity_event,
+    build_activity_runtime,
+    public_activity_state,
+)
+
+
+def _cards(count: int = 8) -> list[ActivityCard]:
+    return [
+        ActivityCard(
+            id=index,
+            word=f"Prompt {index}",
+            definition=f"Definition {index}",
+            domain="Testing" if index < 5 else "Advanced Testing",
+            kind="concept",
+        )
+        for index in range(1, count + 1)
+    ]
+
+
+def test_blitz_is_deterministic_for_same_deck_cards_and_seed():
+    first = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=42,
+        cards=_cards(),
+        seed=12345,
+        round_count=5,
+    )
+    second = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=42,
+        cards=_cards(),
+        seed=12345,
+        round_count=5,
+    )
+
+    first_state = public_activity_state(first)
+    second_state = public_activity_state(second)
+    assert first_state.payload == second_state.payload
+    assert first_state.card_ids == second_state.card_ids
+    assert first_state.seed == second_state.seed == 12345
+
+
+def test_blitz_prompt_state_does_not_leak_correct_choice_or_answer():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=7,
+        cards=_cards(),
+        seed=44,
+    )
+    state = public_activity_state(runtime)
+    serialized = json.dumps(state.model_dump())
+
+    assert state.phase == ActivityPhase.PROMPT
+    assert state.reveal is None
+    assert "correct_choice_id" not in serialized
+    assert '"answer"' not in serialized
+    assert len(state.payload["choices"]) == 4
+
+
+def test_reveal_event_exposes_answer_only_after_runtime_transition():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=7,
+        cards=_cards(),
+        seed=44,
+    )
+    revealed = apply_activity_event(runtime, ActivityEvent(type="answer.revealed"))
+    state = public_activity_state(revealed)
+
+    assert state.phase == ActivityPhase.REVEAL
+    assert state.reveal is not None
+    assert state.reveal["correct_choice_id"].startswith("card-")
+    assert state.reveal["answer"].startswith("Definition")
+
+
+def test_round_completion_advances_then_completes_session():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=9,
+        cards=_cards(4),
+        seed=9,
+        round_count=2,
+    )
+    runtime = apply_activity_event(runtime, ActivityEvent(type="answer.revealed"))
+    runtime = apply_activity_event(runtime, ActivityEvent(type="round.completed"))
+    assert runtime.phase == ActivityPhase.PROMPT
+    assert runtime.round_index == 1
+
+    runtime = apply_activity_event(runtime, ActivityEvent(type="answer.revealed"))
+    runtime = apply_activity_event(runtime, ActivityEvent(type="round.completed"))
+    assert runtime.phase == ActivityPhase.COMPLETE
+    assert public_activity_state(runtime).payload == {}
+
+
+def test_same_blitz_adapter_runs_in_solo_and_room_mode():
+    solo = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=12,
+        cards=_cards(),
+        mode=ActivityMode.SOLO,
+        seed=222,
+    )
+    room = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=12,
+        cards=_cards(),
+        mode=ActivityMode.ROOM,
+        seed=222,
+    )
+
+    solo_state = public_activity_state(solo)
+    room_state = public_activity_state(room)
+    assert solo.definition == room.definition
+    assert solo_state.payload == room_state.payload
+    assert solo_state.card_ids == room_state.card_ids
+    assert solo_state.mode == ActivityMode.SOLO
+    assert room_state.mode == ActivityMode.ROOM
+
+
+def test_match_quest_uses_same_phase_safe_runtime_contract():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.MATCH,
+        deck_id=88,
+        cards=_cards(6),
+        mode=ActivityMode.ROOM,
+        seed=777,
+        round_count=5,
+    )
+    state = public_activity_state(runtime)
+    serialized = json.dumps(state.model_dump())
+
+    assert state.definition.type == ActivityType.MATCH
+    assert state.total_rounds == 1
+    assert len(state.payload["prompts"]) == 5
+    assert len(state.payload["choices"]) == 5
+    assert "answer_map" not in serialized
+
+    revealed = apply_activity_event(runtime, ActivityEvent(type="answer.revealed"))
+    reveal_state = public_activity_state(revealed)
+    assert reveal_state.reveal is not None
+    assert len(reveal_state.reveal["answer_map"]) == 5
+
+
+def test_activity_rejects_too_few_cards():
+    with pytest.raises(ValueError, match="needs at least 4 unique cards"):
+        build_activity_runtime(
+            activity_type=ActivityType.BLITZ,
+            deck_id=1,
+            cards=_cards(3),
+        )
+
+
+def test_activity_deduplicates_cards_by_id_before_validation():
+    repeated = _cards(4)
+    repeated.append(repeated[0])
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=1,
+        cards=repeated,
+        seed=1,
+    )
+    assert len(runtime.card_ids) == 4
+
+
+def test_invalid_transition_cannot_complete_hidden_round():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.BLITZ,
+        deck_id=1,
+        cards=_cards(),
+        seed=1,
+    )
+    with pytest.raises(ValueError, match="requires a revealed round"):
+        apply_activity_event(runtime, ActivityEvent(type="round.completed"))

--- a/docs/ARCADE_ACTIVITY_CONTRACT.md
+++ b/docs/ARCADE_ACTIVITY_CONTRACT.md
@@ -1,0 +1,102 @@
+# Arcade activity contract
+
+FlashQuest Arcade treats a deck as **learning content** and an activity as a **runtime transformation of that content**. Games do not add game-specific columns to every `Deck` or `Card`, and Quest Rooms do not get a separate multiplayer game model.
+
+## Why this boundary exists
+
+The same Docker, math, accounting, law, Linux, community, or future deck should be usable in multiple study experiences. A deck remains the durable source of prompts and answers. The activity runtime chooses compatible cards, creates game-safe prompt payloads, controls reveal state, and emits results that can later be translated into per-user spaced-repetition updates.
+
+```text
+Deck + Cards
+    │
+    ▼
+Activity adapter
+    │
+    ▼
+ActivityRuntime
+    ├── solo host
+    └── Quest Room host (future realtime adapter)
+              │
+              ▼
+      ActivityPublicState
+```
+
+## V1 runtime contract
+
+`backend/app/activities.py` defines:
+
+- `ActivityDefinition` — capabilities, card requirements, timer policy, and scoring identity.
+- `ActivityRuntime` — internal deterministic runtime state. This object may contain answer-bearing round data and must not be serialized directly to clients.
+- `ActivityPublicState` — the only phase-safe state intended for a browser or future room participant.
+- `ActivityEvent` — explicit lifecycle transitions such as `round.locked`, `answer.revealed`, and `round.completed`.
+- `ActivityParticipantState` — per-player score/streak/response state. It is intentionally separate from durable FlashQuest mastery.
+
+The frontend mirror lives in `frontend/src/activityTypes.ts`.
+
+## Phase safety
+
+Correct-answer metadata is an internal runtime concern until reveal. Before a runtime reaches `reveal` or `result`, `ActivityPublicState.reveal` is `null`.
+
+For Multiple-Choice Blitz, the prompt may contain the four possible answer texts because the learner needs to choose among them, but it does **not** contain the correct choice id or a separate answer field. For Match Quest, the prompt contains shuffled terms and definitions but not the answer mapping.
+
+This matters for Quest Rooms: hiding an answer with CSS is not security. The room server must avoid sending answer-bearing payloads until the synchronized reveal transition.
+
+## Determinism
+
+Activities accept a session seed. The same deck content and seed produce the same shuffled activity state, which helps with:
+
+- synchronized room rounds,
+- reconnect debugging,
+- reproducible tests,
+- incident diagnosis when a generated round behaves unexpectedly.
+
+If a caller does not supply a seed, FlashQuest derives one from the activity/deck/card identity.
+
+## First adapters
+
+### Multiple-Choice Blitz
+
+- Minimum: 4 cards.
+- A target prompt is paired with its correct definition and up to three distractors from compatible cards.
+- Choices are shuffled deterministically.
+- The correct choice id and answer appear only after reveal.
+
+### Match Quest
+
+- Minimum: 3 cards.
+- Prompts and definitions are shuffled independently into one matching board.
+- The term-to-definition answer map appears only after reveal.
+
+Both adapters can be built in `solo` or `room` mode from the same definition/runtime code.
+
+## Progress boundary
+
+Activity scoring and durable learning progress are deliberately separate.
+
+A later progress adapter can translate a participant result into a FlashQuest study result such as `correct` or `wrong`. A room's team score, aggregate percentage, or combo must never mutate another participant's spaced-repetition state.
+
+## Accessibility and game feel
+
+Activities should consume shared platform behavior rather than invent local alternatives:
+
+- global sound/motion semantics from the game-feel system,
+- reduced-motion behavior,
+- keyboard operation,
+- visible/text feedback that does not rely only on color or sound,
+- optional/no-timer presentation where the activity definition permits it.
+
+These concerns are tracked by the adaptable-mode/accessibility work and remain presentation choices; they do not change the learning content stored in a deck.
+
+## What is intentionally not in V1
+
+This contract does **not** add:
+
+- database persistence for activity sessions,
+- WebSocket transport,
+- room membership/presence,
+- matchmaking,
+- leaderboards,
+- a payment boundary,
+- game-specific fields on every card.
+
+Those features can build around the runtime after the contract is proven, rather than forcing the contract to depend on them first.

--- a/frontend/src/activityTypes.ts
+++ b/frontend/src/activityTypes.ts
@@ -1,0 +1,77 @@
+export type ActivityType =
+  | "blitz"
+  | "match"
+  | "sort"
+  | "order"
+  | "recall"
+  | "debug"
+  | "story"
+  | "boss";
+
+export type ActivityMode = "solo" | "room";
+export type ActivityPhase =
+  | "lobby"
+  | "prompt"
+  | "hint"
+  | "locked"
+  | "reveal"
+  | "result"
+  | "complete";
+export type TimerPolicy = "none" | "optional" | "required";
+
+export interface ActivityDefinition {
+  id: string;
+  version: number;
+  type: ActivityType;
+  title: string;
+  description: string;
+  min_cards: number;
+  max_cards: number;
+  compatible_kinds: string[];
+  timer_policy: TimerPolicy;
+  supports_hints: boolean;
+  supports_reveal: boolean;
+  supports_teams: boolean;
+  supports_late_join: boolean;
+  score_rule: string;
+}
+
+export interface ActivityParticipantState {
+  participant_id: string;
+  score: number;
+  streak: number;
+  response: string | null;
+  confidence: number | null;
+  round_complete: boolean;
+}
+
+export interface ActivityEvent {
+  type: string;
+  participant_id?: string | null;
+  payload?: Record<string, unknown>;
+}
+
+export interface ActivityPublicState {
+  session_id: string;
+  definition: ActivityDefinition;
+  mode: ActivityMode;
+  phase: ActivityPhase;
+  deck_id: number;
+  card_ids: number[];
+  round_index: number;
+  total_rounds: number;
+  seed: number;
+  payload: Record<string, unknown>;
+  reveal: Record<string, unknown> | null;
+  participants: ActivityParticipantState[];
+}
+
+/**
+ * The browser only consumes ActivityPublicState. Correct-answer fields belong in
+ * `reveal` and should remain null until the runtime reaches a reveal/result phase.
+ * Quest Rooms will synchronize this same shape instead of inventing a second
+ * multiplayer game contract.
+ */
+export function isActivityRevealed(state: ActivityPublicState): boolean {
+  return state.phase === "reveal" || state.phase === "result";
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: FlashQuest’s
-site_description: A reusable game-like study engine with a featured Platform Engineering deck, private custom decks, and spaced repetition.
+site_name: FlashQuest
+site_description: A game-like learning platform with spaced repetition, a public deck Library, community remixing, and reusable Arcade foundations.
 site_url: https://flashquest-docs.netlify.app/
 repo_name: mergemaven11/FlashQuest
 repo_url: https://github.com/mergemaven11/FlashQuest
@@ -64,7 +64,7 @@ extra_css:
 
 nav:
   - Home: index.md
-  - Open FlashQuest’s: https://flaskquest.netlify.app/
+  - Open FlashQuest: https://flaskquest.netlify.app/
   - Product:
       - Make Your Own Deck: MAKE_YOUR_OWN_DECK.md
       - Accounts & Email Verification: AUTHENTICATION.md
@@ -73,6 +73,7 @@ nav:
       - Break/Fix Labs: LABS.md
   - Engineering:
       - Architecture & Design: PLATFORM_ENGINEERING.md
+      - Arcade Activity Contract: ARCADE_ACTIVITY_CONTRACT.md
       - Operations & Deployment: OPERATIONS.md
   - Reference:
       - Backend API: backend/api.md
@@ -82,4 +83,4 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/mergemaven11/FlashQuest
-      name: FlashQuest’s on GitHub
+      name: FlashQuest on GitHub


### PR DESCRIPTION
## What changed

Implements the first concrete slice of #21: one reusable activity runtime that can power solo Arcade and future Quest Room-hosted games without adding game-specific fields to Deck/Card persistence.

### Shared runtime contract
- Adds `ActivityDefinition`, `ActivityRuntime`, `ActivityPublicState`, `ActivityEvent`, and per-participant runtime state.
- Separates internal answer-bearing runtime data from the phase-safe public state that a browser/room participant may receive.
- Adds explicit lifecycle phases and events for prompt → lock/reveal → next round/complete.
- Keeps durable spaced-repetition mastery outside the multiplayer/team score model.
- Mirrors the public contract in TypeScript for future Arcade/Quest Room UI.

### First two adapters
- **Multiple-Choice Blitz**: deck prompt + shuffled definition choices, deterministic by seed.
- **Match Quest**: shuffled prompt/definition board with the answer map withheld until reveal.
- Both adapters run through the same code in `solo` or `room` mode.

### Spoiler boundary
- Pre-reveal public state never contains `correct_choice_id`, a separate `answer`, or Match Quest's `answer_map`.
- Correct-answer payloads appear only after an explicit `answer.revealed` transition.
- This is designed for future server-controlled Quest Room synchronization rather than trusting CSS/UI to hide answers.

### Determinism + tests
- Activities accept deterministic session seeds for synchronized rounds/replay/debugging.
- Tests cover deterministic Blitz generation, spoiler-safe serialization, reveal transitions, round progression, solo vs room parity, Match Quest, validation, deduplication, and invalid transitions.

### Docs
- Adds an Arcade Activity Contract architecture page.
- Documents persistence/runtime/room boundaries, progress ownership, accessibility integration, and intentionally deferred WebSocket/persistence concerns.
- Refreshes the docs brand text from the old possessive `FlashQuest’s` wording.

## Scope boundary
This does **not** add WebSocket transport, activity persistence, matchmaking, leaderboards, or full Arcade UI. Those now have a stable contract to build on instead of dictating one later.

Closes #21