### PR TITLE
Add Quest Room persistence and permission foundation

### DIFF
--- a/backend/alembic/versions/e0c1f4a5b6d7_add_quest_room_foundation.py
+++ b/backend/alembic/versions/e0c1f4a5b6d7_add_quest_room_foundation.py
@@ -1,0 +1,133 @@
+"""add quest room foundation
+
+Revision ID: e0c1f4a5b6d7
+Revises: d9b0e3f4a5c6
+Create Date: 2026-08-19
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e0c1f4a5b6d7"
+down_revision: Union[str, Sequence[str], None] = "d9b0e3f4a5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create persistent rooms, memberships, and message history."""
+    op.create_table(
+        "study_room",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("host_user_id", sa.Integer(), nullable=False),
+        sa.Column("deck_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("visibility", sa.String(), nullable=False, server_default="private"),
+        sa.Column("status", sa.String(), nullable=False, server_default="open"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "visibility IN ('public', 'private', 'invite_only')",
+            name="ck_study_room_visibility",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'closed')",
+            name="ck_study_room_status",
+        ),
+        sa.ForeignKeyConstraint(["deck_id"], ["deck.id"], name="fk_study_room_deck_id"),
+        sa.ForeignKeyConstraint(
+            ["host_user_id"], ["app_user.id"], name="fk_study_room_host_user_id"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_study_room_host_user_id"), "study_room", ["host_user_id"], unique=False)
+    op.create_index(op.f("ix_study_room_deck_id"), "study_room", ["deck_id"], unique=False)
+    op.create_index(op.f("ix_study_room_name"), "study_room", ["name"], unique=False)
+    op.create_index(op.f("ix_study_room_visibility"), "study_room", ["visibility"], unique=False)
+    op.create_index(op.f("ix_study_room_status"), "study_room", ["status"], unique=False)
+
+    op.create_table(
+        "room_member",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(), nullable=False, server_default="member"),
+        sa.Column("status", sa.String(), nullable=False, server_default="active"),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "role IN ('host', 'moderator', 'member')",
+            name="ck_room_member_role",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'left', 'removed')",
+            name="ck_room_member_status",
+        ),
+        sa.ForeignKeyConstraint(["room_id"], ["study_room.id"], name="fk_room_member_room_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["app_user.id"], name="fk_room_member_user_id"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("room_id", "user_id", name="uq_room_member_room_user"),
+    )
+    op.create_index(op.f("ix_room_member_room_id"), "room_member", ["room_id"], unique=False)
+    op.create_index(op.f("ix_room_member_user_id"), "room_member", ["user_id"], unique=False)
+    op.create_index(op.f("ix_room_member_role"), "room_member", ["role"], unique=False)
+    op.create_index(op.f("ix_room_member_status"), "room_member", ["status"], unique=False)
+
+    op.create_table(
+        "room_message",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False, server_default="chat"),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("card_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "kind IN ('chat', 'card', 'system', 'activity')",
+            name="ck_room_message_kind",
+        ),
+        sa.ForeignKeyConstraint(["card_id"], ["card.id"], name="fk_room_message_card_id"),
+        sa.ForeignKeyConstraint(["room_id"], ["study_room.id"], name="fk_room_message_room_id"),
+        sa.ForeignKeyConstraint(["user_id"], ["app_user.id"], name="fk_room_message_user_id"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_room_message_room_id"), "room_message", ["room_id"], unique=False)
+    op.create_index(op.f("ix_room_message_user_id"), "room_message", ["user_id"], unique=False)
+    op.create_index(op.f("ix_room_message_kind"), "room_message", ["kind"], unique=False)
+    op.create_index(op.f("ix_room_message_card_id"), "room_message", ["card_id"], unique=False)
+    op.create_index(op.f("ix_room_message_created_at"), "room_message", ["created_at"], unique=False)
+    op.create_index(
+        "ix_room_message_room_created_at",
+        "room_message",
+        ["room_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove Quest Room persistence tables."""
+    op.drop_index("ix_room_message_room_created_at", table_name="room_message")
+    op.drop_index(op.f("ix_room_message_created_at"), table_name="room_message")
+    op.drop_index(op.f("ix_room_message_card_id"), table_name="room_message")
+    op.drop_index(op.f("ix_room_message_kind"), table_name="room_message")
+    op.drop_index(op.f("ix_room_message_user_id"), table_name="room_message")
+    op.drop_index(op.f("ix_room_message_room_id"), table_name="room_message")
+    op.drop_table("room_message")
+
+    op.drop_index(op.f("ix_room_member_status"), table_name="room_member")
+    op.drop_index(op.f("ix_room_member_role"), table_name="room_member")
+    op.drop_index(op.f("ix_room_member_user_id"), table_name="room_member")
+    op.drop_index(op.f("ix_room_member_room_id"), table_name="room_member")
+    op.drop_table("room_member")
+
+    op.drop_index(op.f("ix_study_room_status"), table_name="study_room")
+    op.drop_index(op.f("ix_study_room_visibility"), table_name="study_room")
+    op.drop_index(op.f("ix_study_room_name"), table_name="study_room")
+    op.drop_index(op.f("ix_study_room_deck_id"), table_name="study_room")
+    op.drop_index(op.f("ix_study_room_host_user_id"), table_name="study_room")
+    op.drop_table("study_room")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 
 from .config import settings
 from .db import get_session
-from .routers import activities, auth, cards, decks, study
+from .routers import activities, auth, cards, decks, rooms, study
 
 
 def _allowed_origins() -> list[str]:
@@ -74,6 +74,7 @@ app.include_router(decks.router)
 app.include_router(cards.router)
 app.include_router(study.router)
 app.include_router(activities.router)
+app.include_router(rooms.router)
 
 
 @app.get("/health")

--- a/backend/app/room_models.py
+++ b/backend/app/room_models.py
@@ -1,0 +1,143 @@
+"""Persistent data contracts for deck-linked Quest Rooms.
+
+Room membership and message history are durable PostgreSQL state. Realtime
+presence intentionally lives outside these tables so heartbeats do not become a
+write-amplification problem.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+
+from .models import utc_now
+
+ROOM_VISIBILITIES = {"public", "private", "invite_only"}
+ROOM_STATUSES = {"open", "closed"}
+ROOM_ROLES = {"host", "moderator", "member"}
+ROOM_MEMBER_STATUSES = {"active", "left", "removed"}
+ROOM_MESSAGE_KINDS = {"chat", "card", "system", "activity"}
+
+
+class StudyRoom(SQLModel, table=True):
+    """Deck-linked persistent container for social study and shared activities."""
+
+    __tablename__ = "study_room"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "visibility IN ('public', 'private', 'invite_only')",
+            name="ck_study_room_visibility",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'closed')",
+            name="ck_study_room_status",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    host_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    deck_id: int = Field(foreign_key="deck.id", index=True, sa_type=sa.Integer)
+    name: str = Field(index=True, sa_type=sa.String)
+    visibility: str = Field(default="private", index=True, sa_type=sa.String)
+    status: str = Field(default="open", index=True, sa_type=sa.String)
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    updated_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    closed_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
+class RoomMember(SQLModel, table=True):
+    """Persistent membership/role; a WebSocket connection is never membership."""
+
+    __tablename__ = "room_member"
+    __table_args__ = (
+        sa.UniqueConstraint("room_id", "user_id", name="uq_room_member_room_user"),
+        sa.CheckConstraint(
+            "role IN ('host', 'moderator', 'member')",
+            name="ck_room_member_role",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'left', 'removed')",
+            name="ck_room_member_status",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    room_id: int = Field(
+        foreign_key="study_room.id", index=True, sa_type=sa.Integer
+    )
+    user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    role: str = Field(default="member", index=True, sa_type=sa.String)
+    status: str = Field(default="active", index=True, sa_type=sa.String)
+    joined_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    last_seen_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    removed_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
+class RoomMessage(SQLModel, table=True):
+    """Durable room history independent of any one realtime process."""
+
+    __tablename__ = "room_message"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "kind IN ('chat', 'card', 'system', 'activity')",
+            name="ck_room_message_kind",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    room_id: int = Field(
+        foreign_key="study_room.id", index=True, sa_type=sa.Integer
+    )
+    user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    kind: str = Field(default="chat", index=True, sa_type=sa.String)
+    body: str = Field(sa_column=sa.Column(sa.Text(), nullable=False))
+    card_id: Optional[int] = Field(
+        default=None, foreign_key="card.id", index=True, sa_type=sa.Integer
+    )
+    created_at: datetime = Field(
+        default_factory=utc_now, index=True, sa_type=sa.DateTime(timezone=True)
+    )
+    removed_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
+class RoomCreate(SQLModel):
+    """Verified-user request to create a deck-linked room."""
+
+    deck_id: int
+    name: str
+    visibility: str = "private"
+
+
+class RoomRead(SQLModel):
+    """Permission-aware room summary returned by the REST foundation."""
+
+    id: int
+    host_user_id: int
+    deck_id: int
+    name: str
+    visibility: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    closed_at: Optional[datetime] = None
+    member_count: int = 0
+    current_user_role: Optional[str] = None
+
+
+class RoomMemberRead(SQLModel):
+    id: int
+    room_id: int
+    user_id: int
+    role: str
+    status: str
+    joined_at: datetime
+    last_seen_at: datetime

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -1,0 +1,311 @@
+"""Quest Room REST foundation: ownership, membership, and deck privacy boundaries."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from ..db import get_session
+from ..models import Deck, User, utc_now
+from ..room_models import (
+    ROOM_VISIBILITIES,
+    RoomCreate,
+    RoomMember,
+    RoomMemberRead,
+    RoomRead,
+    StudyRoom,
+)
+from ..security import get_current_user, require_verified_user
+
+router = APIRouter(prefix="/rooms", tags=["rooms"])
+
+
+def _clean_name(value: str) -> str:
+    name = " ".join(value.strip().split())
+    if not name:
+        raise HTTPException(status_code=422, detail="Room name cannot be empty")
+    if len(name) > 80:
+        raise HTTPException(status_code=422, detail="Room name must be 80 characters or fewer")
+    return name
+
+
+def _room_or_404(session: Session, room_id: int) -> StudyRoom:
+    room = session.get(StudyRoom, room_id)
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+    return room
+
+
+def _active_member(session: Session, room_id: int, user_id: int) -> RoomMember | None:
+    return session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.user_id == user_id,
+            RoomMember.status == "active",
+        )
+    ).first()
+
+
+def _any_membership(session: Session, room_id: int, user_id: int) -> RoomMember | None:
+    return session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.user_id == user_id,
+        )
+    ).first()
+
+
+def _member_count(session: Session, room_id: int) -> int:
+    count = session.exec(
+        select(func.count())
+        .select_from(RoomMember)
+        .where(RoomMember.room_id == room_id, RoomMember.status == "active")
+    ).one()
+    return int(count or 0)
+
+
+def _read_room(session: Session, room: StudyRoom, user_id: int) -> RoomRead:
+    membership = _active_member(session, int(room.id or 0), user_id)
+    return RoomRead(
+        id=int(room.id or 0),
+        host_user_id=room.host_user_id,
+        deck_id=room.deck_id,
+        name=room.name,
+        visibility=room.visibility,
+        status=room.status,
+        created_at=room.created_at,
+        updated_at=room.updated_at,
+        closed_at=room.closed_at,
+        member_count=_member_count(session, int(room.id or 0)),
+        current_user_role=membership.role if membership is not None else None,
+    )
+
+
+def _deck_for_room(
+    session: Session,
+    *,
+    deck_id: int,
+    user_id: int,
+    room_visibility: str,
+) -> Deck:
+    deck = session.get(Deck, deck_id)
+    if deck is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+
+    owns_deck = deck.owner_id == user_id and not deck.is_builtin
+    shareable = deck.is_builtin or deck.visibility in {"public", "unlisted"}
+    if not owns_deck and not shareable:
+        raise HTTPException(status_code=403, detail="You cannot create a room for this deck")
+
+    # A room must never widen the discoverability of its backing deck.
+    if room_visibility == "public" and not (deck.is_builtin or deck.visibility == "public"):
+        raise HTTPException(
+            status_code=422,
+            detail="Public rooms require an Official or public deck",
+        )
+    return deck
+
+
+def _require_member(session: Session, room: StudyRoom, user_id: int) -> RoomMember:
+    membership = _active_member(session, int(room.id or 0), user_id)
+    if membership is None:
+        raise HTTPException(status_code=403, detail="Active room membership required")
+    return membership
+
+
+def _require_host(session: Session, room: StudyRoom, user_id: int) -> RoomMember:
+    membership = _require_member(session, room, user_id)
+    if membership.role != "host" or room.host_user_id != user_id:
+        raise HTTPException(status_code=403, detail="Only the room host can do that")
+    return membership
+
+
+@router.post("", response_model=RoomRead, status_code=201)
+def create_room(
+    payload: RoomCreate,
+    user: User = Depends(require_verified_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Create a room and persist the creator as its host member."""
+    visibility = payload.visibility.strip().lower()
+    if visibility not in ROOM_VISIBILITIES:
+        raise HTTPException(
+            status_code=422,
+            detail="Room visibility must be public, private, or invite_only",
+        )
+    name = _clean_name(payload.name)
+    _deck_for_room(
+        session,
+        deck_id=payload.deck_id,
+        user_id=int(user.id or 0),
+        room_visibility=visibility,
+    )
+
+    room = StudyRoom(
+        host_user_id=int(user.id or 0),
+        deck_id=payload.deck_id,
+        name=name,
+        visibility=visibility,
+        status="open",
+    )
+    session.add(room)
+    session.flush()
+    session.add(
+        RoomMember(
+            room_id=int(room.id or 0),
+            user_id=int(user.id or 0),
+            role="host",
+            status="active",
+        )
+    )
+    session.commit()
+    session.refresh(room)
+    return _read_room(session, room, int(user.id or 0))
+
+
+@router.get("/mine", response_model=list[RoomRead])
+def my_rooms(
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[RoomRead]:
+    """Return rooms where the current account has active membership."""
+    rows = session.exec(
+        select(StudyRoom)
+        .join(RoomMember, RoomMember.room_id == StudyRoom.id)
+        .where(
+            RoomMember.user_id == int(user.id or 0),
+            RoomMember.status == "active",
+        )
+        .order_by(StudyRoom.updated_at.desc())
+    ).all()
+    return [_read_room(session, room, int(user.id or 0)) for room in rows]
+
+
+@router.get("/{room_id}", response_model=RoomRead)
+def room_detail(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Return a member room, or an open public room summary before joining."""
+    room = _room_or_404(session, room_id)
+    member = _active_member(session, room_id, int(user.id or 0))
+    if member is None and not (room.visibility == "public" and room.status == "open"):
+        # Hide private/invite-only room existence from non-members.
+        raise HTTPException(status_code=404, detail="Room not found")
+    return _read_room(session, room, int(user.id or 0))
+
+
+@router.post("/{room_id}/join", response_model=RoomRead)
+def join_room(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Join an open public room. Invite/private membership is handled separately."""
+    room = _room_or_404(session, room_id)
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+
+    current = _active_member(session, room_id, int(user.id or 0))
+    if current is not None:
+        return _read_room(session, room, int(user.id or 0))
+
+    prior = _any_membership(session, room_id, int(user.id or 0))
+    if prior is not None:
+        if prior.status == "removed":
+            raise HTTPException(status_code=403, detail="Membership was removed")
+        if prior.status == "left" and room.visibility == "public":
+            prior.status = "active"
+            prior.removed_at = None
+            prior.last_seen_at = utc_now()
+            session.add(prior)
+            session.commit()
+            return _read_room(session, room, int(user.id or 0))
+
+    if room.visibility != "public":
+        raise HTTPException(status_code=403, detail="Invite or membership required")
+
+    session.add(
+        RoomMember(
+            room_id=room_id,
+            user_id=int(user.id or 0),
+            role="member",
+            status="active",
+        )
+    )
+    room.updated_at = utc_now()
+    session.add(room)
+    session.commit()
+    return _read_room(session, room, int(user.id or 0))
+
+
+@router.post("/{room_id}/leave", response_model=RoomRead)
+def leave_room(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Leave a room without deleting its durable membership history."""
+    room = _room_or_404(session, room_id)
+    membership = _require_member(session, room, int(user.id or 0))
+    if membership.role == "host":
+        raise HTTPException(status_code=409, detail="Host must close the room instead of leaving")
+
+    membership.status = "left"
+    membership.removed_at = utc_now()
+    membership.last_seen_at = utc_now()
+    room.updated_at = utc_now()
+    session.add(membership)
+    session.add(room)
+    session.commit()
+    return _read_room(session, room, int(user.id or 0))
+
+
+@router.post("/{room_id}/close", response_model=RoomRead)
+def close_room(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Close a room as its host; closed rooms reject new joins."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    if room.status != "closed":
+        now = utc_now()
+        room.status = "closed"
+        room.closed_at = now
+        room.updated_at = now
+        session.add(room)
+        session.commit()
+        session.refresh(room)
+    return _read_room(session, room, int(user.id or 0))
+
+
+@router.get("/{room_id}/members", response_model=list[RoomMemberRead])
+def room_members(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[RoomMemberRead]:
+    """Return active membership to current room members only."""
+    room = _room_or_404(session, room_id)
+    _require_member(session, room, int(user.id or 0))
+    rows = session.exec(
+        select(RoomMember)
+        .where(RoomMember.room_id == room_id, RoomMember.status == "active")
+        .order_by(RoomMember.joined_at.asc())
+    ).all()
+    return [
+        RoomMemberRead(
+            id=int(member.id or 0),
+            room_id=member.room_id,
+            user_id=member.user_id,
+            role=member.role,
+            status=member.status,
+            joined_at=member.joined_at,
+            last_seen_at=member.last_seen_at,
+        )
+        for member in rows
+    ]

--- a/backend/tests/test_quest_rooms.py
+++ b/backend/tests/test_quest_rooms.py
@@ -1,0 +1,382 @@
+"""Quest Room ownership, deck privacy, membership, and lifecycle tests."""
+
+from sqlmodel import Session, select
+
+from app.models import Deck, User
+from app.room_models import RoomMember, RoomMessage, StudyRoom
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str, *, verified: bool = True) -> User:
+    user = User(
+        email=f"room-{suffix}@example.com",
+        display_name=f"Room User {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=verified,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck(
+    session: Session,
+    *,
+    slug: str,
+    owner: User | None = None,
+    visibility: str = "public",
+    builtin: bool = False,
+) -> Deck:
+    deck = Deck(
+        owner_id=None if builtin else (owner.id if owner is not None else None),
+        title=f"Room Deck {slug}",
+        slug=slug,
+        description="Quest Room test deck",
+        is_builtin=builtin,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public" if builtin else visibility,
+        tags=["rooms"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return deck
+
+
+def _create_room(client, session: Session, host: User, deck: Deck, **overrides):
+    payload = {
+        "deck_id": int(deck.id or 0),
+        "name": overrides.get("name", "Study Crew"),
+        "visibility": overrides.get("visibility", "private"),
+    }
+    return client.post("/rooms", headers=_headers(session, host), json=payload)
+
+
+def test_unverified_account_cannot_create_room(client, sqlite_session: Session):
+    user = _user(sqlite_session, "unverified", verified=False)
+    deck = _deck(sqlite_session, slug="public-for-unverified", visibility="public")
+
+    response = _create_room(
+        client,
+        sqlite_session,
+        user,
+        deck,
+        visibility="public",
+    )
+    assert response.status_code == 403
+    assert "verify" in response.json()["detail"].lower()
+
+
+def test_verified_host_creates_room_and_host_membership(client, sqlite_session: Session):
+    host = _user(sqlite_session, "host")
+    deck = _deck(sqlite_session, slug="public-host-deck", visibility="public")
+
+    response = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+        name="  Platform   Crew  ",
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["name"] == "Platform Crew"
+    assert payload["visibility"] == "public"
+    assert payload["status"] == "open"
+    assert payload["member_count"] == 1
+    assert payload["current_user_role"] == "host"
+
+    membership = sqlite_session.exec(
+        select(RoomMember).where(RoomMember.room_id == payload["id"])
+    ).one()
+    assert membership.user_id == host.id
+    assert membership.role == "host"
+    assert membership.status == "active"
+
+
+def test_public_room_cannot_widen_unlisted_deck_visibility(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "unlisted-owner")
+    deck = _deck(
+        sqlite_session,
+        slug="unlisted-room-deck",
+        owner=owner,
+        visibility="unlisted",
+    )
+
+    response = _create_room(
+        client,
+        sqlite_session,
+        owner,
+        deck,
+        visibility="public",
+    )
+    assert response.status_code == 422
+    assert "public rooms require" in response.json()["detail"].lower()
+
+    allowed = _create_room(
+        client,
+        sqlite_session,
+        owner,
+        deck,
+        visibility="invite_only",
+    )
+    assert allowed.status_code == 201
+    assert allowed.json()["visibility"] == "invite_only"
+
+
+def test_non_owner_cannot_create_room_for_private_deck(client, sqlite_session: Session):
+    owner = _user(sqlite_session, "private-owner")
+    stranger = _user(sqlite_session, "private-stranger")
+    deck = _deck(
+        sqlite_session,
+        slug="private-room-deck",
+        owner=owner,
+        visibility="private",
+    )
+
+    response = _create_room(
+        client,
+        sqlite_session,
+        stranger,
+        deck,
+        visibility="private",
+    )
+    assert response.status_code == 403
+
+    owner_response = _create_room(
+        client,
+        sqlite_session,
+        owner,
+        deck,
+        visibility="private",
+    )
+    assert owner_response.status_code == 201
+
+
+def test_authenticated_user_can_join_public_room_idempotently(client, sqlite_session: Session):
+    host = _user(sqlite_session, "join-host")
+    member = _user(sqlite_session, "join-member")
+    deck = _deck(sqlite_session, slug="join-public", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+    headers = _headers(sqlite_session, member)
+
+    first = client.post(f"/rooms/{room['id']}/join", headers=headers)
+    second = client.post(f"/rooms/{room['id']}/join", headers=headers)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["member_count"] == 2
+    assert second.json()["current_user_role"] == "member"
+
+    rows = sqlite_session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room["id"], RoomMember.user_id == member.id
+        )
+    ).all()
+    assert len(rows) == 1
+
+
+def test_private_and_invite_rooms_reject_generic_join(client, sqlite_session: Session):
+    host = _user(sqlite_session, "invite-host")
+    stranger = _user(sqlite_session, "invite-stranger")
+    deck = _deck(sqlite_session, slug="invite-public-deck", visibility="public")
+    headers = _headers(sqlite_session, stranger)
+
+    for visibility in ("private", "invite_only"):
+        room = _create_room(
+            client,
+            sqlite_session,
+            host,
+            deck,
+            visibility=visibility,
+            name=f"{visibility} room",
+        ).json()
+        response = client.post(f"/rooms/{room['id']}/join", headers=headers)
+        assert response.status_code == 403
+        assert "invite" in response.json()["detail"].lower()
+
+
+def test_private_room_is_not_enumerable_by_non_member(client, sqlite_session: Session):
+    host = _user(sqlite_session, "hidden-host")
+    stranger = _user(sqlite_session, "hidden-stranger")
+    deck = _deck(sqlite_session, slug="hidden-public-deck", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="private",
+    ).json()
+
+    response = client.get(
+        f"/rooms/{room['id']}", headers=_headers(sqlite_session, stranger)
+    )
+    assert response.status_code == 404
+
+
+def test_public_room_summary_is_visible_before_join(client, sqlite_session: Session):
+    host = _user(sqlite_session, "summary-host")
+    stranger = _user(sqlite_session, "summary-stranger")
+    deck = _deck(sqlite_session, slug="summary-public-deck", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+
+    response = client.get(
+        f"/rooms/{room['id']}", headers=_headers(sqlite_session, stranger)
+    )
+    assert response.status_code == 200
+    assert response.json()["current_user_role"] is None
+    assert response.json()["member_count"] == 1
+
+
+def test_non_host_cannot_close_room_and_closed_room_rejects_join(client, sqlite_session: Session):
+    host = _user(sqlite_session, "close-host")
+    member = _user(sqlite_session, "close-member")
+    late = _user(sqlite_session, "close-late")
+    deck = _deck(sqlite_session, slug="close-public", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+
+    member_headers = _headers(sqlite_session, member)
+    assert client.post(f"/rooms/{room['id']}/join", headers=member_headers).status_code == 200
+    denied = client.post(f"/rooms/{room['id']}/close", headers=member_headers)
+    assert denied.status_code == 403
+
+    closed = client.post(
+        f"/rooms/{room['id']}/close", headers=_headers(sqlite_session, host)
+    )
+    assert closed.status_code == 200
+    assert closed.json()["status"] == "closed"
+    assert closed.json()["closed_at"] is not None
+
+    late_join = client.post(
+        f"/rooms/{room['id']}/join", headers=_headers(sqlite_session, late)
+    )
+    assert late_join.status_code == 409
+
+
+def test_member_can_leave_and_rejoin_public_room(client, sqlite_session: Session):
+    host = _user(sqlite_session, "leave-host")
+    member = _user(sqlite_session, "leave-member")
+    deck = _deck(sqlite_session, slug="leave-public", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+    headers = _headers(sqlite_session, member)
+
+    assert client.post(f"/rooms/{room['id']}/join", headers=headers).status_code == 200
+    left = client.post(f"/rooms/{room['id']}/leave", headers=headers)
+    assert left.status_code == 200
+    assert left.json()["current_user_role"] is None
+    assert left.json()["member_count"] == 1
+
+    rejoined = client.post(f"/rooms/{room['id']}/join", headers=headers)
+    assert rejoined.status_code == 200
+    assert rejoined.json()["current_user_role"] == "member"
+    assert rejoined.json()["member_count"] == 2
+
+
+def test_removed_member_cannot_rejoin_public_room(client, sqlite_session: Session):
+    host = _user(sqlite_session, "removed-host")
+    member = _user(sqlite_session, "removed-member")
+    deck = _deck(sqlite_session, slug="removed-public", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+    headers = _headers(sqlite_session, member)
+    assert client.post(f"/rooms/{room['id']}/join", headers=headers).status_code == 200
+
+    membership = sqlite_session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room["id"], RoomMember.user_id == member.id
+        )
+    ).one()
+    membership.status = "removed"
+    sqlite_session.add(membership)
+    sqlite_session.commit()
+
+    response = client.post(f"/rooms/{room['id']}/join", headers=headers)
+    assert response.status_code == 403
+    assert "removed" in response.json()["detail"].lower()
+
+
+def test_my_rooms_only_lists_active_memberships(client, sqlite_session: Session):
+    host = _user(sqlite_session, "mine-host")
+    member = _user(sqlite_session, "mine-member")
+    deck = _deck(sqlite_session, slug="mine-public", visibility="public")
+    room = _create_room(
+        client,
+        sqlite_session,
+        host,
+        deck,
+        visibility="public",
+    ).json()
+    headers = _headers(sqlite_session, member)
+
+    assert client.post(f"/rooms/{room['id']}/join", headers=headers).status_code == 200
+    mine = client.get("/rooms/mine", headers=headers)
+    assert mine.status_code == 200
+    assert [item["id"] for item in mine.json()] == [room["id"]]
+
+    assert client.post(f"/rooms/{room['id']}/leave", headers=headers).status_code == 200
+    assert client.get("/rooms/mine", headers=headers).json() == []
+
+
+def test_room_message_model_is_durable_history_not_presence(sqlite_session: Session):
+    host = _user(sqlite_session, "message-host")
+    deck = _deck(sqlite_session, slug="message-deck", visibility="public")
+    room = StudyRoom(
+        host_user_id=int(host.id or 0),
+        deck_id=int(deck.id or 0),
+        name="Message Room",
+        visibility="private",
+    )
+    sqlite_session.add(room)
+    sqlite_session.commit()
+    sqlite_session.refresh(room)
+
+    message = RoomMessage(
+        room_id=int(room.id or 0),
+        user_id=int(host.id or 0),
+        kind="chat",
+        body="Persistent hello",
+    )
+    sqlite_session.add(message)
+    sqlite_session.commit()
+    sqlite_session.refresh(message)
+
+    stored = sqlite_session.get(RoomMessage, message.id)
+    assert stored is not None
+    assert stored.body == "Persistent hello"
+    assert not hasattr(stored, "is_online")

--- a/docs/QUEST_ROOMS_ARCHITECTURE.md
+++ b/docs/QUEST_ROOMS_ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# Quest Rooms architecture
+
+Quest Rooms are **deck-linked study session containers**. Chat, card sharing, presence, and synchronized Arcade activities all live inside the same room boundary rather than becoming separate social systems.
+
+## State boundaries
+
+| State | Storage | Why |
+| --- | --- | --- |
+| Room identity, host, deck, visibility, status | PostgreSQL | Must survive deploys/restarts |
+| Membership and roles | PostgreSQL | Permissions cannot depend on a socket being connected |
+| Message/card/activity history | PostgreSQL | Reconnect/history must be durable |
+| Presence and connection counts | Ephemeral realtime process | Heartbeats should not write to the database continuously |
+| Shared Arcade runtime | Realtime host, with phase-safe snapshots | Uses the same activity contract as solo Arcade |
+
+The first realtime implementation may keep presence and active room runtime in memory while FlashQuest runs a single realtime instance. Before horizontal scale, a shared pub/sub layer is required so participants connected to different instances receive the same events.
+
+## Persistent models
+
+### `StudyRoom`
+
+A room references one existing deck. It never copies deck/card content into room tables.
+
+- `host_user_id`
+- `deck_id`
+- `name`
+- `visibility`: `public | private | invite_only`
+- `status`: `open | closed`
+- creation/update/close timestamps
+
+### `RoomMember`
+
+Membership is durable permission state, not connection state.
+
+- one row per `(room_id, user_id)`
+- `role`: `host | moderator | member`
+- `status`: `active | left | removed`
+- join/last-seen/removal timestamps
+
+A reconnect or second browser tab does not create a second membership row.
+
+### `RoomMessage`
+
+Messages are durable history with room/user attribution.
+
+- `kind`: `chat | card | system | activity`
+- text body
+- optional `card_id`
+- creation/removal timestamps
+
+Presence is intentionally absent from this model.
+
+## Deck privacy rules
+
+A room must never widen the discoverability of its backing deck.
+
+- Official/public decks may back public, private, or invite-only rooms.
+- Unlisted decks may back private or invite-only rooms, but **not public rooms**.
+- Private decks may only be used by their owner and may not back public rooms.
+- Server-side checks enforce these rules; the UI is not the security boundary.
+
+There is intentionally no public room-discovery endpoint in the foundation. Broad public-room discovery remains blocked until moderation/reporting work is ready.
+
+## Membership lifecycle
+
+Verified accounts may create rooms. The creator becomes the persistent `host` member in the same transaction.
+
+Authenticated accounts may join open public rooms. Generic join does not bypass private/invite-only membership. A member who voluntarily left a public room may rejoin; a member marked `removed` cannot self-rejoin.
+
+Only the host closes a room in the foundation. Closed rooms preserve membership/history but reject new joins.
+
+## Realtime authentication
+
+Browser WebSocket APIs should not receive long-lived account bearer tokens in query strings.
+
+The planned connection flow is:
+
+1. Authenticated HTTP client requests `POST /rooms/{id}/ws-ticket`.
+2. Server validates membership/access and returns a short-lived, one-use opaque ticket.
+3. Browser opens `WS /rooms/{id}/ws?ticket=...`.
+4. Server consumes the ticket and binds the socket to the resolved room member.
+
+Tickets should expire in roughly 30–60 seconds and are capabilities for one connection attempt, not replacement login sessions.
+
+## Presence and reconnects
+
+Presence is an in-memory connection registry keyed by room/user connection ids.
+
+- Multiple tabs may create multiple live connections for one member.
+- The member remains online until the final live connection closes or expires.
+- Heartbeats update ephemeral connection expiry.
+- `RoomMember.last_seen_at` may be updated opportunistically, not on every ping.
+- Reconnect loads persistent membership/history and the current phase-safe activity snapshot.
+
+## Realtime event envelope
+
+Quest Rooms will use one versioned envelope for chat, presence, and games. Planned event types include:
+
+- `presence.joined`
+- `presence.left`
+- `message.created`
+- `card.shared`
+- `room.updated`
+- `activity.started`
+- `activity.state`
+- `activity.completed`
+- `error`
+
+Every mutation is authorized server-side regardless of what controls the client displays.
+
+## Shared Arcade contract
+
+Room games do **not** get a second multiplayer game engine. Quest Rooms host the same `ActivityRuntime` used by solo Arcade and broadcast only `ActivityPublicState`.
+
+Correct answer ids/maps stay server-internal until synchronized reveal. Room/team score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
+
+## Moderation launch gate
+
+Before broad public-room discovery ships, the realtime/message layer must include at least:
+
+- message length limits
+- per-user/room rate limits
+- host kick/remove hooks
+- room close hooks
+- permission-checked message/card posting
+- report/block/ban support from the moderation workstream
+
+This foundation intentionally ships persistence and permissions before public social discovery.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
   - Engineering:
       - Architecture & Design: PLATFORM_ENGINEERING.md
       - Arcade Activity Contract: ARCADE_ACTIVITY_CONTRACT.md
+      - Quest Rooms Architecture: QUEST_ROOMS_ARCHITECTURE.md
       - Operations & Deployment: OPERATIONS.md
   - Reference:
       - Backend API: backend/api.md


### PR DESCRIPTION
## What changed

Implements the first server/data slice of Quest Rooms from #14 on top of the merged solo Arcade baseline.

### Persistent room model
- Adds `StudyRoom`, `RoomMember`, and `RoomMessage` SQLModel tables.
- Adds Alembic revision `e0c1f4a5b6d7` after the Library migration head.
- Room/member/message state is durable; realtime presence is intentionally **not** persisted per heartbeat.
- Membership has a unique `(room_id, user_id)` boundary plus explicit host/moderator/member and active/left/removed states.
- Messages support chat/card/system/activity history and optional card attribution for later realtime work.

### REST permission foundation
- Verified accounts can create deck-linked rooms.
- Creator becomes the persistent host member in the same transaction.
- Authenticated users can join open public rooms.
- Private/invite-only rooms reject generic join until #18 adds explicit invite/private UX.
- Voluntarily-left public members may rejoin; removed members cannot self-rejoin.
- Only the host can close a room; closed rooms reject new joins.
- `/rooms/mine`, room detail, member listing, join, leave, and close are permission checked server-side.
- Private/invite-only room ids return 404 to non-members rather than becoming an enumeration surface.

### Deck privacy boundary
A room cannot widen its backing deck's visibility:
- Official/public decks may back public/private/invite-only rooms.
- Unlisted decks may back private/invite-only rooms but not public rooms.
- Private decks can only be used by their owner and cannot back public rooms.
- There is intentionally no public room-directory endpoint in this slice.

### Architecture docs
Adds `QUEST_ROOMS_ARCHITECTURE.md` covering:
- durable room/member/message state vs ephemeral presence
- single-instance realtime boundary and future pub/sub scale-out
- short-lived one-use WebSocket ticket flow (no long-lived bearer tokens in URLs)
- reconnect/multiple-tab semantics
- shared `ActivityPublicState` contract for room-hosted Arcade
- moderation gate before broad public-room discovery

### Tests
Covers:
- verified creator requirement
- automatic host membership
- public-room/unlisted-deck leak prevention
- private deck ownership
- public join idempotency
- private/invite generic-join denial
- private room non-enumerability
- public summary before join
- host-only close + closed-room join rejection
- leave/rejoin behavior
- removed-member rejoin denial
- active-only `/rooms/mine`
- durable message model separation from presence

## Intentionally deferred
This does **not** add WebSocket transport, presence, chat posting, ws-ticket issuance, room invites, or public room discovery yet. Those remain separate follow-on slices (#15, #18, #19, #23) after this persistence/permission layer proves clean.

Related to #14; does not close it yet.