### PR TITLE
Add adaptable learning experience preferences

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, NavLink, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "./auth";
+import { ExperienceProvider } from "./experience";
 import { GameFeelProvider, SoundToggle } from "./gameFeel";
 import Admin from "./pages/Admin";
 import Landing from "./pages/Landing";
@@ -7,6 +8,7 @@ import Library from "./pages/Library";
 import LibraryDeck from "./pages/LibraryDeck";
 import Login from "./pages/Login";
 import MyDecks from "./pages/MyDecks";
+import Preferences from "./pages/Preferences";
 import Signup from "./pages/Signup";
 import Status from "./pages/Status";
 import Study from "./pages/Study";
@@ -48,6 +50,14 @@ function Shell() {
               ))}
             </nav>
             <SoundToggle />
+            <NavLink
+              to="/preferences"
+              aria-label="Experience settings"
+              title="Experience settings"
+              className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
+            >
+              <span aria-hidden="true">🎚️</span><span className="hidden xl:inline">Experience</span>
+            </NavLink>
             <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
             {user ? (
               <div className="flex items-center gap-2">
@@ -71,6 +81,7 @@ function Shell() {
           <Route path="/admin" element={<Navigate to="/deck-lab" replace />} />
           <Route path="/decks" element={<MyDecks />} />
           <Route path="/status" element={<Status />} />
+          <Route path="/preferences" element={<Preferences />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/verify-email" element={<VerifyEmail />} />
@@ -79,7 +90,7 @@ function Shell() {
       </main>
 
       <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-        <span>Library · community decks · Platform Engineering · 12 mastery levels</span>
+        <span>Library · community decks · Arcade foundation · adaptable learning modes</span>
         <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>
       </footer>
     </div>
@@ -88,12 +99,14 @@ function Shell() {
 
 export default function App() {
   return (
-    <GameFeelProvider>
-      <BrowserRouter>
-        <AuthProvider>
-          <Shell />
-        </AuthProvider>
-      </BrowserRouter>
-    </GameFeelProvider>
+    <ExperienceProvider>
+      <GameFeelProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <Shell />
+          </AuthProvider>
+        </BrowserRouter>
+      </GameFeelProvider>
+    </ExperienceProvider>
   );
 }

--- a/frontend/src/activityTypes.ts
+++ b/frontend/src/activityTypes.ts
@@ -1,3 +1,5 @@
+import type { ExperiencePolicy } from "./experienceContext";
+
 export type ActivityType =
   | "blitz"
   | "match"
@@ -74,4 +76,19 @@ export interface ActivityPublicState {
  */
 export function isActivityRevealed(state: ActivityPublicState): boolean {
   return state.phase === "reveal" || state.phase === "result";
+}
+
+/**
+ * Resolve an activity's timer against the learner's current presentation policy.
+ * Required timers remain part of games whose rules depend on them; optional
+ * timers disappear in Chill/Focus mode without changing the underlying deck or
+ * durable progress.
+ */
+export function shouldUseActivityTimer(
+  definition: ActivityDefinition,
+  policy: ExperiencePolicy
+): boolean {
+  if (definition.timer_policy === "required") return true;
+  if (definition.timer_policy === "none") return false;
+  return policy.allowOptionalTimers;
 }

--- a/frontend/src/experience.tsx
+++ b/frontend/src/experience.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  ExperienceContext,
+  type ExperiencePolicy,
+  type ExperiencePreferences,
+  type LearningMode,
+  type MotionPreference,
+  type TextScale,
+} from "./experienceContext";
+
+const EXPERIENCE_KEY = "flashquest-experience-preferences-v1";
+
+const DEFAULT_PREFERENCES: ExperiencePreferences = {
+  learningMode: "arcade",
+  motionPreference: "system",
+  textScale: "default",
+  highContrast: false,
+  captionsEnabled: true,
+};
+
+function readPreferences(): ExperiencePreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(EXPERIENCE_KEY);
+    if (!raw) return DEFAULT_PREFERENCES;
+    const parsed = JSON.parse(raw) as Partial<ExperiencePreferences>;
+    const learningMode: LearningMode = ["arcade", "chill", "focus", "party"].includes(
+      parsed.learningMode ?? ""
+    )
+      ? (parsed.learningMode as LearningMode)
+      : DEFAULT_PREFERENCES.learningMode;
+    const motionPreference: MotionPreference = parsed.motionPreference === "reduced"
+      ? "reduced"
+      : "system";
+    const textScale: TextScale = parsed.textScale === "large" ? "large" : "default";
+    return {
+      learningMode,
+      motionPreference,
+      textScale,
+      highContrast: parsed.highContrast === true,
+      captionsEnabled: parsed.captionsEnabled !== false,
+    };
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+function persist(preferences: ExperiencePreferences) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(EXPERIENCE_KEY, JSON.stringify(preferences));
+  }
+}
+
+export function ExperienceProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferences] = useState<ExperiencePreferences>(readPreferences);
+  const [systemReducedMotion, setSystemReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setSystemReducedMotion(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  const reducedMotion = preferences.motionPreference === "reduced" || systemReducedMotion;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.learningMode = preferences.learningMode;
+    root.dataset.reducedMotion = String(reducedMotion);
+    root.dataset.textScale = preferences.textScale;
+    root.dataset.highContrast = String(preferences.highContrast);
+    root.dataset.captions = String(preferences.captionsEnabled);
+  }, [preferences, reducedMotion]);
+
+  const update = useCallback((patch: Partial<ExperiencePreferences>) => {
+    setPreferences((current) => {
+      const next = { ...current, ...patch };
+      persist(next);
+      return next;
+    });
+  }, []);
+
+  const resetPreferences = useCallback(() => {
+    persist(DEFAULT_PREFERENCES);
+    setPreferences(DEFAULT_PREFERENCES);
+  }, []);
+
+  const policy = useMemo<ExperiencePolicy>(
+    () => ({
+      allowOptionalTimers:
+        preferences.learningMode === "arcade" || preferences.learningMode === "party",
+      encourageHints: preferences.learningMode === "chill",
+      minimizeVisualNoise: preferences.learningMode === "focus",
+      partyPresentation: preferences.learningMode === "party",
+      reducedMotion,
+    }),
+    [preferences.learningMode, reducedMotion]
+  );
+
+  const value = useMemo(
+    () => ({
+      preferences,
+      policy,
+      setLearningMode: (learningMode: LearningMode) => update({ learningMode }),
+      setMotionPreference: (motionPreference: MotionPreference) => update({ motionPreference }),
+      setTextScale: (textScale: TextScale) => update({ textScale }),
+      setHighContrast: (highContrast: boolean) => update({ highContrast }),
+      setCaptionsEnabled: (captionsEnabled: boolean) => update({ captionsEnabled }),
+      resetPreferences,
+    }),
+    [preferences, policy, resetPreferences, update]
+  );
+
+  return <ExperienceContext.Provider value={value}>{children}</ExperienceContext.Provider>;
+}

--- a/frontend/src/experienceContext.ts
+++ b/frontend/src/experienceContext.ts
@@ -1,0 +1,40 @@
+import { createContext, useContext } from "react";
+
+export type LearningMode = "arcade" | "chill" | "focus" | "party";
+export type MotionPreference = "system" | "reduced";
+export type TextScale = "default" | "large";
+
+export type ExperiencePreferences = {
+  learningMode: LearningMode;
+  motionPreference: MotionPreference;
+  textScale: TextScale;
+  highContrast: boolean;
+  captionsEnabled: boolean;
+};
+
+export type ExperiencePolicy = {
+  allowOptionalTimers: boolean;
+  encourageHints: boolean;
+  minimizeVisualNoise: boolean;
+  partyPresentation: boolean;
+  reducedMotion: boolean;
+};
+
+export type ExperienceValue = {
+  preferences: ExperiencePreferences;
+  policy: ExperiencePolicy;
+  setLearningMode: (mode: LearningMode) => void;
+  setMotionPreference: (preference: MotionPreference) => void;
+  setTextScale: (scale: TextScale) => void;
+  setHighContrast: (enabled: boolean) => void;
+  setCaptionsEnabled: (enabled: boolean) => void;
+  resetPreferences: () => void;
+};
+
+export const ExperienceContext = createContext<ExperienceValue | null>(null);
+
+export function useExperience(): ExperienceValue {
+  const value = useContext(ExperienceContext);
+  if (!value) throw new Error("useExperience must be used inside ExperienceProvider");
+  return value;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,7 @@
 
 * { box-sizing: border-box; }
 html { min-width: 320px; background: var(--ink-black); }
+html[data-text-scale="large"] { font-size: 112.5%; }
 body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--ink-black); }
 button, input, textarea, select { font: inherit; }
 button { cursor: pointer; }
@@ -198,6 +199,43 @@ select.game-input option { background: var(--ink-black); color: white; }
   0% { transform: translateY(8px) scale(.9); opacity: 0; }
   70% { transform: translateY(-2px) scale(1.04); opacity: 1; }
   100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+/* Experience preferences are presentation-only. They never alter study data. */
+html[data-learning-mode="focus"] .game-grid { display: none; }
+html[data-learning-mode="focus"] .floaty { animation: none; }
+html[data-learning-mode="focus"] .game-page-enter { animation-duration: 80ms; }
+html[data-learning-mode="focus"] .game-panel,
+html[data-learning-mode="focus"] .quest-card {
+  backdrop-filter: none;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, .24);
+}
+html[data-learning-mode="focus"] .quest-card::after { display: none; }
+
+html[data-high-contrast="true"] .game-panel,
+html[data-high-contrast="true"] .quest-card,
+html[data-high-contrast="true"] .game-chip,
+html[data-high-contrast="true"] .game-input,
+html[data-high-contrast="true"] .deck-input {
+  border-color: rgba(255, 255, 255, .3);
+}
+html[data-high-contrast="true"] .game-panel {
+  background: rgba(3, 7, 30, .96);
+}
+html[data-high-contrast="true"] .game-chip { background: rgba(255, 255, 255, .1); }
+html[data-high-contrast="true"] :where(.text-slate-400, .text-slate-500) { color: #cbd5e1; }
+html[data-high-contrast="true"] :where(a, button, input, textarea, select):focus-visible {
+  outline-width: 3px;
+  outline-color: #ffba08;
+}
+
+html[data-reduced-motion="true"] *,
+html[data-reduced-motion="true"] *::before,
+html[data-reduced-motion="true"] *::after {
+  scroll-behavior: auto !important;
+  animation-duration: .01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: .01ms !important;
 }
 
 @media (max-width: 480px) {

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -1,0 +1,213 @@
+import { useExperience } from "../experienceContext";
+import { useGameFeel } from "../gameFeelContext";
+import type { LearningMode } from "../experienceContext";
+
+const modes: Array<{
+  value: LearningMode;
+  icon: string;
+  title: string;
+  detail: string;
+  note: string;
+}> = [
+  {
+    value: "arcade",
+    icon: "⚡",
+    title: "Arcade",
+    detail: "Lively feedback, combos, and optional timers when a game supports them.",
+    note: "Best when you want pace and game energy.",
+  },
+  {
+    value: "chill",
+    icon: "🌿",
+    title: "Chill",
+    detail: "No optional timers. Hints are encouraged and the pressure stays low.",
+    note: "Same learning progress, calmer presentation.",
+  },
+  {
+    value: "focus",
+    icon: "🧠",
+    title: "Focus",
+    detail: "Cuts decorative motion and background noise so the material stays central.",
+    note: "Useful when you want fewer competing signals.",
+  },
+  {
+    value: "party",
+    icon: "👥",
+    title: "Party",
+    detail: "Room-friendly presentation for shared rounds, team feedback, and group play.",
+    note: "The Quest Room layer will use this mode automatically where appropriate.",
+  },
+];
+
+export default function Preferences() {
+  const {
+    preferences,
+    policy,
+    setLearningMode,
+    setMotionPreference,
+    setTextScale,
+    setHighContrast,
+    setCaptionsEnabled,
+    resetPreferences,
+  } = useExperience();
+  const { soundEnabled, setSoundEnabled } = useGameFeel();
+
+  return (
+    <div className="mx-auto grid max-w-5xl gap-6">
+      <section>
+        <p className="metric-label">🎚️ Experience settings</p>
+        <h1 className="mt-2 text-4xl font-black tracking-tight text-white sm:text-5xl">
+          Learn your way <span className="ember-text">right now.</span>
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
+          These are presentation preferences, not permanent learner labels. Switch whenever the subject, environment, or your mood changes — your decks and mastery stay the same.
+        </p>
+      </section>
+
+      <section className="game-panel p-5 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="metric-label">Learning mode</p>
+            <h2 className="mt-1 text-2xl font-black text-white">Choose the vibe, not an identity.</h2>
+          </div>
+          <span className="game-chip px-3 py-1.5 text-xs font-black capitalize text-[#ffba08]">
+            Current · {preferences.learningMode}
+          </span>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          {modes.map((mode) => {
+            const active = preferences.learningMode === mode.value;
+            return (
+              <button
+                key={mode.value}
+                type="button"
+                aria-pressed={active}
+                className={`game-button min-h-40 border p-5 text-left ${
+                  active
+                    ? "border-[#faa307]/60 bg-[#faa307]/10"
+                    : "border-white/10 bg-black/15 hover:border-[#faa307]/30"
+                }`}
+                onClick={() => setLearningMode(mode.value)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span className="text-3xl" aria-hidden="true">{mode.icon}</span>
+                  <span className={`text-xs font-black uppercase tracking-[0.14em] ${active ? "text-[#ffba08]" : "text-slate-500"}`}>
+                    {active ? "Selected" : "Choose"}
+                  </span>
+                </div>
+                <h3 className="mt-4 text-xl font-black text-white">{mode.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">{mode.detail}</p>
+                <p className="mt-2 text-xs leading-5 text-slate-500">{mode.note}</p>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="game-panel p-5 sm:p-6">
+          <p className="metric-label">Motion & visibility</p>
+          <h2 className="mt-1 text-xl font-black text-white">Make the interface easier to follow.</h2>
+
+          <div className="mt-5 grid gap-4">
+            <label className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span>
+                <strong className="block text-sm font-black text-white">Reduce motion</strong>
+                <span className="mt-1 block text-xs leading-5 text-slate-400">System follows your device setting. Reduced explicitly removes nonessential motion.</span>
+              </span>
+              <select
+                className="game-input max-w-32"
+                aria-label="Motion preference"
+                value={preferences.motionPreference}
+                onChange={(event) => setMotionPreference(event.target.value === "reduced" ? "reduced" : "system")}
+              >
+                <option value="system">System</option>
+                <option value="reduced">Reduced</option>
+              </select>
+            </label>
+
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span>
+                <strong className="block text-sm font-black text-white">Larger text</strong>
+                <span className="mt-1 block text-xs leading-5 text-slate-400">Increase the app-wide text scale while keeping layouts responsive.</span>
+              </span>
+              <input
+                type="checkbox"
+                className="h-5 w-5 accent-[#faa307]"
+                checked={preferences.textScale === "large"}
+                onChange={(event) => setTextScale(event.target.checked ? "large" : "default")}
+              />
+            </label>
+
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span>
+                <strong className="block text-sm font-black text-white">Higher contrast</strong>
+                <span className="mt-1 block text-xs leading-5 text-slate-400">Strengthen panel borders, text contrast, and control separation.</span>
+              </span>
+              <input
+                type="checkbox"
+                className="h-5 w-5 accent-[#faa307]"
+                checked={preferences.highContrast}
+                onChange={(event) => setHighContrast(event.target.checked)}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="game-panel p-5 sm:p-6">
+          <p className="metric-label">Audio & comprehension</p>
+          <h2 className="mt-1 text-xl font-black text-white">Sound should help, never carry meaning alone.</h2>
+
+          <div className="mt-5 grid gap-4">
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span>
+                <strong className="block text-sm font-black text-white">Game sounds</strong>
+                <span className="mt-1 block text-xs leading-5 text-slate-400">Feedback sounds stay optional; every important state also has visible text/UI feedback.</span>
+              </span>
+              <input
+                type="checkbox"
+                className="h-5 w-5 accent-[#faa307]"
+                checked={soundEnabled}
+                onChange={(event) => setSoundEnabled(event.target.checked)}
+              />
+            </label>
+
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <span>
+                <strong className="block text-sm font-black text-white">Captions / text equivalents</strong>
+                <span className="mt-1 block text-xs leading-5 text-slate-400">Keep text equivalents enabled for future narrated/audio activities and room cues.</span>
+              </span>
+              <input
+                type="checkbox"
+                className="h-5 w-5 accent-[#faa307]"
+                checked={preferences.captionsEnabled}
+                onChange={(event) => setCaptionsEnabled(event.target.checked)}
+              />
+            </label>
+          </div>
+        </div>
+      </section>
+
+      <section className="game-panel grid gap-4 p-5 sm:p-6 lg:grid-cols-[1fr_auto] lg:items-center">
+        <div>
+          <p className="metric-label">Effective activity policy</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs font-bold text-slate-300">
+            <span className="game-chip px-3 py-1.5">{policy.allowOptionalTimers ? "⏱️ Optional timers allowed" : "🌿 Optional timers off"}</span>
+            <span className="game-chip px-3 py-1.5">{policy.encourageHints ? "💡 Hints encouraged" : "💡 Hints available by activity"}</span>
+            <span className="game-chip px-3 py-1.5">{policy.minimizeVisualNoise ? "🧠 Minimal visual noise" : "✨ Standard visual layer"}</span>
+            <span className="game-chip px-3 py-1.5">{policy.reducedMotion ? "🛑 Reduced motion" : "🎞️ System motion"}</span>
+          </div>
+          <p className="mt-3 text-xs leading-5 text-slate-500">Activities consume this policy; changing it does not alter card answers, XP history, spaced-repetition bins, or deck ownership.</p>
+        </div>
+        <button
+          type="button"
+          className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white"
+          onClick={resetPreferences}
+        >
+          Reset experience settings
+        </button>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

Implements the first app-wide accessibility/presentation foundation for issue #22 without introducing fixed “learning style” labels or changing durable mastery data.

### Learning modes
- Adds persisted **Arcade**, **Chill**, **Focus**, and **Party** presentation preferences.
- Treats modes as temporary choices for the current subject/context, not learner identities.
- Arcade/Party permit optional timers; Chill/Focus suppress optional timers through the shared ActivityDefinition policy.
- Chill encourages hints; Focus reduces decorative visual noise; Party provides the room-oriented presentation policy for future Quest Rooms.

### App-wide accessibility controls
- Adds `/preferences` and a compact Experience control in the global shell.
- Manual Reduced Motion can be selected while still honoring the device `prefers-reduced-motion` setting.
- Adds larger-text and higher-contrast options with persisted local preferences.
- Reuses the existing global sound control and adds a captions/text-equivalent preference hook for future narrated/audio activities.
- Important feedback remains visible/textual rather than sound/color-only.

### Shared presentation policy
- Adds `ExperienceProvider` / `ExperiencePolicy` so Study, Arcade, and future Quest Rooms can consume one preference model.
- Applies effective preferences through app-level data attributes rather than page-specific CSS systems.
- Adds `shouldUseActivityTimer()` so activity timer policy is resolved centrally: required stays required, none stays off, optional follows the current experience mode.
- Switching presentation modes never changes decks, card answers, XP history, ownership, or spaced-repetition state.

### Responsive/performance posture
- No new npm dependencies or blocking assets.
- Focus mode removes decorative grid/glow work and reduces visual effects.
- Larger text remains rem-based so responsive layouts can adapt rather than using fixed pixel zooms.
- Existing 320px mobile floor, touch controls, focus-visible treatment, and global reduced-motion fallback remain intact.

## Scope boundary
This is the core preference/policy layer for #22. Age/grade suitability metadata, actual narrated activity captions, and explicit keyboard acceptance tests for the upcoming playable Arcade UI remain follow-up work, so this PR is **Part of #22** rather than closing it.

Part of #22