### PR TITLE
Ship first playable solo Arcade modes

### DIFF
--- a/backend/app/activities.py
+++ b/backend/app/activities.py
@@ -144,6 +144,7 @@ class ActivityRuntime:
     rounds: tuple[_ActivityRound, ...]
     round_index: int = 0
     participants: tuple[ActivityParticipantState, ...] = ()
+    round_result: dict[str, Any] | None = None
 
 
 BLITZ_DEFINITION = ActivityDefinition(
@@ -313,6 +314,98 @@ def build_activity_runtime(
     )
 
 
+def _participant(
+    runtime: ActivityRuntime, participant_id: str
+) -> ActivityParticipantState:
+    """Return one participant's current game-only score state."""
+    return next(
+        (
+            participant
+            for participant in runtime.participants
+            if participant.participant_id == participant_id
+        ),
+        ActivityParticipantState(participant_id=participant_id),
+    )
+
+
+def _with_participant(
+    runtime: ActivityRuntime, participant: ActivityParticipantState
+) -> tuple[ActivityParticipantState, ...]:
+    """Replace or append one participant in immutable runtime state."""
+    rows = [
+        current
+        for current in runtime.participants
+        if current.participant_id != participant.participant_id
+    ]
+    rows.append(participant)
+    return tuple(rows)
+
+
+def _score_blitz_response(
+    runtime: ActivityRuntime, event: ActivityEvent
+) -> ActivityRuntime:
+    """Score one Blitz choice without trusting the browser with the answer key."""
+    current = runtime.rounds[runtime.round_index]
+    choice_id = str(event.payload.get("choice_id") or "")
+    correct = choice_id == current.reveal["correct_choice_id"]
+    participant_id = event.participant_id or "solo"
+    participant = _participant(runtime, participant_id)
+    points = 100 if correct else 0
+    updated = participant.model_copy(
+        update={
+            "score": participant.score + points,
+            "streak": participant.streak + 1 if correct else 0,
+            "response": "correct" if correct else "wrong",
+            "round_complete": True,
+        }
+    )
+    return replace(
+        runtime,
+        phase=ActivityPhase.RESULT,
+        participants=_with_participant(runtime, updated),
+        round_result={"correct": correct, "points": points},
+    )
+
+
+def _score_match_response(
+    runtime: ActivityRuntime, event: ActivityEvent
+) -> ActivityRuntime:
+    """Score a Match board using the internal answer map."""
+    current = runtime.rounds[runtime.round_index]
+    raw_matches = event.payload.get("matches")
+    submitted = raw_matches if isinstance(raw_matches, dict) else {}
+    answer_map = current.reveal["answer_map"]
+    correct_count = sum(
+        1
+        for card_id, choice_id in answer_map.items()
+        if str(submitted.get(card_id) or "") == choice_id
+    )
+    total = len(answer_map)
+    points = round((correct_count / total) * 500) if total else 0
+    perfect = correct_count == total and total > 0
+    participant_id = event.participant_id or "solo"
+    participant = _participant(runtime, participant_id)
+    updated = participant.model_copy(
+        update={
+            "score": participant.score + points,
+            "streak": participant.streak + 1 if perfect else 0,
+            "response": f"{correct_count}/{total}",
+            "round_complete": True,
+        }
+    )
+    return replace(
+        runtime,
+        phase=ActivityPhase.RESULT,
+        participants=_with_participant(runtime, updated),
+        round_result={
+            "correct_count": correct_count,
+            "total": total,
+            "perfect": perfect,
+            "points": points,
+        },
+    )
+
+
 def public_activity_state(runtime: ActivityRuntime) -> ActivityPublicState:
     """Serialize only data safe for the runtime's current phase."""
     if runtime.phase == ActivityPhase.COMPLETE:
@@ -321,10 +414,13 @@ def public_activity_state(runtime: ActivityRuntime) -> ActivityPublicState:
     else:
         current = runtime.rounds[runtime.round_index]
         payload = current.payload
-        reveal = current.reveal if runtime.phase in {
-            ActivityPhase.REVEAL,
-            ActivityPhase.RESULT,
-        } else None
+        reveal = (
+            {**current.reveal, "result": runtime.round_result}
+            if runtime.phase == ActivityPhase.RESULT
+            else current.reveal
+            if runtime.phase == ActivityPhase.REVEAL
+            else None
+        )
 
     return ActivityPublicState(
         session_id=runtime.session_id,
@@ -343,24 +439,45 @@ def public_activity_state(runtime: ActivityRuntime) -> ActivityPublicState:
 
 
 def apply_activity_event(runtime: ActivityRuntime, event: ActivityEvent) -> ActivityRuntime:
-    """Apply a minimal deterministic lifecycle transition used by solo/room hosts."""
+    """Apply a deterministic lifecycle/game event used by solo and room hosts."""
+    if event.type == "response.submitted":
+        if runtime.phase not in {ActivityPhase.PROMPT, ActivityPhase.LOCKED}:
+            raise ValueError("response.submitted is only valid before reveal")
+        if runtime.definition.type == ActivityType.BLITZ:
+            return _score_blitz_response(runtime, event)
+        if runtime.definition.type == ActivityType.MATCH:
+            return _score_match_response(runtime, event)
+        raise ValueError(
+            f"No scoring adapter for activity type: {runtime.definition.type.value}"
+        )
     if event.type == "round.locked":
         return replace(runtime, phase=ActivityPhase.LOCKED)
     if event.type == "answer.revealed":
         if runtime.phase not in {ActivityPhase.PROMPT, ActivityPhase.LOCKED}:
             raise ValueError("answer.revealed is only valid during prompt/locked phases")
-        return replace(runtime, phase=ActivityPhase.REVEAL)
+        return replace(runtime, phase=ActivityPhase.REVEAL, round_result=None)
     if event.type == "round.completed":
         if runtime.phase not in {ActivityPhase.REVEAL, ActivityPhase.RESULT}:
             raise ValueError("round.completed requires a revealed round")
         next_index = runtime.round_index + 1
+        reset_participants = tuple(
+            participant.model_copy(update={"response": None, "round_complete": False})
+            for participant in runtime.participants
+        )
         if next_index >= len(runtime.rounds):
-            return replace(runtime, phase=ActivityPhase.COMPLETE)
+            return replace(
+                runtime,
+                phase=ActivityPhase.COMPLETE,
+                participants=reset_participants,
+                round_result=None,
+            )
         return replace(
             runtime,
             round_index=next_index,
             phase=ActivityPhase.PROMPT,
+            participants=reset_participants,
+            round_result=None,
         )
     if event.type == "session.completed":
-        return replace(runtime, phase=ActivityPhase.COMPLETE)
+        return replace(runtime, phase=ActivityPhase.COMPLETE, round_result=None)
     raise ValueError(f"Unsupported activity event: {event.type}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 
 from .config import settings
 from .db import get_session
-from .routers import auth, cards, decks, study
+from .routers import activities, auth, cards, decks, study
 
 
 def _allowed_origins() -> list[str]:
@@ -73,6 +73,7 @@ app.include_router(auth.router)
 app.include_router(decks.router)
 app.include_router(cards.router)
 app.include_router(study.router)
+app.include_router(activities.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from threading import Lock
 from time import monotonic
 
@@ -170,12 +170,7 @@ def start_activity(
 
     # Runtime adapters are deterministic by seed, while HTTP sessions need a
     # collision-resistant capability id so two learners can replay one seed safely.
-    runtime = ActivityRuntime(
-        **{
-            **runtime.__dict__,
-            "session_id": secrets.token_urlsafe(18),
-        }
-    )
+    runtime = replace(runtime, session_id=secrets.token_urlsafe(18))
     _store(runtime, owner_key)
     return public_activity_state(runtime)
 

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -1,0 +1,209 @@
+"""HTTP host for the first playable solo FlashQuest Arcade sessions.
+
+V1 sessions are deliberately ephemeral in-process state. The ActivityRuntime is
+transport-neutral and can later be hosted by persistent/realtime Quest Room
+infrastructure without changing the game adapters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from threading import Lock
+from time import monotonic
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel, Field
+from sqlmodel import Session, select
+
+from ..activities import (
+    ActivityCard,
+    ActivityEvent,
+    ActivityMode,
+    ActivityPublicState,
+    ActivityRuntime,
+    ActivityType,
+    apply_activity_event,
+    build_activity_runtime,
+    public_activity_state,
+)
+from ..db import get_session
+from ..models import Card, Deck, User
+from ..security import get_optional_user
+
+router = APIRouter(prefix="/activities", tags=["activities"])
+SESSION_TTL_SECONDS = 2 * 60 * 60
+MAX_SESSIONS = 500
+
+
+class ActivityStartRequest(BaseModel):
+    """Request to create one deterministic solo Arcade run."""
+
+    deck_id: int = Field(gt=0)
+    activity_type: ActivityType
+    round_count: int = Field(default=5, ge=1, le=20)
+    seed: int | None = Field(default=None, ge=0)
+
+
+@dataclass
+class _StoredRuntime:
+    runtime: ActivityRuntime
+    owner_key: str
+    touched_at: float
+
+
+_sessions: dict[str, _StoredRuntime] = {}
+_sessions_lock = Lock()
+
+
+def _owner_key(user: User | None, demo_session: str | None) -> str:
+    """Bind ephemeral game state to an account or anonymous browser session."""
+    if user is not None:
+        return f"user:{int(user.id or 0)}"
+    token = (demo_session or "").strip()
+    if not token:
+        raise HTTPException(
+            status_code=400,
+            detail="Anonymous Arcade requires an X-Demo-Session browser session",
+        )
+    digest = hashlib.blake2b(token[:128].encode("utf-8"), digest_size=12).hexdigest()
+    return f"demo:{digest}"
+
+
+def _accessible_deck(session: Session, deck_id: int, user: User | None) -> Deck:
+    """Enforce the same private/public/unlisted boundary used by Study."""
+    deck = session.get(Deck, deck_id)
+    if deck is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    owner = user is not None and deck.owner_id == user.id
+    shareable = deck.is_builtin or deck.visibility in {"public", "unlisted"}
+    if shareable or owner:
+        return deck
+    if user is None:
+        raise HTTPException(status_code=401, detail="Sign in to play this private deck")
+    raise HTTPException(status_code=403, detail="This deck is private")
+
+
+def _activity_cards(session: Session, deck_id: int) -> list[ActivityCard]:
+    """Load deck content into the transport-neutral activity card shape."""
+    cards = session.exec(select(Card).where(Card.deck_id == deck_id).order_by(Card.id)).all()
+    return [
+        ActivityCard(
+            id=int(card.id or 0),
+            word=card.word,
+            definition=card.definition,
+            domain=card.domain,
+            kind=card.kind,
+        )
+        for card in cards
+    ]
+
+
+def _cleanup_sessions(now: float) -> None:
+    """Bound ephemeral memory without a background cleanup task."""
+    expired = [
+        session_id
+        for session_id, record in _sessions.items()
+        if now - record.touched_at > SESSION_TTL_SECONDS
+    ]
+    for session_id in expired:
+        _sessions.pop(session_id, None)
+
+    if len(_sessions) <= MAX_SESSIONS:
+        return
+    oldest = sorted(_sessions.items(), key=lambda item: item[1].touched_at)
+    for session_id, _record in oldest[: len(_sessions) - MAX_SESSIONS]:
+        _sessions.pop(session_id, None)
+
+
+def _store(runtime: ActivityRuntime, owner_key: str) -> None:
+    now = monotonic()
+    with _sessions_lock:
+        _cleanup_sessions(now)
+        _sessions[runtime.session_id] = _StoredRuntime(
+            runtime=runtime,
+            owner_key=owner_key,
+            touched_at=now,
+        )
+
+
+def _load(session_id: str, owner_key: str) -> ActivityRuntime:
+    now = monotonic()
+    with _sessions_lock:
+        _cleanup_sessions(now)
+        record = _sessions.get(session_id)
+        if record is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Arcade session expired or was not found",
+            )
+        if record.owner_key != owner_key:
+            raise HTTPException(status_code=404, detail="Arcade session not found")
+        record.touched_at = now
+        return record.runtime
+
+
+@router.post("/start", response_model=ActivityPublicState, status_code=201)
+def start_activity(
+    payload: ActivityStartRequest,
+    demo_session: str | None = Header(None, alias="X-Demo-Session"),
+    user: User | None = Depends(get_optional_user),
+    session: Session = Depends(get_session),
+) -> ActivityPublicState:
+    """Create an ephemeral solo Arcade runtime for an accessible deck."""
+    deck = _accessible_deck(session, payload.deck_id, user)
+    owner_key = _owner_key(user, demo_session)
+    cards = _activity_cards(session, int(deck.id or 0))
+    seed = payload.seed if payload.seed is not None else secrets.randbits(63)
+    try:
+        runtime = build_activity_runtime(
+            activity_type=payload.activity_type,
+            deck_id=int(deck.id or 0),
+            cards=cards,
+            mode=ActivityMode.SOLO,
+            seed=seed,
+            round_count=payload.round_count,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    # Runtime adapters are deterministic by seed, while HTTP sessions need a
+    # collision-resistant capability id so two learners can replay one seed safely.
+    runtime = ActivityRuntime(
+        **{
+            **runtime.__dict__,
+            "session_id": secrets.token_urlsafe(18),
+        }
+    )
+    _store(runtime, owner_key)
+    return public_activity_state(runtime)
+
+
+@router.get("/{session_id}", response_model=ActivityPublicState)
+def activity_state(
+    session_id: str,
+    demo_session: str | None = Header(None, alias="X-Demo-Session"),
+    user: User | None = Depends(get_optional_user),
+) -> ActivityPublicState:
+    """Recover current phase-safe state for the same solo browser/account."""
+    owner_key = _owner_key(user, demo_session)
+    return public_activity_state(_load(session_id, owner_key))
+
+
+@router.post("/{session_id}/events", response_model=ActivityPublicState)
+def activity_event(
+    session_id: str,
+    event: ActivityEvent,
+    demo_session: str | None = Header(None, alias="X-Demo-Session"),
+    user: User | None = Depends(get_optional_user),
+) -> ActivityPublicState:
+    """Apply one server-authoritative game transition and return safe state."""
+    owner_key = _owner_key(user, demo_session)
+    runtime = _load(session_id, owner_key)
+    try:
+        updated = apply_activity_event(runtime, event)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    _store(updated, owner_key)
+    return public_activity_state(updated)

--- a/backend/tests/test_api_activities.py
+++ b/backend/tests/test_api_activities.py
@@ -1,0 +1,276 @@
+"""API tests for ephemeral solo Arcade sessions."""
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"arcade-{suffix}@example.com",
+        display_name=f"Arcade {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck(
+    session: Session,
+    *,
+    slug: str,
+    visibility: str = "public",
+    owner: User | None = None,
+    card_count: int = 6,
+) -> Deck:
+    deck = Deck(
+        owner_id=None if owner is None else owner.id,
+        title=f"Arcade {slug}",
+        slug=slug,
+        description="Arcade API test deck",
+        is_builtin=owner is None,
+        subject="Testing",
+        difficulty="beginner",
+        visibility=visibility,
+        tags=["arcade"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    for index in range(1, card_count + 1):
+        session.add(
+            Card(
+                deck_id=deck.id,
+                word=f"Question {index}",
+                definition=f"Answer {index}",
+                topic=deck.title,
+                domain="Testing",
+                kind="concept",
+                is_builtin=deck.is_builtin,
+            )
+        )
+    session.commit()
+    return deck
+
+
+def test_anonymous_browser_can_start_and_finish_blitz_round(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="public-blitz")
+    headers = {"X-Demo-Session": "arcade-browser-one"}
+
+    start = client.post(
+        "/activities/start",
+        headers=headers,
+        json={
+            "deck_id": deck.id,
+            "activity_type": "blitz",
+            "round_count": 2,
+            "seed": 123,
+        },
+    )
+    assert start.status_code == 201
+    prompt = start.json()
+    assert prompt["phase"] == "prompt"
+    assert prompt["mode"] == "solo"
+    assert prompt["reveal"] is None
+    assert "correct_choice_id" not in str(prompt)
+
+    target_number = prompt["payload"]["prompt"].split()[-1]
+    correct_choice = next(
+        choice["id"]
+        for choice in prompt["payload"]["choices"]
+        if choice["text"] == f"Answer {target_number}"
+    )
+    result = client.post(
+        f"/activities/{prompt['session_id']}/events",
+        headers=headers,
+        json={"type": "response.submitted", "payload": {"choice_id": correct_choice}},
+    )
+    assert result.status_code == 200
+    result_payload = result.json()
+    assert result_payload["phase"] == "result"
+    assert result_payload["reveal"]["result"]["correct"] is True
+    assert result_payload["participants"][0]["score"] == 100
+
+    next_round = client.post(
+        f"/activities/{prompt['session_id']}/events",
+        headers=headers,
+        json={"type": "round.completed"},
+    )
+    assert next_round.status_code == 200
+    assert next_round.json()["phase"] == "prompt"
+    assert next_round.json()["round_index"] == 1
+
+
+def test_arcade_session_is_bound_to_anonymous_browser_session(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="browser-owned")
+    start = client.post(
+        "/activities/start",
+        headers={"X-Demo-Session": "browser-a"},
+        json={"deck_id": deck.id, "activity_type": "blitz"},
+    )
+    assert start.status_code == 201
+    session_id = start.json()["session_id"]
+
+    other_browser = client.get(
+        f"/activities/{session_id}",
+        headers={"X-Demo-Session": "browser-b"},
+    )
+    assert other_browser.status_code == 404
+
+    original_browser = client.get(
+        f"/activities/{session_id}",
+        headers={"X-Demo-Session": "browser-a"},
+    )
+    assert original_browser.status_code == 200
+
+
+def test_anonymous_arcade_requires_browser_session_header(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="needs-session")
+    response = client.post(
+        "/activities/start",
+        json={"deck_id": deck.id, "activity_type": "blitz"},
+    )
+    assert response.status_code == 400
+
+
+def test_anonymous_user_can_play_unlisted_deck(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "unlisted-owner")
+    deck = _deck(
+        sqlite_session,
+        slug="unlisted-arcade",
+        visibility="unlisted",
+        owner=owner,
+    )
+    response = client.post(
+        "/activities/start",
+        headers={"X-Demo-Session": "unlisted-player"},
+        json={"deck_id": deck.id, "activity_type": "match"},
+    )
+    assert response.status_code == 201
+    assert response.json()["definition"]["type"] == "match"
+
+
+def test_anonymous_user_cannot_play_private_deck(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "private-owner")
+    deck = _deck(
+        sqlite_session,
+        slug="private-arcade",
+        visibility="private",
+        owner=owner,
+    )
+    response = client.post(
+        "/activities/start",
+        headers={"X-Demo-Session": "private-outsider"},
+        json={"deck_id": deck.id, "activity_type": "blitz"},
+    )
+    assert response.status_code == 401
+
+
+def test_signed_in_owner_can_play_private_deck(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "signed-owner")
+    deck = _deck(
+        sqlite_session,
+        slug="signed-private-arcade",
+        visibility="private",
+        owner=owner,
+    )
+    response = client.post(
+        "/activities/start",
+        headers=_headers(sqlite_session, owner),
+        json={"deck_id": deck.id, "activity_type": "blitz"},
+    )
+    assert response.status_code == 201
+
+
+def test_arcade_rejects_deck_with_too_few_cards(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="tiny-deck", card_count=3)
+    response = client.post(
+        "/activities/start",
+        headers={"X-Demo-Session": "tiny-browser"},
+        json={"deck_id": deck.id, "activity_type": "blitz"},
+    )
+    assert response.status_code == 422
+    assert "at least 4" in response.json()["detail"]
+
+
+def test_match_board_is_scored_by_server(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="match-board", card_count=5)
+    headers = {"X-Demo-Session": "match-browser"}
+    start = client.post(
+        "/activities/start",
+        headers=headers,
+        json={
+            "deck_id": deck.id,
+            "activity_type": "match",
+            "round_count": 5,
+            "seed": 456,
+        },
+    )
+    assert start.status_code == 201
+    prompt = start.json()
+    assert prompt["reveal"] is None
+    matches = {
+        str(item["card_id"]): f"card-{item['card_id']}"
+        for item in prompt["payload"]["prompts"]
+    }
+
+    result = client.post(
+        f"/activities/{prompt['session_id']}/events",
+        headers=headers,
+        json={"type": "response.submitted", "payload": {"matches": matches}},
+    )
+    assert result.status_code == 200
+    payload = result.json()
+    assert payload["phase"] == "result"
+    assert payload["reveal"]["result"]["perfect"] is True
+    assert payload["reveal"]["result"]["correct_count"] == 5
+    assert payload["participants"][0]["score"] == 500
+
+
+def test_activity_session_cannot_be_mutated_after_completion(client, sqlite_session: Session):
+    deck = _deck(sqlite_session, slug="one-round-complete", card_count=4)
+    headers = {"X-Demo-Session": "complete-browser"}
+    start = client.post(
+        "/activities/start",
+        headers=headers,
+        json={
+            "deck_id": deck.id,
+            "activity_type": "blitz",
+            "round_count": 1,
+            "seed": 99,
+        },
+    ).json()
+    target_number = start["payload"]["prompt"].split()[-1]
+    choice = next(
+        item["id"]
+        for item in start["payload"]["choices"]
+        if item["text"] == f"Answer {target_number}"
+    )
+    assert client.post(
+        f"/activities/{start['session_id']}/events",
+        headers=headers,
+        json={"type": "response.submitted", "payload": {"choice_id": choice}},
+    ).status_code == 200
+    completed = client.post(
+        f"/activities/{start['session_id']}/events",
+        headers=headers,
+        json={"type": "round.completed"},
+    )
+    assert completed.status_code == 200
+    assert completed.json()["phase"] == "complete"
+
+    invalid = client.post(
+        f"/activities/{start['session_id']}/events",
+        headers=headers,
+        json={"type": "response.submitted", "payload": {"choice_id": choice}},
+    )
+    assert invalid.status_code == 409

--- a/frontend/src/arcadeApi.ts
+++ b/frontend/src/arcadeApi.ts
@@ -1,0 +1,67 @@
+import axios from "axios";
+
+import { api } from "./api";
+import type {
+  ActivityEvent,
+  ActivityPublicState,
+  ActivityType,
+} from "./activityTypes";
+
+export interface ActivityStartPayload {
+  deck_id: number;
+  activity_type: ActivityType;
+  round_count?: number;
+  seed?: number;
+}
+
+function normalizeArcadeError(error: unknown): Error {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { detail?: unknown } | undefined;
+    const detail = data?.detail ?? error.response?.statusText ?? error.message;
+    return new Error(
+      error.response?.status
+        ? `HTTP ${error.response.status}: ${String(detail)}`
+        : `Network: ${String(detail)}`
+    );
+  }
+  return error instanceof Error ? error : new Error("Unknown Arcade error");
+}
+
+export async function startActivity(
+  payload: ActivityStartPayload
+): Promise<ActivityPublicState> {
+  try {
+    const { data } = await api.post<ActivityPublicState>("/activities/start", payload);
+    return data;
+  } catch (error) {
+    throw normalizeArcadeError(error);
+  }
+}
+
+export async function getActivityState(
+  sessionId: string
+): Promise<ActivityPublicState> {
+  try {
+    const { data } = await api.get<ActivityPublicState>(
+      `/activities/${encodeURIComponent(sessionId)}`
+    );
+    return data;
+  } catch (error) {
+    throw normalizeArcadeError(error);
+  }
+}
+
+export async function sendActivityEvent(
+  sessionId: string,
+  event: ActivityEvent
+): Promise<ActivityPublicState> {
+  try {
+    const { data } = await api.post<ActivityPublicState>(
+      `/activities/${encodeURIComponent(sessionId)}/events`,
+      event
+    );
+    return data;
+  } catch (error) {
+    throw normalizeArcadeError(error);
+  }
+}

--- a/frontend/src/pages/Arcade.tsx
+++ b/frontend/src/pages/Arcade.tsx
@@ -1,0 +1,698 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import {
+  getLibraryDecks,
+  getMyDecks,
+} from "../api";
+import {
+  sendActivityEvent,
+  startActivity,
+} from "../arcadeApi";
+import {
+  shouldUseActivityTimer,
+  type ActivityPublicState,
+  type ActivityType,
+} from "../activityTypes";
+import { useAuth } from "../auth";
+import { useExperience } from "../experienceContext";
+import { useGameFeel } from "../gameFeelContext";
+import type { DeckRead } from "../types";
+
+type BlitzChoice = { id: string; text: string };
+type BlitzPayload = {
+  card_id: number;
+  prompt: string;
+  domain: string;
+  kind: string;
+  choices: BlitzChoice[];
+};
+type MatchPrompt = {
+  card_id: number;
+  prompt: string;
+  domain: string;
+  kind: string;
+};
+type MatchPayload = {
+  prompts: MatchPrompt[];
+  choices: BlitzChoice[];
+};
+type MatchMap = Record<string, string>;
+
+type GameOption = {
+  type: Extract<ActivityType, "blitz" | "match">;
+  icon: string;
+  title: string;
+  detail: string;
+  minCards: number;
+};
+
+const games: GameOption[] = [
+  {
+    type: "blitz",
+    icon: "⚡",
+    title: "Multiple-Choice Blitz",
+    detail: "Five fast rounds. Pick the best answer and build a combo.",
+    minCards: 4,
+  },
+  {
+    type: "match",
+    icon: "🧩",
+    title: "Match Quest",
+    detail: "Pair prompts with definitions using a keyboard- and touch-friendly board.",
+    minCards: 3,
+  },
+];
+
+function blitzPayload(state: ActivityPublicState): BlitzPayload {
+  return state.payload as unknown as BlitzPayload;
+}
+
+function matchPayload(state: ActivityPublicState): MatchPayload {
+  return state.payload as unknown as MatchPayload;
+}
+
+function participantScore(state: ActivityPublicState | null): number {
+  return state?.participants[0]?.score ?? 0;
+}
+
+function resultRecord(state: ActivityPublicState): Record<string, unknown> {
+  const reveal = state.reveal ?? {};
+  const result = reveal.result;
+  return typeof result === "object" && result !== null
+    ? (result as Record<string, unknown>)
+    : {};
+}
+
+function uniqueDecks(rows: DeckRead[]): DeckRead[] {
+  const seen = new Set<number>();
+  return rows.filter((deck) => {
+    if (seen.has(deck.id)) return false;
+    seen.add(deck.id);
+    return true;
+  });
+}
+
+export default function Arcade() {
+  const { user } = useAuth();
+  const { policy, preferences } = useExperience();
+  const { play } = useGameFeel();
+  const [params, setParams] = useSearchParams();
+
+  const requestedDeck = Number(params.get("deck") || 0) || null;
+  const requestedGame = params.get("game") === "match" ? "match" : "blitz";
+
+  const [decks, setDecks] = useState<DeckRead[]>([]);
+  const [deckId, setDeckId] = useState<number | null>(requestedDeck);
+  const [gameType, setGameType] = useState<"blitz" | "match">(requestedGame);
+  const [activity, setActivity] = useState<ActivityPublicState | null>(null);
+  const [matches, setMatches] = useState<MatchMap>({});
+  const [timerEnabled, setTimerEnabled] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedDeck = useMemo(
+    () => decks.find((deck) => deck.id === deckId) ?? null,
+    [decks, deckId]
+  );
+  const selectedGame = games.find((game) => game.type === gameType) ?? games[0];
+  const canStart = Boolean(
+    selectedDeck && selectedDeck.card_count >= selectedGame.minCards && !loading
+  );
+
+  const loadDecks = useCallback(async () => {
+    setError(null);
+    try {
+      const publicPage = await getLibraryDecks({ page_size: 50, sort: "featured" });
+      const mine = user ? await getMyDecks() : [];
+      const all = uniqueDecks([...publicPage.items, ...mine]);
+      setDecks(all);
+      setDeckId((current) => {
+        const wanted = requestedDeck ?? current;
+        if (wanted && all.some((deck) => deck.id === wanted)) return wanted;
+        return all[0]?.id ?? null;
+      });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not load Arcade decks");
+    }
+  }, [requestedDeck, user]);
+
+  useEffect(() => {
+    void loadDecks();
+  }, [loadDecks]);
+
+  useEffect(() => {
+    if (!activity) return;
+    const allowed = shouldUseActivityTimer(activity.definition, policy);
+    if (!allowed) setTimerEnabled(false);
+  }, [activity, policy]);
+
+  useEffect(() => {
+    setMatches({});
+  }, [activity?.round_index, activity?.session_id]);
+
+  const submitResponse = useCallback(
+    async (payload: Record<string, unknown>) => {
+      if (!activity || !["prompt", "locked"].includes(activity.phase) || loading) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const next = await sendActivityEvent(activity.session_id, {
+          type: "response.submitted",
+          payload,
+        });
+        setActivity(next);
+        const result = resultRecord(next);
+        const success =
+          gameType === "blitz"
+            ? result.correct === true
+            : Number(result.correct_count ?? 0) === Number(result.total ?? -1);
+        play(success ? "success" : "miss");
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : "Could not submit Arcade response");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [activity, gameType, loading, play]
+  );
+
+  useEffect(() => {
+    if (!activity || activity.phase !== "prompt" || !timerEnabled || loading) {
+      setSecondsLeft(null);
+      return;
+    }
+    const duration = gameType === "match" ? 45 : 20;
+    let remaining = duration;
+    let expired = false;
+    setSecondsLeft(remaining);
+    const timer = window.setInterval(() => {
+      remaining -= 1;
+      setSecondsLeft(Math.max(0, remaining));
+      if (remaining > 0 || expired) return;
+      expired = true;
+      window.clearInterval(timer);
+      if (gameType === "match") {
+        void submitResponse({ matches });
+      } else {
+        void submitResponse({ choice_id: "" });
+      }
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [activity, gameType, loading, matches, submitResponse, timerEnabled]);
+
+  useEffect(() => {
+    if (!activity || activity.phase !== "prompt" || gameType !== "blitz") return;
+    const choices = blitzPayload(activity).choices;
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.matches("input, textarea, select, [contenteditable='true']")) return;
+      const index = Number(event.key) - 1;
+      if (index >= 0 && index < choices.length) {
+        event.preventDefault();
+        void submitResponse({ choice_id: choices[index].id });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [activity, gameType, submitResponse]);
+
+  async function beginGame() {
+    if (!selectedDeck || !canStart) return;
+    setLoading(true);
+    setError(null);
+    setMatches({});
+    try {
+      const next = await startActivity({
+        deck_id: selectedDeck.id,
+        activity_type: gameType,
+        round_count: 5,
+      });
+      setActivity(next);
+      setTimerEnabled(shouldUseActivityTimer(next.definition, policy));
+      setParams({ deck: String(selectedDeck.id), game: gameType }, { replace: true });
+      play("roundStart");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not start Arcade session");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function revealWithoutScore() {
+    if (!activity || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await sendActivityEvent(activity.session_id, {
+        type: "answer.revealed",
+      });
+      setActivity(next);
+      play("reveal");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not reveal this round");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function nextRound() {
+    if (!activity || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await sendActivityEvent(activity.session_id, {
+        type: "round.completed",
+      });
+      setActivity(next);
+      setMatches({});
+      if (next.phase === "complete") play("complete");
+      else play("roundStart");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not continue Arcade session");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function resetGame(nextType?: "blitz" | "match") {
+    const resolved = nextType ?? gameType;
+    setActivity(null);
+    setMatches({});
+    setSecondsLeft(null);
+    setGameType(resolved);
+    if (deckId) setParams({ deck: String(deckId), game: resolved }, { replace: true });
+  }
+
+  const timerAllowed = activity
+    ? shouldUseActivityTimer(activity.definition, policy)
+    : policy.allowOptionalTimers;
+
+  return (
+    <div className="mx-auto grid max-w-6xl gap-6">
+      <section className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="metric-label">🎮 FlashQuest Arcade</p>
+          <h1 className="mt-2 text-4xl font-black tracking-tight text-white sm:text-5xl">
+            Same deck. <span className="ember-text">Different game.</span>
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
+            Play with any compatible Library or owned deck. Arcade points belong to this game run; your durable Study mastery stays separate in this first playable V1.
+          </p>
+        </div>
+        <Link
+          to="/preferences"
+          className="game-button game-chip px-4 py-2 text-sm font-black text-slate-200"
+        >
+          🎚️ {preferences.learningMode} mode
+        </Link>
+      </section>
+
+      {!activity && (
+        <section className="game-panel grid gap-6 p-5 sm:p-6 lg:grid-cols-[.8fr_1.2fr]">
+          <div>
+            <p className="metric-label">1 · Pick a deck</p>
+            <select
+              className="game-input mt-2"
+              aria-label="Arcade deck"
+              value={deckId ?? ""}
+              onChange={(event) => setDeckId(Number(event.target.value))}
+            >
+              {decks.map((deck) => (
+                <option key={deck.id} value={deck.id}>
+                  {deck.is_official ? "⭐ " : deck.visibility === "private" ? "🔒 " : "🧑‍🚀 "}
+                  {deck.title} · {deck.card_count}
+                </option>
+              ))}
+            </select>
+            {selectedDeck && (
+              <div className="mt-3 rounded-2xl border border-white/10 bg-black/15 p-4">
+                <div className="flex flex-wrap gap-2 text-xs font-black">
+                  <span className="game-chip px-2.5 py-1 text-[#ffba08]">{selectedDeck.is_official ? "⭐ Official" : "🧑‍🚀 Your/Community deck"}</span>
+                  <span className="game-chip px-2.5 py-1 text-slate-300">{selectedDeck.subject}</span>
+                  <span className="game-chip px-2.5 py-1 capitalize text-slate-300">{selectedDeck.difficulty}</span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{selectedDeck.description}</p>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <p className="metric-label">2 · Pick a game</p>
+            <div className="mt-2 grid gap-3 sm:grid-cols-2">
+              {games.map((game) => {
+                const active = gameType === game.type;
+                const enoughCards = (selectedDeck?.card_count ?? 0) >= game.minCards;
+                return (
+                  <button
+                    key={game.type}
+                    type="button"
+                    aria-pressed={active}
+                    className={`game-button min-h-40 border p-5 text-left ${
+                      active
+                        ? "border-[#faa307]/60 bg-[#faa307]/10"
+                        : "border-white/10 bg-black/15"
+                    }`}
+                    onClick={() => setGameType(game.type)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <span className="text-3xl" aria-hidden="true">{game.icon}</span>
+                      <span className={`text-xs font-black ${enoughCards ? "text-slate-500" : "text-rose-300"}`}>
+                        {enoughCards ? `${game.minCards}+ cards` : `Needs ${game.minCards} cards`}
+                      </span>
+                    </div>
+                    <h2 className="mt-4 text-xl font-black text-white">{game.title}</h2>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">{game.detail}</p>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/15 p-4">
+              <div>
+                <p className="text-sm font-black text-white">
+                  {timerAllowed ? "⏱️ Optional timer available" : "🌿 Timer off in this mode"}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">Arcade/Party allow optional timers. Chill/Focus keep the same game untimed.</p>
+              </div>
+              <button
+                type="button"
+                className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+                disabled={!canStart}
+                onClick={() => void beginGame()}
+                data-game-sound="roundStart"
+              >
+                {loading ? "Loading arena…" : `${selectedGame.icon} Start ${selectedGame.title}`}
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {error && (
+        <section className="game-panel border-[#d00000]/50 p-5">
+          <h2 className="font-black text-white">🛡️ Arcade interrupted</h2>
+          <p className="mt-2 text-sm text-slate-300">{error}</p>
+        </section>
+      )}
+
+      {activity && activity.phase !== "complete" && (
+        <>
+          <section className="grid gap-3 sm:grid-cols-3">
+            <div className="game-panel p-4">
+              <p className="metric-label">Game</p>
+              <strong className="mt-2 block text-xl font-black text-white">{activity.definition.title}</strong>
+            </div>
+            <div className="game-panel p-4">
+              <p className="metric-label">Round</p>
+              <strong className="mt-2 block text-2xl font-black text-white">{activity.round_index + 1}/{activity.total_rounds}</strong>
+            </div>
+            <div className="game-panel p-4">
+              <p className="metric-label">Arcade score</p>
+              <strong className="mt-2 block text-2xl font-black text-white">⚡ {participantScore(activity)}</strong>
+            </div>
+          </section>
+
+          <section className="game-panel flex flex-wrap items-center justify-between gap-3 p-4">
+            <div className="flex flex-wrap gap-2">
+              <span className="game-chip px-3 py-1.5 text-xs font-black capitalize text-slate-300">🎚️ {preferences.learningMode}</span>
+              {timerEnabled && secondsLeft !== null ? (
+                <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]" role="timer" aria-live="polite">⏱️ {secondsLeft}s</span>
+              ) : (
+                <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-400">🌿 No timer</span>
+              )}
+            </div>
+            {activity.definition.timer_policy === "optional" && timerAllowed && activity.phase === "prompt" && (
+              <button
+                type="button"
+                className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white"
+                onClick={() => setTimerEnabled((value) => !value)}
+              >
+                {timerEnabled ? "Turn timer off" : "Turn timer on"}
+              </button>
+            )}
+          </section>
+
+          {gameType === "blitz" ? (
+            <BlitzBoard
+              state={activity}
+              loading={loading}
+              onAnswer={(choiceId) => void submitResponse({ choice_id: choiceId })}
+              onReveal={() => void revealWithoutScore()}
+              onNext={() => void nextRound()}
+            />
+          ) : (
+            <MatchBoard
+              state={activity}
+              matches={matches}
+              loading={loading}
+              onMatch={(cardId, choiceId) =>
+                setMatches((current) => ({ ...current, [String(cardId)]: choiceId }))
+              }
+              onSubmit={() => void submitResponse({ matches })}
+              onReveal={() => void revealWithoutScore()}
+              onNext={() => void nextRound()}
+            />
+          )}
+        </>
+      )}
+
+      {activity?.phase === "complete" && (
+        <section className="quest-card p-7 text-center sm:p-10">
+          <div className="relative z-10">
+            <div className="text-6xl" aria-hidden="true">🏆</div>
+            <p className="metric-label mt-5">Run complete</p>
+            <h2 className="mt-2 text-4xl font-black text-white">Arcade quest cleared!</h2>
+            <p className="mt-4 text-5xl font-black text-[#ffba08]">⚡ {participantScore(activity)} pts</p>
+            <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-slate-400">
+              These are game-session points. Your spaced-repetition mastery is still managed by Study in this V1, so a fast Arcade score cannot silently rewrite your durable learning history.
+            </p>
+            <div className="mt-7 flex flex-wrap justify-center gap-3">
+              <button
+                className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+                onClick={() => resetGame()}
+              >
+                🔁 Play again
+              </button>
+              <button
+                className="game-button border border-cyan-300/25 bg-cyan-300/[0.08] px-5 py-3 font-black text-cyan-100"
+                onClick={() => resetGame(gameType === "blitz" ? "match" : "blitz")}
+              >
+                🎲 Switch game
+              </button>
+              {deckId && (
+                <Link
+                  to={`/study?deck=${deckId}`}
+                  className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 font-black text-white"
+                >
+                  🧠 Study this deck
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function BlitzBoard({
+  state,
+  loading,
+  onAnswer,
+  onReveal,
+  onNext,
+}: {
+  state: ActivityPublicState;
+  loading: boolean;
+  onAnswer: (choiceId: string) => void;
+  onReveal: () => void;
+  onNext: () => void;
+}) {
+  const payload = blitzPayload(state);
+  const result = resultRecord(state);
+  const correctChoiceId = String(state.reveal?.correct_choice_id ?? "");
+  const showResult = state.phase === "result" || state.phase === "reveal";
+
+  return (
+    <section className="quest-card p-5 sm:p-8">
+      <div className="relative z-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">⚡ BLITZ</span>
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">{payload.domain}</span>
+        </div>
+        <h2 className="mx-auto mt-8 max-w-4xl text-center text-3xl font-black leading-tight text-white sm:text-5xl">{payload.prompt}</h2>
+
+        <div className="mx-auto mt-8 grid max-w-4xl gap-3 sm:grid-cols-2">
+          {payload.choices.map((choice, index) => {
+            const correct = showResult && choice.id === correctChoiceId;
+            return (
+              <button
+                key={choice.id}
+                type="button"
+                disabled={loading || showResult}
+                onClick={() => onAnswer(choice.id)}
+                className={`game-button min-h-28 border p-4 text-left ${
+                  correct
+                    ? "border-emerald-300/50 bg-emerald-300/[0.12] text-emerald-50"
+                    : "border-white/10 bg-black/20 text-slate-100"
+                }`}
+              >
+                <span className="text-xs font-black text-[#faa307]">{index + 1}</span>
+                <span className="mt-2 block text-sm font-bold leading-6">{choice.text}</span>
+                {correct && <span className="mt-2 block text-xs font-black text-emerald-200">✓ Correct answer</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        {showResult && (
+          <div className="answer-pop mx-auto mt-6 max-w-3xl rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.08] p-5">
+            {state.phase === "result" ? (
+              <p className="text-sm font-black text-white">
+                {result.correct === true ? "✨ Correct! +100 Arcade points" : "💪 Not quite — this one is worth another look."}
+              </p>
+            ) : (
+              <p className="text-sm font-black text-white">👀 Answer revealed — no Arcade points awarded for this round.</p>
+            )}
+            <p className="mt-3 text-sm leading-6 text-cyan-50">{String(state.reveal?.answer ?? "")}</p>
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {!showResult ? (
+            <button
+              className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white"
+              disabled={loading}
+              onClick={onReveal}
+            >
+              👀 Reveal / skip round
+            </button>
+          ) : (
+            <button
+              className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+              disabled={loading}
+              onClick={onNext}
+            >
+              Next round →
+            </button>
+          )}
+        </div>
+        {!showResult && <p className="mt-4 text-center text-xs text-slate-500">Keyboard: press 1–4 to answer.</p>}
+      </div>
+    </section>
+  );
+}
+
+function MatchBoard({
+  state,
+  matches,
+  loading,
+  onMatch,
+  onSubmit,
+  onReveal,
+  onNext,
+}: {
+  state: ActivityPublicState;
+  matches: MatchMap;
+  loading: boolean;
+  onMatch: (cardId: number, choiceId: string) => void;
+  onSubmit: () => void;
+  onReveal: () => void;
+  onNext: () => void;
+}) {
+  const payload = matchPayload(state);
+  const result = resultRecord(state);
+  const answerMap = (state.reveal?.answer_map ?? {}) as Record<string, string>;
+  const showResult = state.phase === "result" || state.phase === "reveal";
+  const completeBoard = payload.prompts.every((prompt) => Boolean(matches[String(prompt.card_id)]));
+  const choiceText = new Map(payload.choices.map((choice) => [choice.id, choice.text]));
+
+  return (
+    <section className="quest-card p-5 sm:p-8">
+      <div className="relative z-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">🧩 MATCH QUEST</span>
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">{payload.prompts.length} pairs</span>
+        </div>
+        <h2 className="mt-6 text-2xl font-black text-white sm:text-3xl">Match each prompt to the best definition.</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-400">Native selects keep the board fully usable with keyboard, touch, switch controls, and screen-reader navigation — drag-and-drop is not required.</p>
+
+        <div className="mt-6 grid gap-4">
+          {payload.prompts.map((prompt, index) => {
+            const selected = matches[String(prompt.card_id)] ?? "";
+            const correctChoice = answerMap[String(prompt.card_id)] ?? "";
+            const correct = showResult && selected === correctChoice;
+            return (
+              <div key={prompt.card_id} className="game-panel grid gap-3 p-4 lg:grid-cols-[1fr_1fr] lg:items-center">
+                <div>
+                  <p className="metric-label">Pair {index + 1} · {prompt.domain}</p>
+                  <p className="mt-2 font-black leading-6 text-white">{prompt.prompt}</p>
+                </div>
+                <div>
+                  <label className="text-xs font-black text-slate-300" htmlFor={`match-${prompt.card_id}`}>Choose definition</label>
+                  <select
+                    id={`match-${prompt.card_id}`}
+                    className="game-input mt-1.5"
+                    disabled={loading || showResult}
+                    value={selected}
+                    onChange={(event) => onMatch(prompt.card_id, event.target.value)}
+                  >
+                    <option value="">Select a match…</option>
+                    {payload.choices.map((choice) => <option key={choice.id} value={choice.id}>{choice.text}</option>)}
+                  </select>
+                  {showResult && (
+                    <div className="mt-2 text-xs leading-5">
+                      <strong className={correct ? "text-emerald-200" : "text-rose-200"}>{correct ? "✓ Correct" : "✕ Not matched"}</strong>
+                      <span className="ml-2 text-slate-400">Correct: {choiceText.get(correctChoice) ?? "—"}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {showResult && (
+          <div className="answer-pop mt-5 rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.08] p-5">
+            <p className="font-black text-white">
+              {state.phase === "result"
+                ? `🧩 ${Number(result.correct_count ?? 0)}/${Number(result.total ?? payload.prompts.length)} matched · +${Number(result.points ?? 0)} Arcade points`
+                : "👀 Board revealed — no Arcade points awarded."}
+            </p>
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {!showResult ? (
+            <>
+              <button
+                className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+                disabled={loading || !completeBoard}
+                onClick={onSubmit}
+              >
+                Check my matches
+              </button>
+              <button
+                className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white"
+                disabled={loading}
+                onClick={onReveal}
+              >
+                👀 Reveal board
+              </button>
+            </>
+          ) : (
+            <button
+              className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+              disabled={loading}
+              onClick={onNext}
+            >
+              Finish quest →
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed

Turns the merged Arcade activity contract into the first playable FlashQuest Arcade experience for issue #34.

### Playable games
- Adds **Multiple-Choice Blitz** with five server-scored rounds, 1–4 keyboard shortcuts, reveal/skip, session score, and completion summary.
- Adds **Match Quest** with a keyboard/touch/screen-reader-friendly native-select board; drag-and-drop is never required.
- Both games use the shared ActivityDefinition/ActivityRuntime contract from #21 rather than implementing answer logic in React.

### Server-authoritative solo session host
- Adds `POST /activities/start`, `GET /activities/{session_id}`, and `POST /activities/{session_id}/events`.
- Loads only decks the learner is allowed to access: public/unlisted/Official decks or their own private decks.
- Anonymous runs bind to the existing `X-Demo-Session`; signed-in runs bind to the account.
- Another browser/account receives 404 instead of being able to read or mutate the run.
- Session ids are collision-resistant even when a deterministic activity seed is reused.
- V1 runtime state is deliberately ephemeral/in-process with a 2-hour TTL and bounded session count; an API restart may end an in-progress solo run. Persistent/realtime hosting remains a Quest Room concern rather than being hidden behind fake durability.

### Server scoring + spoiler boundary
- Adds `response.submitted` scoring to the shared runtime.
- Blitz awards 100 points for a correct choice; Match Quest scores the number of correct pairs.
- Correct-answer ids/maps and result payloads remain server-internal until submit/reveal.
- The browser renders the returned phase-safe state and never decides which answer is correct.
- Arcade score/streak remains game-session state and does not silently mutate spaced-repetition mastery in this V1.
- Durable Arcade→mastery integration is intentionally tracked in #36 as an idempotent per-card progress adapter rather than being mixed into this UI slice.

### Adaptable experience integration
- Arcade/Party modes permit the optional round timer.
- Chill/Focus keep the exact same games untimed through the shared `shouldUseActivityTimer()` policy.
- Blitz timer is 20 seconds; Match Quest is 45 seconds when enabled.
- Match timer is scoped to the round, not reset by each selection.
- Reuses the global sound/motion system for round start, success/miss, reveal, and completion.
- Existing reduced-motion, larger-text, and high-contrast app preferences apply automatically.

### App UX
- Adds `/arcade` and a global 🎮 Arcade nav item.
- Learners can choose any compatible public Library deck or signed-in owned deck.
- Completion offers Replay, Switch Game, and Study This Deck.
- UI explicitly says Arcade points are separate from durable Study mastery in this first V1.

### Tests
- Runtime scoring for correct/wrong Blitz and partial Match boards.
- Score persistence between rounds without carrying stale response state.
- Response submission cannot happen after reveal.
- Anonymous start/scoring flow.
- Browser-session ownership isolation.
- Anonymous session-header requirement.
- Public/unlisted/private deck access boundaries.
- Signed-in private-deck access.
- Minimum-card validation.
- Match server scoring.
- Completed sessions reject new answer submissions.

Closes #34
Related: #36