### PR TITLE
Add realtime Quest Room chat and presence

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 
 from .config import settings
 from .db import get_session
-from .routers import activities, auth, cards, decks, rooms, study
+from .routers import activities, auth, cards, decks, room_realtime, rooms, study
 
 
 def _allowed_origins() -> list[str]:
@@ -75,6 +75,7 @@ app.include_router(cards.router)
 app.include_router(study.router)
 app.include_router(activities.router)
 app.include_router(rooms.router)
+app.include_router(room_realtime.router)
 
 
 @app.get("/health")

--- a/backend/app/room_models.py
+++ b/backend/app/room_models.py
@@ -141,3 +141,23 @@ class RoomMemberRead(SQLModel):
     status: str
     joined_at: datetime
     last_seen_at: datetime
+
+
+class RoomMessageRead(SQLModel):
+    """Durable message shape used by history and realtime snapshots."""
+
+    id: int
+    room_id: int
+    user_id: int
+    author_display_name: str
+    kind: str
+    body: str
+    card_id: Optional[int] = None
+    created_at: datetime
+
+
+class WsTicketResponse(SQLModel):
+    """One-use capability for opening one room WebSocket connection."""
+
+    ticket: str
+    expires_in_seconds: int

--- a/backend/app/room_realtime.py
+++ b/backend/app/room_realtime.py
@@ -1,0 +1,168 @@
+"""Single-instance realtime primitives for Quest Rooms.
+
+Tickets, presence, and rate-limit windows are intentionally ephemeral. Durable
+membership and messages live in PostgreSQL. Before horizontally scaling the
+realtime service, broadcasts must move behind shared pub/sub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import secrets
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from time import monotonic
+from typing import Any
+
+from fastapi import WebSocket
+
+WS_TICKET_TTL_SECONDS = 45
+MAX_WS_TICKETS = 2_000
+MESSAGE_RATE_LIMIT = 8
+MESSAGE_RATE_WINDOW_SECONDS = 10
+MESSAGE_MAX_LENGTH = 1_000
+EVENT_SCHEMA = "quest-room.v1"
+
+
+@dataclass(frozen=True)
+class RoomWsTicket:
+    room_id: int
+    user_id: int
+    expires_at: float
+
+
+_ticket_lock = Lock()
+_tickets: dict[str, RoomWsTicket] = {}
+
+
+def _ticket_key(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _cleanup_tickets(now: float) -> None:
+    expired = [key for key, value in _tickets.items() if value.expires_at <= now]
+    for key in expired:
+        _tickets.pop(key, None)
+    if len(_tickets) <= MAX_WS_TICKETS:
+        return
+    oldest = sorted(_tickets.items(), key=lambda item: item[1].expires_at)
+    for key, _value in oldest[: len(_tickets) - MAX_WS_TICKETS]:
+        _tickets.pop(key, None)
+
+
+def issue_ws_ticket(room_id: int, user_id: int) -> str:
+    """Create a short-lived one-use opaque capability for one room socket."""
+    raw = secrets.token_urlsafe(32)
+    now = monotonic()
+    with _ticket_lock:
+        _cleanup_tickets(now)
+        _tickets[_ticket_key(raw)] = RoomWsTicket(
+            room_id=room_id,
+            user_id=user_id,
+            expires_at=now + WS_TICKET_TTL_SECONDS,
+        )
+    return raw
+
+
+def consume_ws_ticket(raw: str, room_id: int) -> RoomWsTicket | None:
+    """Atomically consume one ticket. Reuse, expiry, or room mismatch fails."""
+    if not raw:
+        return None
+    now = monotonic()
+    with _ticket_lock:
+        _cleanup_tickets(now)
+        ticket = _tickets.pop(_ticket_key(raw), None)
+    if ticket is None or ticket.expires_at <= now or ticket.room_id != room_id:
+        return None
+    return ticket
+
+
+def event_envelope(room_id: int, event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the versioned server event shape shared by all room realtime work."""
+    return {
+        "schema": EVENT_SCHEMA,
+        "room_id": room_id,
+        "type": event_type,
+        "server_timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": payload,
+    }
+
+
+class RoomConnectionManager:
+    """In-memory presence/broadcast manager for one realtime process."""
+
+    def __init__(self) -> None:
+        self._connections: dict[int, dict[int, list[WebSocket]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        self._lock = asyncio.Lock()
+
+    async def connect(self, room_id: int, user_id: int, websocket: WebSocket) -> bool:
+        """Register a socket and return True when this is the user's first tab."""
+        async with self._lock:
+            first_connection = not self._connections[room_id][user_id]
+            self._connections[room_id][user_id].append(websocket)
+            return first_connection
+
+    async def disconnect(self, room_id: int, user_id: int, websocket: WebSocket) -> bool:
+        """Remove one socket and return True when the user is now fully offline."""
+        async with self._lock:
+            room = self._connections.get(room_id)
+            if room is None:
+                return False
+            sockets = room.get(user_id, [])
+            if websocket in sockets:
+                sockets.remove(websocket)
+            if sockets:
+                return False
+            room.pop(user_id, None)
+            if not room:
+                self._connections.pop(room_id, None)
+            return True
+
+    async def online_user_ids(self, room_id: int) -> list[int]:
+        async with self._lock:
+            return sorted(self._connections.get(room_id, {}).keys())
+
+    async def broadcast(self, room_id: int, event: dict[str, Any]) -> None:
+        """Broadcast best-effort to sockets attached to this process."""
+        async with self._lock:
+            sockets = [
+                socket
+                for user_sockets in self._connections.get(room_id, {}).values()
+                for socket in user_sockets
+            ]
+        for socket in sockets:
+            try:
+                await socket.send_json(event)
+            except Exception:
+                # Disconnect cleanup belongs to each socket handler. A failed send
+                # must not stop healthy participants from receiving the event.
+                continue
+
+
+class MessageRateLimiter:
+    """Small in-memory anti-spam window; moderation adds stronger controls later."""
+
+    def __init__(self) -> None:
+        self._events: dict[tuple[int, int], deque[float]] = defaultdict(deque)
+        self._lock = Lock()
+
+    def allow(self, room_id: int, user_id: int) -> bool:
+        now = monotonic()
+        key = (room_id, user_id)
+        with self._lock:
+            window = self._events[key]
+            while window and now - window[0] > MESSAGE_RATE_WINDOW_SECONDS:
+                window.popleft()
+            if len(window) >= MESSAGE_RATE_LIMIT:
+                return False
+            window.append(now)
+            return True
+
+
+room_connections = RoomConnectionManager()
+message_rate_limiter = MessageRateLimiter()

--- a/backend/app/routers/room_realtime.py
+++ b/backend/app/routers/room_realtime.py
@@ -1,0 +1,297 @@
+"""Realtime Quest Room transport with one-use tickets and durable chat history."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
+from sqlmodel import Session, select
+
+from ..db import get_session
+from ..models import User, utc_now
+from ..room_models import RoomMessage, RoomMessageRead, StudyRoom, WsTicketResponse
+from ..room_realtime import (
+    MESSAGE_MAX_LENGTH,
+    WS_TICKET_TTL_SECONDS,
+    consume_ws_ticket,
+    event_envelope,
+    issue_ws_ticket,
+    message_rate_limiter,
+    room_connections,
+)
+from ..security import get_current_user
+from .rooms import _active_member, _require_member, _room_or_404
+
+router = APIRouter(prefix="/rooms", tags=["room-realtime"])
+
+
+def _message_payload(session: Session, message: RoomMessage) -> dict[str, Any]:
+    user = session.get(User, message.user_id)
+    return {
+        "id": int(message.id or 0),
+        "room_id": message.room_id,
+        "user_id": message.user_id,
+        "author_display_name": user.display_name if user is not None else "Unknown learner",
+        "kind": message.kind,
+        "body": message.body,
+        "card_id": message.card_id,
+        "created_at": message.created_at.isoformat(),
+    }
+
+
+def _message_read(session: Session, message: RoomMessage) -> RoomMessageRead:
+    payload = _message_payload(session, message)
+    return RoomMessageRead(**payload)
+
+
+def _recent_messages(
+    session: Session,
+    room_id: int,
+    *,
+    limit: int = 50,
+    before_id: int | None = None,
+) -> list[RoomMessage]:
+    query = select(RoomMessage).where(
+        RoomMessage.room_id == room_id,
+        RoomMessage.removed_at.is_(None),
+    )
+    if before_id is not None:
+        query = query.where(RoomMessage.id < before_id)
+    rows = session.exec(query.order_by(RoomMessage.id.desc()).limit(limit)).all()
+    return list(reversed(rows))
+
+
+def _presence_payload(session: Session, user_ids: list[int]) -> list[dict[str, Any]]:
+    presence: list[dict[str, Any]] = []
+    for user_id in user_ids:
+        user = session.get(User, user_id)
+        if user is None:
+            continue
+        presence.append({"user_id": user_id, "display_name": user.display_name})
+    return presence
+
+
+@router.post("/{room_id}/ws-ticket", response_model=WsTicketResponse)
+def room_ws_ticket(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> WsTicketResponse:
+    """Issue a short-lived one-use ticket to an active room member."""
+    room = _room_or_404(session, room_id)
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+    _require_member(session, room, int(user.id or 0))
+    raw = issue_ws_ticket(room_id, int(user.id or 0))
+    return WsTicketResponse(ticket=raw, expires_in_seconds=WS_TICKET_TTL_SECONDS)
+
+
+@router.get("/{room_id}/messages", response_model=list[RoomMessageRead])
+def room_message_history(
+    room_id: int,
+    limit: int = Query(50, ge=1, le=100),
+    before_id: int | None = Query(None, ge=1),
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[RoomMessageRead]:
+    """Return durable chronological history to active room members."""
+    room = _room_or_404(session, room_id)
+    _require_member(session, room, int(user.id or 0))
+    return [
+        _message_read(session, message)
+        for message in _recent_messages(
+            session,
+            room_id,
+            limit=limit,
+            before_id=before_id,
+        )
+    ]
+
+
+@router.websocket("/{room_id}/ws")
+async def room_websocket(
+    websocket: WebSocket,
+    room_id: int,
+    ticket: str = Query(...),
+    session: Session = Depends(get_session),
+) -> None:
+    """Connect one authenticated room member for realtime presence and chat."""
+    capability = consume_ws_ticket(ticket, room_id)
+    if capability is None:
+        await websocket.close(code=4401)
+        return
+
+    room = session.get(StudyRoom, room_id)
+    member = _active_member(session, room_id, capability.user_id)
+    user = session.get(User, capability.user_id)
+    if room is None or room.status != "open" or member is None or user is None:
+        await websocket.close(code=4403)
+        return
+
+    await websocket.accept()
+    first_connection = await room_connections.connect(
+        room_id,
+        capability.user_id,
+        websocket,
+    )
+    member.last_seen_at = utc_now()
+    session.add(member)
+    session.commit()
+
+    online_ids = await room_connections.online_user_ids(room_id)
+    snapshot = event_envelope(
+        room_id,
+        "room.snapshot",
+        {
+            "self_user_id": capability.user_id,
+            "messages": [
+                _message_payload(session, message)
+                for message in _recent_messages(session, room_id, limit=50)
+            ],
+            "presence": _presence_payload(session, online_ids),
+        },
+    )
+    await websocket.send_json(snapshot)
+
+    if first_connection:
+        await room_connections.broadcast(
+            room_id,
+            event_envelope(
+                room_id,
+                "presence.joined",
+                {
+                    "user": {
+                        "user_id": capability.user_id,
+                        "display_name": user.display_name,
+                    },
+                    "presence": _presence_payload(session, online_ids),
+                },
+            ),
+        )
+
+    try:
+        while True:
+            incoming = await websocket.receive_json()
+            if not isinstance(incoming, dict):
+                await websocket.send_json(
+                    event_envelope(room_id, "error", {"message": "Invalid event"})
+                )
+                continue
+
+            event_type = str(incoming.get("type") or "")
+            if event_type == "ping":
+                await websocket.send_json(event_envelope(room_id, "pong", {}))
+                continue
+
+            if event_type != "chat.send":
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "error",
+                        {"message": "Unsupported room event"},
+                    )
+                )
+                continue
+
+            # Re-check durable permissions on every mutation. A user removed while
+            # connected cannot keep posting because their original ticket was valid.
+            session.expire_all()
+            current_room = session.get(StudyRoom, room_id)
+            current_member = _active_member(session, room_id, capability.user_id)
+            if (
+                current_room is None
+                or current_room.status != "open"
+                or current_member is None
+            ):
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "error",
+                        {"message": "Active room membership required"},
+                    )
+                )
+                await websocket.close(code=4403)
+                return
+
+            payload = incoming.get("payload")
+            payload = payload if isinstance(payload, dict) else {}
+            body = " ".join(str(payload.get("body") or "").strip().split())
+            if not body:
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "error",
+                        {"message": "Message cannot be empty"},
+                    )
+                )
+                continue
+            if len(body) > MESSAGE_MAX_LENGTH:
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "error",
+                        {"message": f"Message must be {MESSAGE_MAX_LENGTH} characters or fewer"},
+                    )
+                )
+                continue
+            if not message_rate_limiter.allow(room_id, capability.user_id):
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "error",
+                        {"message": "You're sending messages too quickly"},
+                    )
+                )
+                continue
+
+            message = RoomMessage(
+                room_id=room_id,
+                user_id=capability.user_id,
+                kind="chat",
+                body=body,
+            )
+            current_member.last_seen_at = utc_now()
+            current_room.updated_at = utc_now()
+            session.add(message)
+            session.add(current_member)
+            session.add(current_room)
+            session.commit()
+            session.refresh(message)
+
+            await room_connections.broadcast(
+                room_id,
+                event_envelope(
+                    room_id,
+                    "message.created",
+                    {"message": _message_payload(session, message)},
+                ),
+            )
+    except WebSocketDisconnect:
+        pass
+    finally:
+        last_connection = await room_connections.disconnect(
+            room_id,
+            capability.user_id,
+            websocket,
+        )
+        membership = _active_member(session, room_id, capability.user_id)
+        if membership is not None:
+            membership.last_seen_at = utc_now()
+            session.add(membership)
+            session.commit()
+        if last_connection:
+            online_ids = await room_connections.online_user_ids(room_id)
+            await room_connections.broadcast(
+                room_id,
+                event_envelope(
+                    room_id,
+                    "presence.left",
+                    {
+                        "user": {
+                            "user_id": capability.user_id,
+                            "display_name": user.display_name,
+                        },
+                        "presence": _presence_payload(session, online_ids),
+                    },
+                ),
+            )

--- a/backend/tests/test_room_realtime.py
+++ b/backend/tests/test_room_realtime.py
@@ -1,0 +1,257 @@
+"""Realtime Quest Room ticket, chat, presence, and reconnect tests."""
+
+from sqlmodel import Session, select
+
+from app.models import Deck, User
+from app.room_models import RoomMember, RoomMessage
+from app.room_realtime import (
+    MESSAGE_RATE_LIMIT,
+    MessageRateLimiter,
+    consume_ws_ticket,
+    issue_ws_ticket,
+)
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"realtime-{suffix}@example.com",
+        display_name=f"Realtime {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _public_deck(session: Session, owner: User, slug: str) -> Deck:
+    deck = Deck(
+        owner_id=owner.id,
+        title=f"Realtime Deck {slug}",
+        slug=slug,
+        description="Realtime room test deck",
+        is_builtin=False,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public",
+        tags=["realtime"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return deck
+
+
+def _public_room(client, session: Session, host: User, deck: Deck) -> dict:
+    response = client.post(
+        "/rooms",
+        headers=_headers(session, host),
+        json={
+            "deck_id": int(deck.id or 0),
+            "name": "Realtime Crew",
+            "visibility": "public",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _join(client, session: Session, room_id: int, user: User) -> dict[str, str]:
+    headers = _headers(session, user)
+    response = client.post(f"/rooms/{room_id}/join", headers=headers)
+    assert response.status_code == 200
+    return headers
+
+
+def _ticket(client, room_id: int, headers: dict[str, str]) -> str:
+    response = client.post(f"/rooms/{room_id}/ws-ticket", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["expires_in_seconds"] == 45
+    return payload["ticket"]
+
+
+def test_ws_ticket_is_one_use_and_bound_to_room():
+    raw = issue_ws_ticket(room_id=7, user_id=22)
+    assert consume_ws_ticket(raw, room_id=8) is None
+    # Room mismatch consumes the capability rather than leaving a reusable secret.
+    assert consume_ws_ticket(raw, room_id=7) is None
+
+    raw = issue_ws_ticket(room_id=7, user_id=22)
+    ticket = consume_ws_ticket(raw, room_id=7)
+    assert ticket is not None
+    assert ticket.room_id == 7
+    assert ticket.user_id == 22
+    assert consume_ws_ticket(raw, room_id=7) is None
+
+
+def test_ws_ticket_requires_active_membership(client, sqlite_session: Session):
+    host = _user(sqlite_session, "ticket-host")
+    stranger = _user(sqlite_session, "ticket-stranger")
+    deck = _public_deck(sqlite_session, host, "ticket-deck")
+    room = _public_room(client, sqlite_session, host, deck)
+
+    denied = client.post(
+        f"/rooms/{room['id']}/ws-ticket",
+        headers=_headers(sqlite_session, stranger),
+    )
+    assert denied.status_code == 403
+
+    joined_headers = _join(client, sqlite_session, room["id"], stranger)
+    allowed = client.post(
+        f"/rooms/{room['id']}/ws-ticket",
+        headers=joined_headers,
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["ticket"]
+
+
+def test_two_websockets_exchange_persisted_chat_and_presence(client, sqlite_session: Session):
+    host = _user(sqlite_session, "socket-host")
+    member = _user(sqlite_session, "socket-member")
+    deck = _public_deck(sqlite_session, host, "socket-deck")
+    room = _public_room(client, sqlite_session, host, deck)
+    host_headers = _headers(sqlite_session, host)
+    member_headers = _join(client, sqlite_session, room["id"], member)
+    host_ticket = _ticket(client, room["id"], host_headers)
+    member_ticket = _ticket(client, room["id"], member_headers)
+
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={host_ticket}"
+    ) as host_ws:
+        host_snapshot = host_ws.receive_json()
+        assert host_snapshot["type"] == "room.snapshot"
+        assert host_snapshot["payload"]["self_user_id"] == host.id
+        assert len(host_snapshot["payload"]["presence"]) == 1
+        assert host_ws.receive_json()["type"] == "presence.joined"
+
+        with client.websocket_connect(
+            f"/rooms/{room['id']}/ws?ticket={member_ticket}"
+        ) as member_ws:
+            member_snapshot = member_ws.receive_json()
+            assert member_snapshot["type"] == "room.snapshot"
+            assert len(member_snapshot["payload"]["presence"]) == 2
+
+            host_joined = host_ws.receive_json()
+            member_joined = member_ws.receive_json()
+            assert host_joined["type"] == "presence.joined"
+            assert member_joined["type"] == "presence.joined"
+            assert host_joined["payload"]["user"]["user_id"] == member.id
+
+            host_ws.send_json(
+                {"type": "chat.send", "payload": {"body": "  hello   room  "}}
+            )
+            host_message = host_ws.receive_json()
+            member_message = member_ws.receive_json()
+            assert host_message["type"] == "message.created"
+            assert member_message["type"] == "message.created"
+            assert host_message["payload"]["message"]["body"] == "hello room"
+            assert member_message["payload"]["message"]["id"] == host_message["payload"]["message"]["id"]
+            assert host_message["payload"]["message"]["author_display_name"] == host.display_name
+
+        left = host_ws.receive_json()
+        assert left["type"] == "presence.left"
+        assert left["payload"]["user"]["user_id"] == member.id
+        assert len(left["payload"]["presence"]) == 1
+
+    messages = sqlite_session.exec(
+        select(RoomMessage).where(RoomMessage.room_id == room["id"])
+    ).all()
+    assert len(messages) == 1
+    assert messages[0].body == "hello room"
+
+    history = client.get(
+        f"/rooms/{room['id']}/messages",
+        headers=host_headers,
+    )
+    assert history.status_code == 200
+    assert len(history.json()) == 1
+    assert history.json()[0]["body"] == "hello room"
+    assert history.json()[0]["author_display_name"] == host.display_name
+
+
+def test_reconnect_keeps_membership_and_message_history_single(client, sqlite_session: Session):
+    host = _user(sqlite_session, "reconnect-host")
+    member = _user(sqlite_session, "reconnect-member")
+    deck = _public_deck(sqlite_session, host, "reconnect-deck")
+    room = _public_room(client, sqlite_session, host, deck)
+    headers = _join(client, sqlite_session, room["id"], member)
+
+    first_ticket = _ticket(client, room["id"], headers)
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={first_ticket}"
+    ) as websocket:
+        assert websocket.receive_json()["type"] == "room.snapshot"
+        assert websocket.receive_json()["type"] == "presence.joined"
+        websocket.send_json(
+            {"type": "chat.send", "payload": {"body": "survive reconnect"}}
+        )
+        assert websocket.receive_json()["type"] == "message.created"
+
+    second_ticket = _ticket(client, room["id"], headers)
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={second_ticket}"
+    ) as websocket:
+        snapshot = websocket.receive_json()
+        assert snapshot["type"] == "room.snapshot"
+        assert [message["body"] for message in snapshot["payload"]["messages"]] == [
+            "survive reconnect"
+        ]
+        assert websocket.receive_json()["type"] == "presence.joined"
+
+    memberships = sqlite_session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room["id"], RoomMember.user_id == member.id
+        )
+    ).all()
+    messages = sqlite_session.exec(
+        select(RoomMessage).where(RoomMessage.room_id == room["id"])
+    ).all()
+    assert len(memberships) == 1
+    assert memberships[0].status == "active"
+    assert len(messages) == 1
+
+
+def test_empty_and_oversized_chat_are_rejected_without_persistence(client, sqlite_session: Session):
+    host = _user(sqlite_session, "invalid-host")
+    deck = _public_deck(sqlite_session, host, "invalid-deck")
+    room = _public_room(client, sqlite_session, host, deck)
+    headers = _headers(sqlite_session, host)
+    ticket = _ticket(client, room["id"], headers)
+
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={ticket}"
+    ) as websocket:
+        assert websocket.receive_json()["type"] == "room.snapshot"
+        assert websocket.receive_json()["type"] == "presence.joined"
+
+        websocket.send_json({"type": "chat.send", "payload": {"body": "   "}})
+        empty = websocket.receive_json()
+        assert empty["type"] == "error"
+        assert "empty" in empty["payload"]["message"].lower()
+
+        websocket.send_json(
+            {"type": "chat.send", "payload": {"body": "x" * 1_001}}
+        )
+        oversized = websocket.receive_json()
+        assert oversized["type"] == "error"
+        assert "1000" in oversized["payload"]["message"]
+
+    assert sqlite_session.exec(select(RoomMessage)).all() == []
+
+
+def test_message_rate_limiter_blocks_burst_after_limit():
+    limiter = MessageRateLimiter()
+    for _ in range(MESSAGE_RATE_LIMIT):
+        assert limiter.allow(room_id=1, user_id=2) is True
+    assert limiter.allow(room_id=1, user_id=2) is False
+    # Limits are isolated by room/user instead of becoming a global throttle.
+    assert limiter.allow(room_id=1, user_id=3) is True
+    assert limiter.allow(room_id=2, user_id=2) is True

--- a/docs/QUEST_ROOMS_ARCHITECTURE.md
+++ b/docs/QUEST_ROOMS_ARCHITECTURE.md
@@ -12,7 +12,7 @@ Quest Rooms are **deck-linked study session containers**. Chat, card sharing, pr
 | Presence and connection counts | Ephemeral realtime process | Heartbeats should not write to the database continuously |
 | Shared Arcade runtime | Realtime host, with phase-safe snapshots | Uses the same activity contract as solo Arcade |
 
-The first realtime implementation may keep presence and active room runtime in memory while FlashQuest runs a single realtime instance. Before horizontal scale, a shared pub/sub layer is required so participants connected to different instances receive the same events.
+The first realtime implementation keeps presence in memory while FlashQuest runs a single realtime instance. Before horizontal scale, a shared pub/sub layer is required so participants connected to different instances receive the same events.
 
 ## Persistent models
 
@@ -72,46 +72,60 @@ Only the host closes a room in the foundation. Closed rooms preserve membership/
 
 Browser WebSocket APIs should not receive long-lived account bearer tokens in query strings.
 
-The planned connection flow is:
+The implemented connection flow is:
 
-1. Authenticated HTTP client requests `POST /rooms/{id}/ws-ticket`.
-2. Server validates membership/access and returns a short-lived, one-use opaque ticket.
+1. Authenticated active room member requests `POST /rooms/{id}/ws-ticket`.
+2. Server returns a **45-second, one-use opaque ticket**.
 3. Browser opens `WS /rooms/{id}/ws?ticket=...`.
-4. Server consumes the ticket and binds the socket to the resolved room member.
+4. Server atomically consumes the ticket, revalidates room/membership, and binds the socket to that user.
 
-Tickets should expire in roughly 30–60 seconds and are capabilities for one connection attempt, not replacement login sessions.
+The raw ticket is never stored persistently. Reuse, expiry, or room mismatch fails. The ticket is a capability for one connection attempt, not a replacement login session.
 
-## Presence and reconnects
+## Presence, chat, and reconnects
 
-Presence is an in-memory connection registry keyed by room/user connection ids.
+Presence is an in-memory connection registry keyed by room and user, while chat messages are persisted before broadcast.
 
 - Multiple tabs may create multiple live connections for one member.
-- The member remains online until the final live connection closes or expires.
-- Heartbeats update ephemeral connection expiry.
-- `RoomMember.last_seen_at` may be updated opportunistically, not on every ping.
-- Reconnect loads persistent membership/history and the current phase-safe activity snapshot.
+- `presence.joined` is emitted only for the first live connection for that user.
+- `presence.left` is emitted only after the final live connection closes.
+- Reconnect requests a fresh one-use ticket and receives a `room.snapshot` containing current presence plus the latest durable messages.
+- `RoomMember.last_seen_at` is updated opportunistically rather than on every network event.
+- Every chat mutation re-checks durable room membership, so a user removed while connected cannot keep posting with an old socket.
+- Chat messages are capped at 1,000 characters and have a basic per-user/per-room burst limit.
+- `GET /rooms/{id}/messages` provides durable member-only history independently of the WebSocket connection.
+
+The current connection manager is intentionally single-process. Cross-instance broadcasts require shared pub/sub before running multiple realtime instances.
 
 ## Realtime event envelope
 
-Quest Rooms will use one versioned envelope for chat, presence, and games. Planned event types include:
+Quest Rooms use the versioned `quest-room.v1` envelope with room id, event type, server timestamp, and event-specific payload.
 
+Implemented chat/presence events include:
+
+- `room.snapshot`
 - `presence.joined`
 - `presence.left`
 - `message.created`
+- `pong`
+- `error`
+
+Planned shared-study events include:
+
 - `card.shared`
 - `room.updated`
 - `activity.started`
 - `activity.state`
 - `activity.completed`
-- `error`
 
 Every mutation is authorized server-side regardless of what controls the client displays.
 
 ## Shared Arcade contract
 
-Room games do **not** get a second multiplayer game engine. Quest Rooms host the same `ActivityRuntime` used by solo Arcade and broadcast only `ActivityPublicState`.
+Room games do **not** get a second multiplayer game engine. Quest Rooms will host the same `ActivityRuntime` used by solo Arcade and broadcast only `ActivityPublicState`.
 
 Correct answer ids/maps stay server-internal until synchronized reveal. Room/team score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
+
+Room-hosted Arcade synchronization remains a follow-on slice; the current realtime implementation covers chat, presence, durable history, and secure connection tickets.
 
 ## Moderation launch gate
 
@@ -124,4 +138,4 @@ Before broad public-room discovery ships, the realtime/message layer must includ
 - permission-checked message/card posting
 - report/block/ban support from the moderation workstream
 
-This foundation intentionally ships persistence and permissions before public social discovery.
+The first two controls and membership-checked chat posting exist in the realtime foundation. Broad public-room discovery remains blocked until the remaining moderation/reporting controls are implemented.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,15 @@ import { AuthProvider, useAuth } from "./auth";
 import { ExperienceProvider } from "./experience";
 import { GameFeelProvider, SoundToggle } from "./gameFeel";
 import Admin from "./pages/Admin";
+import Arcade from "./pages/Arcade";
 import Landing from "./pages/Landing";
 import Library from "./pages/Library";
 import LibraryDeck from "./pages/LibraryDeck";
 import Login from "./pages/Login";
 import MyDecks from "./pages/MyDecks";
 import Preferences from "./pages/Preferences";
+import Room from "./pages/Room";
+import Rooms from "./pages/Rooms";
 import Signup from "./pages/Signup";
 import Status from "./pages/Status";
 import Study from "./pages/Study";
@@ -21,7 +24,9 @@ function Shell() {
   const location = useLocation();
   const navItems = [
     { to: "/study", icon: "⚡", label: "Play" },
+    { to: "/arcade", icon: "🎮", label: "Arcade" },
     { to: "/library", icon: "📚", label: "Library" },
+    ...(user ? [{ to: "/rooms", icon: "👥", label: "Rooms" }] : []),
     { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
     ...(user ? [{ to: "/decks", icon: "🗂️", label: "My Decks" }] : []),
     { to: "/status", icon: "🗺️", label: "Deck Map" },
@@ -75,8 +80,11 @@ function Shell() {
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/study" element={<Study />} />
+          <Route path="/arcade" element={<Arcade />} />
           <Route path="/library" element={<Library />} />
           <Route path="/library/:slug" element={<LibraryDeck />} />
+          <Route path="/rooms" element={<Rooms />} />
+          <Route path="/rooms/:roomId" element={<Room />} />
           <Route path="/deck-lab" element={<Admin />} />
           <Route path="/admin" element={<Navigate to="/deck-lab" replace />} />
           <Route path="/decks" element={<MyDecks />} />
@@ -90,7 +98,7 @@ function Shell() {
       </main>
 
       <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-        <span>Library · community decks · Arcade foundation · adaptable learning modes</span>
+        <span>Library · community decks · Arcade · Quest Rooms · adaptable learning modes</span>
         <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>
       </footer>
     </div>

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -1,0 +1,460 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { useAuth } from "../auth";
+import { useGameFeel } from "../gameFeelContext";
+import {
+  closeRoom,
+  getRoom,
+  getRoomWsTicket,
+  joinRoom,
+  leaveRoom,
+  roomWebSocketUrl,
+  type PresenceUser,
+  type RoomMessageRead,
+  type RoomRead,
+  type RoomRealtimeEvent,
+} from "../roomApi";
+
+type ConnectionState = "idle" | "connecting" | "live" | "offline";
+
+function messageTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function isMessage(value: unknown): value is RoomMessageRead {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "id" in value &&
+      "body" in value &&
+      "author_display_name" in value
+  );
+}
+
+function presenceFrom(value: unknown): PresenceUser[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is PresenceUser =>
+      Boolean(
+        item &&
+          typeof item === "object" &&
+          "user_id" in item &&
+          "display_name" in item
+      )
+  );
+}
+
+export default function Room() {
+  const { roomId: roomIdParam } = useParams();
+  const roomId = Number(roomIdParam || 0);
+  const { user } = useAuth();
+  const { play } = useGameFeel();
+  const navigate = useNavigate();
+  const socketRef = useRef<WebSocket | null>(null);
+
+  const [room, setRoom] = useState<RoomRead | null>(null);
+  const [messages, setMessages] = useState<RoomMessageRead[]>([]);
+  const [presence, setPresence] = useState<PresenceUser[]>([]);
+  const [connection, setConnection] = useState<ConnectionState>("idle");
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const loadRoom = useCallback(async () => {
+    if (!user || !Number.isInteger(roomId) || roomId <= 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      setRoom(await getRoom(roomId));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not open this room");
+    } finally {
+      setBusy(false);
+    }
+  }, [roomId, user]);
+
+  useEffect(() => {
+    void loadRoom();
+  }, [loadRoom]);
+
+  const handleRealtimeEvent = useCallback(
+    (event: RoomRealtimeEvent) => {
+      if (event.type === "room.snapshot") {
+        const nextMessages = event.payload.messages;
+        if (Array.isArray(nextMessages)) {
+          setMessages(nextMessages.filter(isMessage));
+        }
+        setPresence(presenceFrom(event.payload.presence));
+        return;
+      }
+
+      if (event.type === "presence.joined" || event.type === "presence.left") {
+        setPresence(presenceFrom(event.payload.presence));
+        return;
+      }
+
+      if (event.type === "message.created") {
+        const message = event.payload.message;
+        if (!isMessage(message)) return;
+        setMessages((current) =>
+          current.some((existing) => existing.id === message.id)
+            ? current
+            : [...current, message]
+        );
+        if (message.user_id !== user?.id) play("success");
+        return;
+      }
+
+      if (event.type === "error") {
+        const message = event.payload.message;
+        setError(typeof message === "string" ? message : "Quest Room realtime error");
+      }
+    },
+    [play, user?.id]
+  );
+
+  const connectRealtime = useCallback(async () => {
+    if (
+      !user ||
+      !room ||
+      !room.current_user_role ||
+      room.status !== "open" ||
+      !Number.isInteger(roomId) ||
+      roomId <= 0
+    ) {
+      return;
+    }
+
+    socketRef.current?.close();
+    socketRef.current = null;
+    setConnection("connecting");
+    setError(null);
+
+    try {
+      const { ticket } = await getRoomWsTicket(roomId);
+      const socket = new WebSocket(roomWebSocketUrl(roomId, ticket));
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        if (socketRef.current === socket) setConnection("live");
+      };
+      socket.onmessage = (messageEvent) => {
+        try {
+          const parsed = JSON.parse(String(messageEvent.data)) as RoomRealtimeEvent;
+          if (parsed?.schema === "quest-room.v1" && parsed.room_id === roomId) {
+            handleRealtimeEvent(parsed);
+          }
+        } catch {
+          setError("Received an unreadable realtime event");
+        }
+      };
+      socket.onerror = () => {
+        if (socketRef.current === socket) {
+          setError("Realtime connection hit a network error");
+        }
+      };
+      socket.onclose = () => {
+        if (socketRef.current === socket) {
+          socketRef.current = null;
+          setConnection("offline");
+        }
+      };
+    } catch (cause) {
+      setConnection("offline");
+      setError(cause instanceof Error ? cause.message : "Could not connect to realtime room");
+    }
+  }, [handleRealtimeEvent, room, roomId, user]);
+
+  useEffect(() => {
+    if (room?.current_user_role && room.status === "open") {
+      void connectRealtime();
+    }
+    return () => {
+      socketRef.current?.close();
+      socketRef.current = null;
+    };
+  }, [connectRealtime, room?.current_user_role, room?.status]);
+
+  if (!user) {
+    return (
+      <section className="game-panel mx-auto max-w-xl p-8 text-center">
+        <div className="text-5xl">👥</div>
+        <h1 className="mt-4 text-2xl font-black text-white">Sign in to enter a Quest Room</h1>
+        <Link to="/login" className="game-button mt-6 inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]">
+          Sign in
+        </Link>
+      </section>
+    );
+  }
+
+  async function handleJoin() {
+    setBusy(true);
+    setError(null);
+    try {
+      const joined = await joinRoom(roomId);
+      setRoom(joined);
+      play("success");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not join room");
+      play("miss");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleLeave() {
+    setBusy(true);
+    setError(null);
+    try {
+      await leaveRoom(roomId);
+      socketRef.current?.close();
+      play("reveal");
+      navigate("/rooms");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not leave room");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleClose() {
+    setBusy(true);
+    setError(null);
+    try {
+      const closed = await closeRoom(roomId);
+      socketRef.current?.close();
+      setRoom(closed);
+      setConnection("offline");
+      play("complete");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not close room");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyRoomLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+      play("success");
+    } catch {
+      setError("Could not copy the room link on this device");
+    }
+  }
+
+  function sendChat(event: FormEvent) {
+    event.preventDefault();
+    const body = draft.trim();
+    const socket = socketRef.current;
+    if (!body || !socket || socket.readyState !== WebSocket.OPEN) return;
+    socket.send(JSON.stringify({ type: "chat.send", payload: { body } }));
+    setDraft("");
+  }
+
+  if (!room && busy) {
+    return <div className="game-panel p-8 text-center text-slate-300">Opening Quest Room…</div>;
+  }
+
+  if (!room) {
+    return (
+      <section className="game-panel mx-auto max-w-2xl p-8 text-center">
+        <div className="text-5xl">🚪</div>
+        <h1 className="mt-4 text-2xl font-black text-white">Room unavailable</h1>
+        <p className="mt-3 text-slate-400">{error ?? "This room does not exist or is not visible to you."}</p>
+        <Link to="/rooms" className="game-button mt-6 inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]">
+          Back to Quest Rooms
+        </Link>
+      </section>
+    );
+  }
+
+  const isMember = Boolean(room.current_user_role);
+  const isHost = room.current_user_role === "host";
+  const connectionLabel =
+    connection === "live"
+      ? "🟢 Live"
+      : connection === "connecting"
+        ? "🟡 Connecting"
+        : "⚪ Offline";
+
+  return (
+    <div className="grid gap-5">
+      <section className="game-panel p-5 sm:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-[#ffba08]">👥 Quest Room #{room.id}</span>
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{room.visibility.replace("_", " ")}</span>
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{room.status}</span>
+            </div>
+            <h1 className="mt-3 text-3xl font-black text-white sm:text-4xl">{room.name}</h1>
+            <p className="mt-2 text-sm text-slate-400">
+              Deck #{room.deck_id} · {room.member_count} member{room.member_count === 1 ? "" : "s"}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button type="button" onClick={() => void copyRoomLink()} className="game-button game-chip px-3 py-2 text-xs font-black text-slate-200">
+              {copied ? "✅ Copied" : "🔗 Copy room link"}
+            </button>
+            <Link to={`/study?deck=${room.deck_id}`} className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white">
+              ⚡ Study deck
+            </Link>
+            <Link to={`/arcade?deck=${room.deck_id}`} className="game-button border border-[#faa307]/25 bg-[#370617]/60 px-3 py-2 text-xs font-black text-[#ffba08]">
+              🎮 Arcade
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {error && (
+        <section className="game-panel border-[#d00000]/50 p-4 text-sm text-rose-200">
+          🛡️ {error}
+        </section>
+      )}
+
+      {!isMember && room.status === "open" && room.visibility === "public" && (
+        <section className="game-panel p-7 text-center">
+          <div className="text-4xl">🚪</div>
+          <h2 className="mt-3 text-2xl font-black text-white">You found a public Quest Room</h2>
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-400">
+            Join to receive live presence and chat. Membership is persistent; disconnecting your browser does not create or remove membership rows.
+          </p>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void handleJoin()}
+            className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          >
+            👋 Join room
+          </button>
+        </section>
+      )}
+
+      {isMember && (
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="game-panel flex min-h-[520px] flex-col overflow-hidden">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
+              <div>
+                <p className="text-sm font-black text-white">💬 Room chat</p>
+                <p className="mt-0.5 text-xs text-slate-500">Messages persist across reconnects.</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{connectionLabel}</span>
+                {room.status === "open" && connection === "offline" && (
+                  <button type="button" className="game-button px-2.5 py-1 text-xs font-black text-[#ffba08]" onClick={() => void connectRealtime()}>
+                    Reconnect
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-5" aria-live="polite">
+              {messages.length === 0 ? (
+                <div className="grid min-h-60 place-items-center text-center text-sm text-slate-500">
+                  <div><div className="text-4xl">🌱</div><p className="mt-3">No messages yet. Somebody gets to be first.</p></div>
+                </div>
+              ) : (
+                messages.map((message) => {
+                  const mine = message.user_id === user.id;
+                  return (
+                    <article key={message.id} className={`max-w-[88%] rounded-2xl border p-3 ${mine ? "ml-auto border-[#faa307]/25 bg-[#faa307]/10" : "border-white/10 bg-black/20"}`}>
+                      <div className="flex flex-wrap items-center gap-2 text-xs">
+                        <strong className={mine ? "text-[#ffba08]" : "text-slate-200"}>{mine ? "You" : message.author_display_name}</strong>
+                        <span className="text-slate-600">{messageTime(message.created_at)}</span>
+                      </div>
+                      <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">{message.body}</p>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+
+            <form className="border-t border-white/10 p-3 sm:p-4" onSubmit={sendChat}>
+              <div className="flex gap-2">
+                <label htmlFor="room-chat" className="sr-only">Message room</label>
+                <input
+                  id="room-chat"
+                  className="game-input"
+                  maxLength={1000}
+                  value={draft}
+                  disabled={connection !== "live" || room.status !== "open"}
+                  placeholder={connection === "live" ? "Message the room…" : "Reconnect to chat…"}
+                  onChange={(event) => setDraft(event.target.value)}
+                />
+                <button
+                  type="submit"
+                  disabled={!draft.trim() || connection !== "live" || room.status !== "open"}
+                  className="game-button bg-[#faa307] px-4 font-black text-[#370617]"
+                >
+                  Send
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <aside className="grid content-start gap-4">
+            <section className="game-panel p-4">
+              <div className="flex items-center justify-between gap-2">
+                <p className="metric-label">Online now</p>
+                <span className="game-chip px-2 py-0.5 text-xs font-black text-slate-300">{presence.length}</span>
+              </div>
+              <div className="mt-3 space-y-2">
+                {presence.length === 0 ? (
+                  <p className="text-sm text-slate-500">Presence is offline.</p>
+                ) : (
+                  presence.map((person) => (
+                    <div key={person.user_id} className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm font-bold text-slate-200">
+                      <span aria-hidden="true">🟢</span>
+                      <span className="truncate">{person.user_id === user.id ? "You" : person.display_name}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="game-panel p-4">
+              <p className="metric-label">Room controls</p>
+              <p className="mt-2 text-sm text-slate-400">Role: <strong className="text-slate-200">{room.current_user_role}</strong></p>
+              {isHost ? (
+                <button
+                  type="button"
+                  disabled={busy || room.status === "closed"}
+                  onClick={() => void handleClose()}
+                  className="game-button mt-4 w-full border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm font-black text-rose-200"
+                >
+                  🔒 Close room
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void handleLeave()}
+                  className="game-button mt-4 w-full border border-white/10 bg-white/[0.04] px-3 py-2 text-sm font-black text-slate-200"
+                >
+                  Leave room
+                </button>
+              )}
+            </section>
+
+            <p className="px-2 text-xs leading-5 text-slate-600">
+              Presence is realtime process state; membership and messages stay durable in PostgreSQL.
+            </p>
+          </aside>
+        </section>
+      )}
+
+      {room.status === "closed" && (
+        <section className="game-panel p-5 text-center text-slate-300">
+          🔒 This room is closed. Its membership and chat history remain durable, but realtime posting is off.
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { getLibraryDecks, getMyDecks } from "../api";

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,0 +1,301 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { getLibraryDecks, getMyDecks } from "../api";
+import { useAuth } from "../auth";
+import { useGameFeel } from "../gameFeelContext";
+import {
+  createRoom,
+  getMyRooms,
+  getRoom,
+  joinRoom,
+  type RoomRead,
+  type RoomVisibility,
+} from "../roomApi";
+import type { DeckRead } from "../types";
+
+function uniqueDecks(rows: DeckRead[]): DeckRead[] {
+  const seen = new Set<number>();
+  return rows.filter((deck) => {
+    if (seen.has(deck.id)) return false;
+    seen.add(deck.id);
+    return true;
+  });
+}
+
+function roomBadge(room: RoomRead): string {
+  if (room.status === "closed") return "🔒 Closed";
+  if (room.visibility === "public") return "🌐 Public by link";
+  if (room.visibility === "invite_only") return "✉️ Invite only";
+  return "🔐 Private";
+}
+
+export default function Rooms() {
+  const { user } = useAuth();
+  const { play } = useGameFeel();
+  const navigate = useNavigate();
+  const [rooms, setRooms] = useState<RoomRead[]>([]);
+  const [decks, setDecks] = useState<DeckRead[]>([]);
+  const [name, setName] = useState("Study Crew");
+  const [deckId, setDeckId] = useState<number | null>(null);
+  const [visibility, setVisibility] = useState<RoomVisibility>("private");
+  const [joinId, setJoinId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedDeck = useMemo(
+    () => decks.find((deck) => deck.id === deckId) ?? null,
+    [deckId, decks]
+  );
+  const canPublic = Boolean(
+    selectedDeck && (selectedDeck.is_official || selectedDeck.visibility === "public")
+  );
+
+  useEffect(() => {
+    if (visibility === "public" && selectedDeck && !canPublic) {
+      setVisibility("private");
+    }
+  }, [canPublic, selectedDeck, visibility]);
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const [mine, library, owned] = await Promise.all([
+          getMyRooms(),
+          getLibraryDecks({ page_size: 50, sort: "featured" }),
+          getMyDecks(),
+        ]);
+        if (cancelled) return;
+        const availableDecks = uniqueDecks([...library.items, ...owned]);
+        setRooms(mine);
+        setDecks(availableDecks);
+        setDeckId((current) => current ?? availableDecks[0]?.id ?? null);
+      } catch (cause) {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : "Could not load Quest Rooms");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  if (!user) {
+    return (
+      <section className="game-panel mx-auto max-w-2xl p-8 text-center">
+        <div className="text-5xl" aria-hidden="true">👥</div>
+        <h1 className="mt-4 text-3xl font-black text-white">Quest Rooms need an account</h1>
+        <p className="mt-3 text-slate-400">
+          Rooms keep persistent membership and author identity, so realtime participation starts with signed-in learners.
+        </p>
+        <Link
+          to="/login"
+          className="game-button mt-6 inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]"
+        >
+          Sign in to Rooms
+        </Link>
+      </section>
+    );
+  }
+
+  async function submitCreate(event: FormEvent) {
+    event.preventDefault();
+    if (!deckId || !name.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const room = await createRoom({
+        deck_id: deckId,
+        name,
+        visibility,
+      });
+      play("success");
+      navigate(`/rooms/${room.id}`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not create room");
+      play("miss");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitJoin(event: FormEvent) {
+    event.preventDefault();
+    const roomId = Number(joinId);
+    if (!Number.isInteger(roomId) || roomId <= 0) {
+      setError("Enter a valid room number");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const room = await getRoom(roomId);
+      if (!room.current_user_role) await joinRoom(roomId);
+      play("success");
+      navigate(`/rooms/${roomId}`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not join that room");
+      play("miss");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-7">
+      <section>
+        <p className="metric-label">👥 Quest Rooms</p>
+        <h1 className="mt-2 text-4xl font-black tracking-tight text-white sm:text-5xl">
+          Study together. <span className="ember-text">Same deck, same room.</span>
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
+          Rooms are deck-linked spaces for live chat and presence. Public rooms are joinable by shared link or room number; FlashQuest is not publishing a global room directory yet.
+        </p>
+      </section>
+
+      {error && (
+        <section className="game-panel border-[#d00000]/50 p-4 text-sm text-rose-200">
+          🛡️ {error}
+        </section>
+      )}
+
+      <section className="grid gap-5 lg:grid-cols-2">
+        <form className="game-panel p-5 sm:p-6" onSubmit={submitCreate}>
+          <p className="metric-label">Create a room</p>
+          <h2 className="mt-2 text-2xl font-black text-white">Start a study crew</h2>
+
+          <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="room-name">
+            Room name
+          </label>
+          <input
+            id="room-name"
+            className="game-input mt-2"
+            value={name}
+            maxLength={80}
+            onChange={(event) => setName(event.target.value)}
+          />
+
+          <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-deck">
+            Deck
+          </label>
+          <select
+            id="room-deck"
+            className="game-input mt-2"
+            value={deckId ?? ""}
+            onChange={(event) => setDeckId(Number(event.target.value))}
+          >
+            {decks.map((deck) => (
+              <option key={deck.id} value={deck.id}>
+                {deck.is_official ? "⭐ " : deck.visibility === "private" ? "🔒 " : "🧑‍🚀 "}
+                {deck.title} · {deck.card_count} cards
+              </option>
+            ))}
+          </select>
+
+          <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-visibility">
+            Room access
+          </label>
+          <select
+            id="room-visibility"
+            className="game-input mt-2"
+            value={visibility}
+            onChange={(event) => setVisibility(event.target.value as RoomVisibility)}
+          >
+            <option value="private">Private · host only for now</option>
+            <option value="invite_only">Invite only · invite UX arrives next</option>
+            <option value="public" disabled={!canPublic}>
+              Public by link/ID · signed-in learners can join
+            </option>
+          </select>
+          {!canPublic && selectedDeck && (
+            <p className="mt-2 text-xs leading-5 text-slate-500">
+              This deck is {selectedDeck.visibility}; FlashQuest will not widen it through a public room.
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !deckId || !name.trim()}
+            className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          >
+            {loading ? "Opening room…" : "👥 Create Quest Room"}
+          </button>
+        </form>
+
+        <form className="game-panel p-5 sm:p-6" onSubmit={submitJoin}>
+          <p className="metric-label">Join a shared room</p>
+          <h2 className="mt-2 text-2xl font-black text-white">Got a room number?</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-400">
+            Public rooms are intentionally link/ID based in this phase. Private and invite-only rooms do not become enumerable just because you know a nearby number.
+          </p>
+          <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="join-room-id">
+            Room number
+          </label>
+          <input
+            id="join-room-id"
+            className="game-input mt-2"
+            inputMode="numeric"
+            placeholder="42"
+            value={joinId}
+            onChange={(event) => setJoinId(event.target.value.replace(/[^0-9]/g, ""))}
+          />
+          <button
+            type="submit"
+            disabled={loading || !joinId}
+            className="game-button mt-5 border border-[#faa307]/30 bg-[#370617]/70 px-5 py-3 font-black text-[#ffba08]"
+          >
+            🔗 Open shared room
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="metric-label">Your memberships</p>
+            <h2 className="mt-1 text-2xl font-black text-white">My Quest Rooms</h2>
+          </div>
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">
+            {rooms.length} room{rooms.length === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {rooms.length === 0 ? (
+          <div className="game-panel mt-4 p-7 text-center text-slate-400">
+            No rooms yet. Create one above, or open a room number somebody shared with you.
+          </div>
+        ) : (
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {rooms.map((room) => (
+              <Link
+                key={room.id}
+                to={`/rooms/${room.id}`}
+                className="game-panel game-button block p-5 text-left"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span className="game-chip px-2.5 py-1 text-xs font-black text-[#ffba08]">
+                    {roomBadge(room)}
+                  </span>
+                  <span className="text-xs font-black text-slate-500">#{room.id}</span>
+                </div>
+                <h3 className="mt-4 text-xl font-black text-white">{room.name}</h3>
+                <p className="mt-2 text-sm text-slate-400">
+                  {room.member_count} member{room.member_count === 1 ? "" : "s"} · {room.current_user_role}
+                </p>
+                <p className="mt-4 text-xs font-black text-[#faa307]">Enter room →</p>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/roomApi.ts
+++ b/frontend/src/roomApi.ts
@@ -1,0 +1,154 @@
+import { api, apiBaseURL } from "./api";
+
+export type RoomVisibility = "public" | "private" | "invite_only";
+export type RoomRole = "host" | "moderator" | "member";
+
+export interface RoomRead {
+  id: number;
+  host_user_id: number;
+  deck_id: number;
+  name: string;
+  visibility: RoomVisibility;
+  status: "open" | "closed";
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  member_count: number;
+  current_user_role: RoomRole | null;
+}
+
+export interface RoomMemberRead {
+  id: number;
+  room_id: number;
+  user_id: number;
+  role: RoomRole;
+  status: "active" | "left" | "removed";
+  joined_at: string;
+  last_seen_at: string;
+}
+
+export interface RoomMessageRead {
+  id: number;
+  room_id: number;
+  user_id: number;
+  author_display_name: string;
+  kind: "chat" | "card" | "system" | "activity";
+  body: string;
+  card_id: number | null;
+  created_at: string;
+}
+
+export type PresenceUser = {
+  user_id: number;
+  display_name: string;
+};
+
+export type RoomRealtimeEvent = {
+  schema: "quest-room.v1";
+  room_id: number;
+  type: string;
+  server_timestamp: string;
+  payload: Record<string, unknown>;
+};
+
+function normalizeRoomError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error("Quest Room request failed");
+}
+
+export async function getMyRooms(): Promise<RoomRead[]> {
+  try {
+    const { data } = await api.get<RoomRead[]>("/rooms/mine");
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function createRoom(payload: {
+  deck_id: number;
+  name: string;
+  visibility: RoomVisibility;
+}): Promise<RoomRead> {
+  try {
+    const { data } = await api.post<RoomRead>("/rooms", payload);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function getRoom(roomId: number): Promise<RoomRead> {
+  try {
+    const { data } = await api.get<RoomRead>(`/rooms/${roomId}`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function joinRoom(roomId: number): Promise<RoomRead> {
+  try {
+    const { data } = await api.post<RoomRead>(`/rooms/${roomId}/join`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function leaveRoom(roomId: number): Promise<RoomRead> {
+  try {
+    const { data } = await api.post<RoomRead>(`/rooms/${roomId}/leave`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function closeRoom(roomId: number): Promise<RoomRead> {
+  try {
+    const { data } = await api.post<RoomRead>(`/rooms/${roomId}/close`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function getRoomMembers(roomId: number): Promise<RoomMemberRead[]> {
+  try {
+    const { data } = await api.get<RoomMemberRead[]>(`/rooms/${roomId}/members`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function getRoomMessages(roomId: number): Promise<RoomMessageRead[]> {
+  try {
+    const { data } = await api.get<RoomMessageRead[]>(`/rooms/${roomId}/messages`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function getRoomWsTicket(
+  roomId: number
+): Promise<{ ticket: string; expires_in_seconds: number }> {
+  try {
+    const { data } = await api.post<{ ticket: string; expires_in_seconds: number }>(
+      `/rooms/${roomId}/ws-ticket`
+    );
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export function roomWebSocketUrl(roomId: number, ticket: string): string {
+  const base = new URL(apiBaseURL());
+  base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+  base.pathname = `/rooms/${roomId}/ws`;
+  base.search = new URLSearchParams({ ticket }).toString();
+  return base.toString();
+}


### PR DESCRIPTION
## What changed

Implements #15 on top of the merged Quest Room persistence/permission foundation.

### Secure realtime transport
- Adds a 45-second, one-use opaque WebSocket ticket flow at `POST /rooms/{id}/ws-ticket`.
- Raw account bearer tokens never go into WebSocket URLs.
- Tickets are stored only as hashes in ephemeral process memory and are atomically consumed.
- Expired, reused, or room-mismatched tickets fail.
- The WebSocket revalidates room state and durable membership before connection and again on each chat mutation.

### Presence
- Adds a single-process in-memory connection manager keyed by room/user.
- Multiple tabs for one user are supported.
- `presence.joined` broadcasts only for the user's first live connection.
- `presence.left` broadcasts only after their final live connection closes.
- New/reconnected sockets receive a `room.snapshot` with current presence and recent durable chat history.
- `RoomMember.last_seen_at` is updated opportunistically rather than on every network event.

### Durable realtime chat
- Adds member-only `GET /rooms/{id}/messages` history.
- `chat.send` persists `RoomMessage` in PostgreSQL before `message.created` is broadcast.
- Author identity comes from the authenticated membership/user, never client-supplied identity.
- Empty messages and messages over 1,000 characters are rejected.
- Adds a basic per-user/per-room burst limiter (8 messages / 10 seconds).
- Removed/left members cannot continue posting through a socket that was opened before their membership changed.

### Frontend
- Adds a signed-in Quest Rooms hub for creating rooms, opening existing memberships, and joining public rooms by shared room number/link.
- Adds a live room screen with realtime chat, online presence, connection status, reconnect, copy-link, leave/close controls, and Study/Arcade deck shortcuts.
- Keeps broad public room discovery intentionally absent until the moderation workstream is ready.
- Adds `🎮 Arcade` and `👥 Rooms` to the actual app shell and routes. This also fixes the latent issue where the merged Arcade page existed but had not been registered in `App.tsx`.

### Tests
- one-use / room-bound tickets
- ticket membership authorization
- two simultaneous browser WebSockets exchanging the same persisted message
- join/leave presence broadcasts
- reconnect snapshot/history without duplicate membership/messages
- empty/oversized chat rejection
- per-user/per-room rate-limit isolation

### Architecture boundary
Presence/tickets/rate windows are intentionally single-process ephemeral state. Durable membership/messages remain PostgreSQL state. Before running multiple realtime instances, broadcasts need a shared pub/sub layer.

Room-hosted synchronized Arcade remains #23, private/invite UX remains #18, and broad public-room moderation/discovery remains #19.

Closes #15