### PR TITLE
Launch synchronized Blitz and Match Quest in Quest Rooms

### DIFF
--- a/backend/app/room_arcade.py
+++ b/backend/app/room_arcade.py
@@ -1,0 +1,173 @@
+"""Single-process synchronized Arcade host for Quest Rooms.
+
+Quest Rooms reuse the transport-neutral ActivityRuntime from solo Arcade. Player
+responses remain pending server-side until the host reveals the round, so a
+fast submission cannot leak correctness or the answer key to other learners.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, replace
+from threading import Lock
+from typing import Any, Iterable
+
+from .activities import (
+    ActivityCard,
+    ActivityEvent,
+    ActivityMode,
+    ActivityPhase,
+    ActivityRuntime,
+    ActivityType,
+    apply_activity_event,
+    build_activity_runtime,
+    public_activity_state,
+)
+
+
+@dataclass
+class RoomActivitySession:
+    """Ephemeral room-hosted activity plus unrevealed participant submissions."""
+
+    runtime: ActivityRuntime
+    submissions: dict[int, dict[str, Any]]
+
+
+_room_activities: dict[int, RoomActivitySession] = {}
+_room_activities_lock = Lock()
+
+
+def _payload(session: RoomActivitySession) -> dict[str, Any]:
+    """Serialize only phase-safe state plus non-answer submission metadata."""
+    submitted_user_ids = sorted(session.submissions)
+    return {
+        "state": public_activity_state(session.runtime).model_dump(mode="json"),
+        "submitted_user_ids": submitted_user_ids,
+        "submitted_count": len(submitted_user_ids),
+    }
+
+
+def room_activity_payload(room_id: int) -> dict[str, Any] | None:
+    """Return the current phase-safe room activity snapshot, if one exists."""
+    with _room_activities_lock:
+        session = _room_activities.get(room_id)
+        return _payload(session) if session is not None else None
+
+
+def start_room_activity(
+    *,
+    room_id: int,
+    deck_id: int,
+    cards: Iterable[ActivityCard],
+    activity_type: ActivityType,
+    round_count: int = 5,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Start Blitz/Match in room mode, replacing only a completed prior run."""
+    with _room_activities_lock:
+        existing = _room_activities.get(room_id)
+        if existing is not None and existing.runtime.phase != ActivityPhase.COMPLETE:
+            raise ValueError("A room Arcade activity is already running")
+
+        runtime = build_activity_runtime(
+            activity_type=activity_type,
+            deck_id=deck_id,
+            cards=cards,
+            mode=ActivityMode.ROOM,
+            seed=seed if seed is not None else secrets.randbits(63),
+            round_count=round_count,
+        )
+        # Deterministic seeds are useful for game construction, while each hosted
+        # room run still needs a distinct id for UI/reconnect bookkeeping.
+        runtime = replace(runtime, session_id=secrets.token_urlsafe(18))
+        session = RoomActivitySession(runtime=runtime, submissions={})
+        _room_activities[room_id] = session
+        return _payload(session)
+
+
+def submit_room_activity_response(
+    *,
+    room_id: int,
+    user_id: int,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Store/replace one participant's unrevealed response for the current round."""
+    with _room_activities_lock:
+        session = _room_activities.get(room_id)
+        if session is None:
+            raise ValueError("No room Arcade activity is running")
+        if session.runtime.phase not in {ActivityPhase.PROMPT, ActivityPhase.LOCKED}:
+            raise ValueError("This round is no longer accepting responses")
+        session.submissions[user_id] = dict(payload)
+        return _payload(session)
+
+
+def reveal_room_activity(room_id: int) -> dict[str, Any]:
+    """Score all pending responses through the shared runtime, then reveal once."""
+    with _room_activities_lock:
+        session = _room_activities.get(room_id)
+        if session is None:
+            raise ValueError("No room Arcade activity is running")
+        if session.runtime.phase not in {ActivityPhase.PROMPT, ActivityPhase.LOCKED}:
+            raise ValueError("This round cannot be revealed right now")
+
+        scoring_runtime = session.runtime
+        for user_id, response_payload in sorted(session.submissions.items()):
+            # The shared solo scorer transitions a response to RESULT. For room
+            # synchronization we intentionally keep the public phase unrevealed
+            # between participants, merge only the participant score state, then
+            # perform one synchronized reveal after everyone has been scored.
+            scored = apply_activity_event(
+                scoring_runtime,
+                ActivityEvent(
+                    type="response.submitted",
+                    participant_id=str(user_id),
+                    payload=response_payload,
+                ),
+            )
+            scoring_runtime = replace(
+                scoring_runtime,
+                phase=session.runtime.phase,
+                participants=scored.participants,
+                round_result=None,
+            )
+
+        session.runtime = apply_activity_event(
+            scoring_runtime,
+            ActivityEvent(type="answer.revealed"),
+        )
+        return _payload(session)
+
+
+def next_room_activity_round(room_id: int) -> dict[str, Any]:
+    """Advance a revealed room activity and clear only round-local submissions."""
+    with _room_activities_lock:
+        session = _room_activities.get(room_id)
+        if session is None:
+            raise ValueError("No room Arcade activity is running")
+        session.runtime = apply_activity_event(
+            session.runtime,
+            ActivityEvent(type="round.completed"),
+        )
+        session.submissions.clear()
+        return _payload(session)
+
+
+def end_room_activity(room_id: int) -> dict[str, Any]:
+    """Let the host end a room activity without closing the room itself."""
+    with _room_activities_lock:
+        session = _room_activities.get(room_id)
+        if session is None:
+            raise ValueError("No room Arcade activity is running")
+        session.runtime = apply_activity_event(
+            session.runtime,
+            ActivityEvent(type="session.completed"),
+        )
+        session.submissions.clear()
+        return _payload(session)
+
+
+def clear_room_activity(room_id: int) -> None:
+    """Test/cleanup helper for explicitly forgetting one ephemeral room runtime."""
+    with _room_activities_lock:
+        _room_activities.pop(room_id, None)

--- a/backend/app/routers/room_realtime.py
+++ b/backend/app/routers/room_realtime.py
@@ -1,4 +1,4 @@
-"""Realtime Quest Room transport with one-use tickets and durable chat history."""
+"""Realtime Quest Room transport for chat, presence, and synchronized Arcade."""
 
 from __future__ import annotations
 
@@ -7,8 +7,17 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 from sqlmodel import Session, select
 
+from ..activities import ActivityCard, ActivityType
 from ..db import get_session
-from ..models import User, utc_now
+from ..models import Card, User, utc_now
+from ..room_arcade import (
+    end_room_activity,
+    next_room_activity_round,
+    reveal_room_activity,
+    room_activity_payload,
+    start_room_activity,
+    submit_room_activity_response,
+)
 from ..room_models import RoomMessage, RoomMessageRead, StudyRoom, WsTicketResponse
 from ..room_realtime import (
     MESSAGE_MAX_LENGTH,
@@ -71,6 +80,25 @@ def _presence_payload(session: Session, user_ids: list[int]) -> list[dict[str, A
     return presence
 
 
+def _activity_cards(session: Session, deck_id: int) -> list[ActivityCard]:
+    """Load one room's deck through the same transport-neutral Arcade card shape."""
+    cards = session.exec(select(Card).where(Card.deck_id == deck_id).order_by(Card.id)).all()
+    return [
+        ActivityCard(
+            id=int(card.id or 0),
+            word=card.word,
+            definition=card.definition,
+            domain=card.domain,
+            kind=card.kind,
+        )
+        for card in cards
+    ]
+
+
+async def _send_error(websocket: WebSocket, room_id: int, message: str) -> None:
+    await websocket.send_json(event_envelope(room_id, "error", {"message": message}))
+
+
 @router.post("/{room_id}/ws-ticket", response_model=WsTicketResponse)
 def room_ws_ticket(
     room_id: int,
@@ -115,7 +143,7 @@ async def room_websocket(
     ticket: str = Query(...),
     session: Session = Depends(get_session),
 ) -> None:
-    """Connect one authenticated room member for realtime presence and chat."""
+    """Connect one authenticated member for presence, chat, and shared Arcade."""
     capability = consume_ws_ticket(ticket, room_id)
     if capability is None:
         await websocket.close(code=4401)
@@ -149,6 +177,7 @@ async def room_websocket(
                 for message in _recent_messages(session, room_id, limit=50)
             ],
             "presence": _presence_payload(session, online_ids),
+            "activity": room_activity_payload(room_id),
         },
     )
     await websocket.send_json(snapshot)
@@ -173,9 +202,7 @@ async def room_websocket(
         while True:
             incoming = await websocket.receive_json()
             if not isinstance(incoming, dict):
-                await websocket.send_json(
-                    event_envelope(room_id, "error", {"message": "Invalid event"})
-                )
+                await _send_error(websocket, room_id, "Invalid event")
                 continue
 
             event_type = str(incoming.get("type") or "")
@@ -183,18 +210,8 @@ async def room_websocket(
                 await websocket.send_json(event_envelope(room_id, "pong", {}))
                 continue
 
-            if event_type != "chat.send":
-                await websocket.send_json(
-                    event_envelope(
-                        room_id,
-                        "error",
-                        {"message": "Unsupported room event"},
-                    )
-                )
-                continue
-
-            # Re-check durable permissions on every mutation. A user removed while
-            # connected cannot keep posting because their original ticket was valid.
+            # Every mutation re-checks durable membership. A removed member cannot
+            # keep chatting or playing merely because their socket was opened earlier.
             session.expire_all()
             current_room = session.get(StudyRoom, room_id)
             current_member = _active_member(session, room_id, capability.user_id)
@@ -203,69 +220,152 @@ async def room_websocket(
                 or current_room.status != "open"
                 or current_member is None
             ):
-                await websocket.send_json(
-                    event_envelope(
-                        room_id,
-                        "error",
-                        {"message": "Active room membership required"},
-                    )
-                )
+                await _send_error(websocket, room_id, "Active room membership required")
                 await websocket.close(code=4403)
                 return
 
             payload = incoming.get("payload")
             payload = payload if isinstance(payload, dict) else {}
-            body = " ".join(str(payload.get("body") or "").strip().split())
-            if not body:
-                await websocket.send_json(
-                    event_envelope(
-                        room_id,
-                        "error",
-                        {"message": "Message cannot be empty"},
-                    )
-                )
-                continue
-            if len(body) > MESSAGE_MAX_LENGTH:
-                await websocket.send_json(
-                    event_envelope(
-                        room_id,
-                        "error",
-                        {"message": f"Message must be {MESSAGE_MAX_LENGTH} characters or fewer"},
-                    )
-                )
-                continue
-            if not message_rate_limiter.allow(room_id, capability.user_id):
-                await websocket.send_json(
-                    event_envelope(
-                        room_id,
-                        "error",
-                        {"message": "You're sending messages too quickly"},
-                    )
-                )
-                continue
 
-            message = RoomMessage(
-                room_id=room_id,
-                user_id=capability.user_id,
-                kind="chat",
-                body=body,
-            )
-            current_member.last_seen_at = utc_now()
-            current_room.updated_at = utc_now()
-            session.add(message)
-            session.add(current_member)
-            session.add(current_room)
-            session.commit()
-            session.refresh(message)
+            if event_type == "chat.send":
+                body = " ".join(str(payload.get("body") or "").strip().split())
+                if not body:
+                    await _send_error(websocket, room_id, "Message cannot be empty")
+                    continue
+                if len(body) > MESSAGE_MAX_LENGTH:
+                    await _send_error(
+                        websocket,
+                        room_id,
+                        f"Message must be {MESSAGE_MAX_LENGTH} characters or fewer",
+                    )
+                    continue
+                if not message_rate_limiter.allow(room_id, capability.user_id):
+                    await _send_error(
+                        websocket,
+                        room_id,
+                        "You're sending messages too quickly",
+                    )
+                    continue
 
-            await room_connections.broadcast(
-                room_id,
-                event_envelope(
+                message = RoomMessage(
+                    room_id=room_id,
+                    user_id=capability.user_id,
+                    kind="chat",
+                    body=body,
+                )
+                current_member.last_seen_at = utc_now()
+                current_room.updated_at = utc_now()
+                session.add(message)
+                session.add(current_member)
+                session.add(current_room)
+                session.commit()
+                session.refresh(message)
+
+                await room_connections.broadcast(
                     room_id,
-                    "message.created",
-                    {"message": _message_payload(session, message)},
-                ),
-            )
+                    event_envelope(
+                        room_id,
+                        "message.created",
+                        {"message": _message_payload(session, message)},
+                    ),
+                )
+                continue
+
+            if event_type == "activity.sync":
+                activity = room_activity_payload(room_id)
+                await websocket.send_json(
+                    event_envelope(
+                        room_id,
+                        "activity.state",
+                        {"activity": activity},
+                    )
+                )
+                continue
+
+            if event_type == "activity.start":
+                if current_member.role != "host":
+                    await _send_error(websocket, room_id, "Only the room host can start Arcade")
+                    continue
+                try:
+                    activity_type = ActivityType(str(payload.get("activity_type") or ""))
+                    round_count = int(payload.get("round_count") or 5)
+                    if round_count < 1 or round_count > 20:
+                        raise ValueError("Round count must be between 1 and 20")
+                    activity = start_room_activity(
+                        room_id=room_id,
+                        deck_id=current_room.deck_id,
+                        cards=_activity_cards(session, current_room.deck_id),
+                        activity_type=activity_type,
+                        round_count=round_count,
+                    )
+                except (TypeError, ValueError) as exc:
+                    await _send_error(websocket, room_id, str(exc))
+                    continue
+                await room_connections.broadcast(
+                    room_id,
+                    event_envelope(room_id, "activity.started", {"activity": activity}),
+                )
+                continue
+
+            if event_type == "activity.submit":
+                try:
+                    activity = submit_room_activity_response(
+                        room_id=room_id,
+                        user_id=capability.user_id,
+                        payload=payload,
+                    )
+                except ValueError as exc:
+                    await _send_error(websocket, room_id, str(exc))
+                    continue
+                state = activity["state"]
+                await room_connections.broadcast(
+                    room_id,
+                    event_envelope(
+                        room_id,
+                        "activity.submitted",
+                        {
+                            "session_id": state["session_id"],
+                            "round_index": state["round_index"],
+                            "user_id": capability.user_id,
+                            "submitted_user_ids": activity["submitted_user_ids"],
+                            "submitted_count": activity["submitted_count"],
+                        },
+                    ),
+                )
+                continue
+
+            if event_type in {"activity.reveal", "activity.next", "activity.end"}:
+                if current_member.role != "host":
+                    await _send_error(
+                        websocket,
+                        room_id,
+                        "Only the room host can control the Arcade round",
+                    )
+                    continue
+                try:
+                    if event_type == "activity.reveal":
+                        activity = reveal_room_activity(room_id)
+                        outgoing_type = "activity.state"
+                    elif event_type == "activity.next":
+                        activity = next_room_activity_round(room_id)
+                        outgoing_type = (
+                            "activity.completed"
+                            if activity["state"]["phase"] == "complete"
+                            else "activity.state"
+                        )
+                    else:
+                        activity = end_room_activity(room_id)
+                        outgoing_type = "activity.completed"
+                except ValueError as exc:
+                    await _send_error(websocket, room_id, str(exc))
+                    continue
+                await room_connections.broadcast(
+                    room_id,
+                    event_envelope(room_id, outgoing_type, {"activity": activity}),
+                )
+                continue
+
+            await _send_error(websocket, room_id, "Unsupported room event")
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/tests/test_room_arcade.py
+++ b/backend/tests/test_room_arcade.py
@@ -1,0 +1,277 @@
+"""Synchronized Quest Room Arcade tests using the shared solo activity runtime."""
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.room_arcade import clear_room_activity
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"room-arcade-{suffix}@example.com",
+        display_name=f"Arcade {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck_with_cards(session: Session, owner: User, slug: str, count: int = 6) -> Deck:
+    deck = Deck(
+        owner_id=owner.id,
+        title=f"Room Arcade {slug}",
+        slug=slug,
+        description="Shared Arcade test deck",
+        is_builtin=False,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public",
+        tags=["arcade", "room"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    for index in range(1, count + 1):
+        session.add(
+            Card(
+                deck_id=deck.id,
+                word=f"Prompt {index}",
+                definition=f"Definition {index}",
+                topic=deck.title,
+                domain="Room Arcade",
+                kind="concept",
+                is_builtin=False,
+            )
+        )
+    session.commit()
+    return deck
+
+
+def _room(client, session: Session, host: User, deck: Deck) -> dict:
+    response = client.post(
+        "/rooms",
+        headers=_headers(session, host),
+        json={
+            "deck_id": int(deck.id or 0),
+            "name": "Arcade Party",
+            "visibility": "public",
+        },
+    )
+    assert response.status_code == 201
+    room = response.json()
+    clear_room_activity(room["id"])
+    return room
+
+
+def _join(client, session: Session, room_id: int, user: User) -> dict[str, str]:
+    headers = _headers(session, user)
+    response = client.post(f"/rooms/{room_id}/join", headers=headers)
+    assert response.status_code == 200
+    return headers
+
+
+def _ticket(client, room_id: int, headers: dict[str, str]) -> str:
+    response = client.post(f"/rooms/{room_id}/ws-ticket", headers=headers)
+    assert response.status_code == 200
+    return response.json()["ticket"]
+
+
+def _open_host(client, room_id: int, ticket: str):
+    return client.websocket_connect(f"/rooms/{room_id}/ws?ticket={ticket}")
+
+
+def test_blitz_two_players_submit_chat_reveal_and_advance(client, sqlite_session: Session):
+    host = _user(sqlite_session, "blitz-host")
+    member = _user(sqlite_session, "blitz-member")
+    deck = _deck_with_cards(sqlite_session, host, "blitz")
+    room = _room(client, sqlite_session, host, deck)
+    host_headers = _headers(sqlite_session, host)
+    member_headers = _join(client, sqlite_session, room["id"], member)
+
+    with _open_host(client, room["id"], _ticket(client, room["id"], host_headers)) as host_ws:
+        host_snapshot = host_ws.receive_json()
+        assert host_snapshot["type"] == "room.snapshot"
+        assert host_snapshot["payload"]["activity"] is None
+        assert host_ws.receive_json()["type"] == "presence.joined"
+
+        with client.websocket_connect(
+            f"/rooms/{room['id']}/ws?ticket={_ticket(client, room['id'], member_headers)}"
+        ) as member_ws:
+            assert member_ws.receive_json()["type"] == "room.snapshot"
+            assert host_ws.receive_json()["type"] == "presence.joined"
+            assert member_ws.receive_json()["type"] == "presence.joined"
+
+            host_ws.send_json(
+                {
+                    "type": "activity.start",
+                    "payload": {"activity_type": "blitz", "round_count": 2},
+                }
+            )
+            host_started = host_ws.receive_json()
+            member_started = member_ws.receive_json()
+            assert host_started["type"] == "activity.started"
+            assert member_started["type"] == "activity.started"
+            activity = host_started["payload"]["activity"]
+            state = activity["state"]
+            assert state["definition"]["type"] == "blitz"
+            assert state["mode"] == "room"
+            assert state["phase"] == "prompt"
+            assert state["reveal"] is None
+            assert activity["submitted_count"] == 0
+
+            # The test can derive the implementation's correct choice from the
+            # target card id; clients never receive a correct_choice_id pre-reveal.
+            correct_choice = f"card-{state['payload']['card_id']}"
+            assert "correct_choice_id" not in state["payload"]
+
+            member_ws.send_json(
+                {"type": "activity.submit", "payload": {"choice_id": "card-999999"}}
+            )
+            host_submitted = host_ws.receive_json()
+            member_submitted = member_ws.receive_json()
+            assert host_submitted["type"] == "activity.submitted"
+            assert member_submitted["type"] == "activity.submitted"
+            assert host_submitted["payload"]["submitted_user_ids"] == [member.id]
+
+            host_ws.send_json(
+                {"type": "activity.submit", "payload": {"choice_id": correct_choice}}
+            )
+            host_submit_two = host_ws.receive_json()
+            member_submit_two = member_ws.receive_json()
+            assert host_submit_two["payload"]["submitted_count"] == 2
+            assert member_submit_two["payload"]["submitted_count"] == 2
+
+            # Chat remains usable while a game is active.
+            member_ws.send_json(
+                {"type": "chat.send", "payload": {"body": "good luck on reveal"}}
+            )
+            host_chat = host_ws.receive_json()
+            member_chat = member_ws.receive_json()
+            assert host_chat["type"] == "message.created"
+            assert member_chat["payload"]["message"]["body"] == "good luck on reveal"
+
+            host_ws.send_json({"type": "activity.reveal", "payload": {}})
+            host_reveal = host_ws.receive_json()
+            member_reveal = member_ws.receive_json()
+            assert host_reveal["type"] == "activity.state"
+            assert member_reveal["type"] == "activity.state"
+            revealed = host_reveal["payload"]["activity"]["state"]
+            assert revealed["phase"] == "reveal"
+            assert revealed["reveal"]["correct_choice_id"] == correct_choice
+            scores = {
+                participant["participant_id"]: participant["score"]
+                for participant in revealed["participants"]
+            }
+            assert scores[str(host.id)] == 100
+            assert scores[str(member.id)] == 0
+
+            host_ws.send_json({"type": "activity.next", "payload": {}})
+            host_next = host_ws.receive_json()
+            member_next = member_ws.receive_json()
+            assert host_next["type"] == "activity.state"
+            assert member_next["type"] == "activity.state"
+            next_activity = host_next["payload"]["activity"]
+            assert next_activity["state"]["phase"] == "prompt"
+            assert next_activity["state"]["round_index"] == 1
+            assert next_activity["submitted_user_ids"] == []
+
+
+def test_late_join_snapshot_restores_current_activity_without_answer_leak(
+    client, sqlite_session: Session
+):
+    host = _user(sqlite_session, "late-host")
+    late = _user(sqlite_session, "late-member")
+    deck = _deck_with_cards(sqlite_session, host, "late")
+    room = _room(client, sqlite_session, host, deck)
+    host_headers = _headers(sqlite_session, host)
+
+    with _open_host(client, room["id"], _ticket(client, room["id"], host_headers)) as host_ws:
+        assert host_ws.receive_json()["type"] == "room.snapshot"
+        assert host_ws.receive_json()["type"] == "presence.joined"
+        host_ws.send_json(
+            {"type": "activity.start", "payload": {"activity_type": "blitz", "round_count": 2}}
+        )
+        started = host_ws.receive_json()["payload"]["activity"]
+        assert started["state"]["reveal"] is None
+
+        late_headers = _join(client, sqlite_session, room["id"], late)
+        with client.websocket_connect(
+            f"/rooms/{room['id']}/ws?ticket={_ticket(client, room['id'], late_headers)}"
+        ) as late_ws:
+            snapshot = late_ws.receive_json()
+            assert snapshot["type"] == "room.snapshot"
+            restored = snapshot["payload"]["activity"]
+            assert restored["state"]["session_id"] == started["state"]["session_id"]
+            assert restored["state"]["phase"] == "prompt"
+            assert restored["state"]["reveal"] is None
+
+
+def test_non_host_cannot_start_or_control_room_arcade(client, sqlite_session: Session):
+    host = _user(sqlite_session, "permission-host")
+    member = _user(sqlite_session, "permission-member")
+    deck = _deck_with_cards(sqlite_session, host, "permission")
+    room = _room(client, sqlite_session, host, deck)
+    member_headers = _join(client, sqlite_session, room["id"], member)
+
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={_ticket(client, room['id'], member_headers)}"
+    ) as websocket:
+        assert websocket.receive_json()["type"] == "room.snapshot"
+        assert websocket.receive_json()["type"] == "presence.joined"
+        websocket.send_json(
+            {"type": "activity.start", "payload": {"activity_type": "blitz"}}
+        )
+        denied = websocket.receive_json()
+        assert denied["type"] == "error"
+        assert "host" in denied["payload"]["message"].lower()
+
+
+def test_match_quest_uses_same_room_runtime_and_scores_on_reveal(client, sqlite_session: Session):
+    host = _user(sqlite_session, "match-host")
+    deck = _deck_with_cards(sqlite_session, host, "match", count=5)
+    room = _room(client, sqlite_session, host, deck)
+    host_headers = _headers(sqlite_session, host)
+
+    with _open_host(client, room["id"], _ticket(client, room["id"], host_headers)) as websocket:
+        assert websocket.receive_json()["type"] == "room.snapshot"
+        assert websocket.receive_json()["type"] == "presence.joined"
+
+        websocket.send_json(
+            {"type": "activity.start", "payload": {"activity_type": "match", "round_count": 5}}
+        )
+        started = websocket.receive_json()
+        state = started["payload"]["activity"]["state"]
+        assert state["definition"]["type"] == "match"
+        assert state["mode"] == "room"
+        assert state["reveal"] is None
+        matches = {
+            str(prompt["card_id"]): f"card-{prompt['card_id']}"
+            for prompt in state["payload"]["prompts"]
+        }
+
+        websocket.send_json({"type": "activity.submit", "payload": {"matches": matches}})
+        submitted = websocket.receive_json()
+        assert submitted["type"] == "activity.submitted"
+        assert submitted["payload"]["submitted_count"] == 1
+
+        websocket.send_json({"type": "activity.reveal", "payload": {}})
+        revealed_event = websocket.receive_json()
+        revealed = revealed_event["payload"]["activity"]["state"]
+        assert revealed["phase"] == "reveal"
+        assert revealed["reveal"]["answer_map"] == matches
+        assert revealed["participants"][0]["score"] == 500
+        assert revealed["participants"][0]["response"] == "5/5"
+
+        websocket.send_json({"type": "activity.next", "payload": {}})
+        completed = websocket.receive_json()
+        assert completed["type"] == "activity.completed"
+        assert completed["payload"]["activity"]["state"]["phase"] == "complete"

--- a/docs/QUEST_ROOMS_ARCHITECTURE.md
+++ b/docs/QUEST_ROOMS_ARCHITECTURE.md
@@ -8,11 +8,11 @@ Quest Rooms are **deck-linked study session containers**. Chat, card sharing, pr
 | --- | --- | --- |
 | Room identity, host, deck, visibility, status | PostgreSQL | Must survive deploys/restarts |
 | Membership and roles | PostgreSQL | Permissions cannot depend on a socket being connected |
-| Message/card/activity history | PostgreSQL | Reconnect/history must be durable |
+| Message/card-share history | PostgreSQL | Reconnect/history must be durable |
 | Presence and connection counts | Ephemeral realtime process | Heartbeats should not write to the database continuously |
-| Shared Arcade runtime | Realtime host, with phase-safe snapshots | Uses the same activity contract as solo Arcade |
+| Shared Arcade runtime + unrevealed submissions | Ephemeral realtime process | Uses the same activity contract as solo Arcade without persisting answer-bearing round state |
 
-The first realtime implementation keeps presence in memory while FlashQuest runs a single realtime instance. Before horizontal scale, a shared pub/sub layer is required so participants connected to different instances receive the same events.
+The first realtime implementation keeps presence and active Arcade runtime in memory while FlashQuest runs a single realtime instance. Before horizontal scale, a shared pub/sub/state layer is required so participants connected to different instances receive the same events and activity phase.
 
 ## Persistent models
 
@@ -47,7 +47,7 @@ Messages are durable history with room/user attribution.
 - optional `card_id`
 - creation/removal timestamps
 
-Presence is intentionally absent from this model.
+Presence and the active game runtime are intentionally absent from this model.
 
 ## Deck privacy rules
 
@@ -88,44 +88,54 @@ Presence is an in-memory connection registry keyed by room and user, while chat 
 - Multiple tabs may create multiple live connections for one member.
 - `presence.joined` is emitted only for the first live connection for that user.
 - `presence.left` is emitted only after the final live connection closes.
-- Reconnect requests a fresh one-use ticket and receives a `room.snapshot` containing current presence plus the latest durable messages.
+- Reconnect requests a fresh one-use ticket and receives a `room.snapshot` containing current presence, the latest durable messages, and the current phase-safe Arcade snapshot when a game is active.
 - `RoomMember.last_seen_at` is updated opportunistically rather than on every network event.
-- Every chat mutation re-checks durable room membership, so a user removed while connected cannot keep posting with an old socket.
+- Every chat/game mutation re-checks durable room membership, so a user removed while connected cannot keep posting or playing with an old socket.
 - Chat messages are capped at 1,000 characters and have a basic per-user/per-room burst limit.
 - `GET /rooms/{id}/messages` provides durable member-only history independently of the WebSocket connection.
 
-The current connection manager is intentionally single-process. Cross-instance broadcasts require shared pub/sub before running multiple realtime instances.
+The current connection/activity manager is intentionally single-process. Cross-instance broadcasts and synchronized games require shared pub/sub/state before running multiple realtime instances.
 
 ## Realtime event envelope
 
 Quest Rooms use the versioned `quest-room.v1` envelope with room id, event type, server timestamp, and event-specific payload.
 
-Implemented chat/presence events include:
+Implemented events include:
 
 - `room.snapshot`
 - `presence.joined`
 - `presence.left`
 - `message.created`
+- `activity.started`
+- `activity.submitted`
+- `activity.state`
+- `activity.completed`
 - `pong`
 - `error`
 
-Planned shared-study events include:
-
-- `card.shared`
-- `room.updated`
-- `activity.started`
-- `activity.state`
-- `activity.completed`
+Planned shared-study events include `card.shared` and broader `room.updated`/moderation events.
 
 Every mutation is authorized server-side regardless of what controls the client displays.
 
 ## Shared Arcade contract
 
-Room games do **not** get a second multiplayer game engine. Quest Rooms will host the same `ActivityRuntime` used by solo Arcade and broadcast only `ActivityPublicState`.
+Room games do **not** get a second multiplayer game engine. Quest Rooms host the same `ActivityRuntime` and `ActivityPublicState` used by solo Arcade.
 
-Correct answer ids/maps stay server-internal until synchronized reveal. Room/team score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
+The first room-playable adapters are **Multiple-Choice Blitz** and **Match Quest**:
 
-Room-hosted Arcade synchronization remains a follow-on slice; the current realtime implementation covers chat, presence, durable history, and secure connection tickets.
+- the host starts the activity against the room's existing deck;
+- all members receive the same prompt/board state;
+- participant responses are stored server-side as pending round submissions;
+- submitting does **not** expose correctness, score changes, or answer ids;
+- the host performs one synchronized reveal, which scores every pending submission through the shared solo scoring adapter and publishes the answer plus room scoreboard together;
+- the host advances or ends the activity without recreating/closing the room;
+- reconnecting or joining late restores the current phase-safe activity snapshot;
+- room chat remains available while the game is active;
+- room rounds are host-paced and untimed by default, preserving a Chill/no-timer path for activities whose timers are optional.
+
+Correct answer ids/maps stay server-internal until synchronized reveal. Room Arcade score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
+
+The active room activity is intentionally ephemeral in this phase. A realtime process restart may end an in-progress room game even though the room, membership, and chat history remain durable.
 
 ## Moderation launch gate
 
@@ -138,4 +148,4 @@ Before broad public-room discovery ships, the realtime/message layer must includ
 - permission-checked message/card posting
 - report/block/ban support from the moderation workstream
 
-The first two controls and membership-checked chat posting exist in the realtime foundation. Broad public-room discovery remains blocked until the remaining moderation/reporting controls are implemented.
+The first two controls and membership-checked chat/game mutations exist in the realtime foundation. Broad public-room discovery remains blocked until the remaining moderation/reporting controls are implemented.

--- a/docs/ROOM_ARCADE_V1.md
+++ b/docs/ROOM_ARCADE_V1.md
@@ -1,0 +1,30 @@
+# Quest Room Arcade V1
+
+This slice makes the first two shared FlashQuest Arcade activities playable inside an existing Quest Room.
+
+## Included
+
+- Multiple-Choice Blitz in room mode
+- Match Quest in room mode
+- host-controlled start, synchronized reveal, next round, and end
+- server-held pending submissions before reveal
+- shared `ActivityRuntime` / `ActivityPublicState` contract with solo Arcade
+- late-join/reconnect activity recovery through `room.snapshot`
+- room scoreboard after synchronized reveal
+- live chat and presence while an activity is running
+- host-paced, no-forced-timer presentation
+
+## Spoiler boundary
+
+A participant submission is not scored into public state immediately. The realtime host stores the response privately until the host reveals the round. At reveal time, every pending response is scored through the same server-side adapter used by solo Arcade, and only then are answer-bearing fields and score changes broadcast.
+
+## Current durability boundary
+
+The room, membership, and chat history remain durable PostgreSQL state. Active room Arcade runtime and unrevealed submissions are intentionally single-process ephemeral state in this phase. Horizontal realtime scale requires shared pub/sub/state before multiple instances can safely host one synchronized activity.
+
+## Still tracked in #23
+
+- Sort the Stack
+- Boss Battle
+- Debug Dungeon for compatible decks
+- additional shared-game polish and room challenge variants

--- a/frontend/src/components/RoomArcadePanel.tsx
+++ b/frontend/src/components/RoomArcadePanel.tsx
@@ -1,0 +1,387 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type { ActivityPublicState } from "../activityTypes";
+import type { PresenceUser } from "../roomApi";
+
+export type RoomActivitySnapshot = {
+  state: ActivityPublicState;
+  submitted_user_ids: number[];
+  submitted_count: number;
+};
+
+type BlitzChoice = { id: string; text: string };
+type BlitzPayload = {
+  card_id: number;
+  prompt: string;
+  domain: string;
+  kind: string;
+  choices: BlitzChoice[];
+};
+type MatchPrompt = {
+  card_id: number;
+  prompt: string;
+  domain: string;
+  kind: string;
+};
+type MatchPayload = {
+  prompts: MatchPrompt[];
+  choices: BlitzChoice[];
+};
+type MatchMap = Record<string, string>;
+
+type Props = {
+  activity: RoomActivitySnapshot | null;
+  userId: number;
+  isHost: boolean;
+  presence: PresenceUser[];
+  connectionLive: boolean;
+  onSend: (type: string, payload?: Record<string, unknown>) => void;
+};
+
+function blitzPayload(state: ActivityPublicState): BlitzPayload {
+  return state.payload as unknown as BlitzPayload;
+}
+
+function matchPayload(state: ActivityPublicState): MatchPayload {
+  return state.payload as unknown as MatchPayload;
+}
+
+function displayName(userId: string, currentUserId: number, presence: PresenceUser[]): string {
+  const numericId = Number(userId);
+  if (numericId === currentUserId) return "You";
+  return presence.find((person) => person.user_id === numericId)?.display_name ?? `Player #${userId}`;
+}
+
+function Scoreboard({
+  state,
+  userId,
+  presence,
+}: {
+  state: ActivityPublicState;
+  userId: number;
+  presence: PresenceUser[];
+}) {
+  if (state.participants.length === 0) return null;
+  const rows = [...state.participants].sort((a, b) => b.score - a.score);
+  return (
+    <div className="mt-5 rounded-2xl border border-white/10 bg-black/15 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="metric-label">Room scoreboard</p>
+        <span className="text-xs font-black text-slate-500">Arcade points only</span>
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map((participant, index) => (
+          <div
+            key={participant.participant_id}
+            className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2"
+          >
+            <span className="truncate text-sm font-bold text-slate-200">
+              {index === 0 ? "🏆 " : ""}
+              {displayName(participant.participant_id, userId, presence)}
+            </span>
+            <strong className="text-sm text-[#ffba08]">{participant.score}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function RoomArcadePanel({
+  activity,
+  userId,
+  isHost,
+  presence,
+  connectionLive,
+  onSend,
+}: Props) {
+  const [matches, setMatches] = useState<MatchMap>({});
+  const state = activity?.state ?? null;
+  const submitted = activity?.submitted_user_ids.includes(userId) ?? false;
+
+  useEffect(() => {
+    setMatches({});
+  }, [state?.session_id, state?.round_index]);
+
+  const presenceNames = useMemo(
+    () => new Map(presence.map((person) => [person.user_id, person.display_name])),
+    [presence]
+  );
+
+  function start(activityType: "blitz" | "match") {
+    onSend("activity.start", { activity_type: activityType, round_count: 5 });
+  }
+
+  if (!state || state.phase === "complete") {
+    return (
+      <section className="quest-card p-5 sm:p-6">
+        <div className="relative z-10 grid gap-5 lg:grid-cols-[1fr_auto] lg:items-center">
+          <div>
+            <p className="metric-label">🎮 Room Arcade</p>
+            <h2 className="mt-2 text-2xl font-black text-white sm:text-3xl">
+              {state?.phase === "complete" ? "Quest cleared. Run it back?" : "Same room. Same question. Everybody plays."}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+              Blitz and Match Quest use the same server-authoritative activity runtime as solo Arcade. Room rounds are host-paced and untimed by default.
+            </p>
+            {state?.phase === "complete" && (
+              <Scoreboard state={state} userId={userId} presence={presence} />
+            )}
+          </div>
+          {isHost ? (
+            <div className="grid min-w-56 gap-2">
+              <button
+                type="button"
+                disabled={!connectionLive}
+                onClick={() => start("blitz")}
+                className="game-button bg-[#ffba08] px-4 py-3 text-sm font-black text-[#370617]"
+              >
+                ⚡ Start Blitz
+              </button>
+              <button
+                type="button"
+                disabled={!connectionLive}
+                onClick={() => start("match")}
+                className="game-button border border-cyan-300/25 bg-cyan-300/[0.08] px-4 py-3 text-sm font-black text-cyan-100"
+              >
+                🧩 Start Match Quest
+              </button>
+            </div>
+          ) : (
+            <div className="game-chip px-4 py-3 text-sm font-black text-slate-300">
+              ⏳ Waiting for host
+            </div>
+          )}
+        </div>
+      </section>
+    );
+  }
+
+  const revealed = state.phase === "reveal" || state.phase === "result";
+
+  return (
+    <section className="quest-card p-5 sm:p-6">
+      <div className="relative z-10">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex flex-wrap gap-2">
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-[#ffba08]">
+                {state.definition.type === "blitz" ? "⚡ BLITZ" : "🧩 MATCH QUEST"}
+              </span>
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">
+                Round {state.round_index + 1}/{state.total_rounds}
+              </span>
+              <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">
+                🌿 Host-paced · no timer
+              </span>
+            </div>
+            <h2 className="mt-3 text-2xl font-black text-white">{state.definition.title}</h2>
+          </div>
+          <div className="text-right">
+            <p className="text-2xl font-black text-white">{activity?.submitted_count ?? 0}</p>
+            <p className="text-xs font-black uppercase tracking-wider text-slate-500">submitted</p>
+          </div>
+        </div>
+
+        {state.definition.type === "blitz" ? (
+          <BlitzRound
+            state={state}
+            submitted={submitted}
+            connectionLive={connectionLive}
+            onSubmit={(choiceId) => onSend("activity.submit", { choice_id: choiceId })}
+          />
+        ) : (
+          <MatchRound
+            state={state}
+            matches={matches}
+            submitted={submitted}
+            connectionLive={connectionLive}
+            onMatch={(cardId, choiceId) =>
+              setMatches((current) => ({ ...current, [String(cardId)]: choiceId }))
+            }
+            onSubmit={() => onSend("activity.submit", { matches })}
+          />
+        )}
+
+        {submitted && !revealed && (
+          <div className="mt-4 rounded-xl border border-emerald-300/20 bg-emerald-300/[0.07] px-4 py-3 text-sm font-bold text-emerald-100">
+            ✅ Your answer is locked in locally. The room will not show whether it was right until the host reveals.
+          </div>
+        )}
+
+        <Scoreboard state={state} userId={userId} presence={presence} />
+
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
+          <div className="text-xs text-slate-500">
+            {activity?.submitted_user_ids.length
+              ? activity.submitted_user_ids
+                  .map((id) => (id === userId ? "You" : presenceNames.get(id) ?? `Player #${id}`))
+                  .join(" · ") + " ready"
+              : "Nobody has submitted yet."}
+          </div>
+          {isHost ? (
+            <div className="flex flex-wrap gap-2">
+              {!revealed ? (
+                <button
+                  type="button"
+                  disabled={!connectionLive}
+                  onClick={() => onSend("activity.reveal")}
+                  className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]"
+                >
+                  👀 Reveal together
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  disabled={!connectionLive}
+                  onClick={() => onSend("activity.next")}
+                  className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]"
+                >
+                  Next round →
+                </button>
+              )}
+              <button
+                type="button"
+                disabled={!connectionLive}
+                onClick={() => onSend("activity.end")}
+                className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-black text-slate-200"
+              >
+                End game
+              </button>
+            </div>
+          ) : (
+            <span className="game-chip px-3 py-2 text-xs font-black text-slate-300">
+              {revealed ? "⏳ Host advances the round" : "⏳ Host controls reveal"}
+            </span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BlitzRound({
+  state,
+  submitted,
+  connectionLive,
+  onSubmit,
+}: {
+  state: ActivityPublicState;
+  submitted: boolean;
+  connectionLive: boolean;
+  onSubmit: (choiceId: string) => void;
+}) {
+  const payload = blitzPayload(state);
+  const correctChoice = String(state.reveal?.correct_choice_id ?? "");
+  const revealed = state.phase === "reveal" || state.phase === "result";
+
+  return (
+    <div className="mt-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-xs font-black uppercase tracking-wider text-slate-500">{payload.domain}</span>
+        <span className="text-xs font-black text-slate-500">Choose one</span>
+      </div>
+      <h3 className="mt-3 text-center text-3xl font-black leading-tight text-white sm:text-4xl">
+        {payload.prompt}
+      </h3>
+      <div className="mx-auto mt-6 grid max-w-4xl gap-3 sm:grid-cols-2">
+        {payload.choices.map((choice, index) => {
+          const correct = revealed && choice.id === correctChoice;
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              disabled={!connectionLive || submitted || revealed}
+              onClick={() => onSubmit(choice.id)}
+              className={`game-button min-h-24 border p-4 text-left ${
+                correct
+                  ? "border-emerald-300/50 bg-emerald-300/[0.12] text-emerald-50"
+                  : "border-white/10 bg-black/20 text-slate-100"
+              }`}
+            >
+              <span className="text-xs font-black text-[#faa307]">{index + 1}</span>
+              <span className="mt-2 block text-sm font-bold leading-6">{choice.text}</span>
+              {correct && <span className="mt-2 block text-xs font-black text-emerald-200">✓ Correct answer</span>}
+            </button>
+          );
+        })}
+      </div>
+      {revealed && (
+        <div className="answer-pop mx-auto mt-5 max-w-3xl rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.08] p-4 text-sm leading-6 text-cyan-50">
+          <strong className="text-white">Synchronized reveal:</strong> {String(state.reveal?.answer ?? "")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MatchRound({
+  state,
+  matches,
+  submitted,
+  connectionLive,
+  onMatch,
+  onSubmit,
+}: {
+  state: ActivityPublicState;
+  matches: MatchMap;
+  submitted: boolean;
+  connectionLive: boolean;
+  onMatch: (cardId: number, choiceId: string) => void;
+  onSubmit: () => void;
+}) {
+  const payload = matchPayload(state);
+  const answerMap = (state.reveal?.answer_map ?? {}) as Record<string, string>;
+  const choiceText = new Map(payload.choices.map((choice) => [choice.id, choice.text]));
+  const revealed = state.phase === "reveal" || state.phase === "result";
+  const completeBoard = payload.prompts.every((prompt) => Boolean(matches[String(prompt.card_id)]));
+
+  return (
+    <div className="mt-6">
+      <p className="text-sm leading-6 text-slate-400">
+        Match each prompt with a definition. Native selects keep the room game usable with keyboard, touch, and screen readers — no drag-and-drop required.
+      </p>
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        {payload.prompts.map((prompt) => {
+          const correctChoiceId = answerMap[String(prompt.card_id)];
+          return (
+            <label key={prompt.card_id} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <span className="text-sm font-black text-white">{prompt.prompt}</span>
+              <span className="mt-1 block text-xs text-slate-500">{prompt.domain}</span>
+              {revealed ? (
+                <span className="mt-3 block rounded-xl border border-emerald-300/20 bg-emerald-300/[0.07] px-3 py-2 text-sm text-emerald-100">
+                  ✓ {choiceText.get(correctChoiceId) ?? "Correct match"}
+                </span>
+              ) : (
+                <select
+                  className="game-input mt-3"
+                  aria-label={`Match for ${prompt.prompt}`}
+                  value={matches[String(prompt.card_id)] ?? ""}
+                  disabled={!connectionLive || submitted}
+                  onChange={(event) => onMatch(prompt.card_id, event.target.value)}
+                >
+                  <option value="">Choose definition…</option>
+                  {payload.choices.map((choice) => (
+                    <option key={choice.id} value={choice.id}>{choice.text}</option>
+                  ))}
+                </select>
+              )}
+            </label>
+          );
+        })}
+      </div>
+      {!revealed && (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            disabled={!connectionLive || submitted || !completeBoard}
+            onClick={onSubmit}
+            className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          >
+            🧩 Submit matches
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -291,14 +291,14 @@ export default function Room() {
     }
   }
 
-  const sendRoomEvent = useCallback((type: string, payload: Record<string, unknown> = {}) => {
+  function sendRoomEvent(type: string, payload: Record<string, unknown> = {}) {
     const socket = socketRef.current;
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       setError("Reconnect to the room before sending realtime actions");
       return;
     }
     socket.send(JSON.stringify({ type, payload }));
-  }, []);
+  }
 
   function sendChat(event: FormEvent) {
     event.preventDefault();

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import RoomArcadePanel, {
+  type RoomActivitySnapshot,
+} from "../components/RoomArcadePanel";
 import { useAuth } from "../auth";
 import { useGameFeel } from "../gameFeelContext";
 import {
@@ -48,6 +51,14 @@ function presenceFrom(value: unknown): PresenceUser[] {
   );
 }
 
+function roomActivityFrom(value: unknown): RoomActivitySnapshot | null {
+  if (!value || typeof value !== "object") return null;
+  if (!("state" in value) || !("submitted_user_ids" in value)) return null;
+  const candidate = value as RoomActivitySnapshot;
+  if (!candidate.state || !Array.isArray(candidate.submitted_user_ids)) return null;
+  return candidate;
+}
+
 export default function Room() {
   const { roomId: roomIdParam } = useParams();
   const roomId = Number(roomIdParam || 0);
@@ -59,6 +70,7 @@ export default function Room() {
   const [room, setRoom] = useState<RoomRead | null>(null);
   const [messages, setMessages] = useState<RoomMessageRead[]>([]);
   const [presence, setPresence] = useState<PresenceUser[]>([]);
+  const [activity, setActivity] = useState<RoomActivitySnapshot | null>(null);
   const [connection, setConnection] = useState<ConnectionState>("idle");
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -90,6 +102,7 @@ export default function Room() {
           setMessages(nextMessages.filter(isMessage));
         }
         setPresence(presenceFrom(event.payload.presence));
+        setActivity(roomActivityFrom(event.payload.activity));
         return;
       }
 
@@ -107,6 +120,35 @@ export default function Room() {
             : [...current, message]
         );
         if (message.user_id !== user?.id) play("success");
+        return;
+      }
+
+      if (
+        event.type === "activity.started" ||
+        event.type === "activity.state" ||
+        event.type === "activity.completed"
+      ) {
+        const next = roomActivityFrom(event.payload.activity);
+        setActivity(next);
+        if (next?.state.phase === "complete") play("complete");
+        else if (next?.state.phase === "reveal") play("reveal");
+        else if (next?.state.phase === "prompt") play("roundStart");
+        return;
+      }
+
+      if (event.type === "activity.submitted") {
+        const submitted = event.payload.submitted_user_ids;
+        if (!Array.isArray(submitted)) return;
+        const userIds = submitted.filter((value): value is number => typeof value === "number");
+        setActivity((current) =>
+          current
+            ? {
+                ...current,
+                submitted_user_ids: userIds,
+                submitted_count: userIds.length,
+              }
+            : current
+        );
         return;
       }
 
@@ -249,12 +291,20 @@ export default function Room() {
     }
   }
 
+  const sendRoomEvent = useCallback((type: string, payload: Record<string, unknown> = {}) => {
+    const socket = socketRef.current;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      setError("Reconnect to the room before sending realtime actions");
+      return;
+    }
+    socket.send(JSON.stringify({ type, payload }));
+  }, []);
+
   function sendChat(event: FormEvent) {
     event.preventDefault();
     const body = draft.trim();
-    const socket = socketRef.current;
-    if (!body || !socket || socket.readyState !== WebSocket.OPEN) return;
-    socket.send(JSON.stringify({ type: "chat.send", payload: { body } }));
+    if (!body) return;
+    sendRoomEvent("chat.send", { body });
     setDraft("");
   }
 
@@ -307,7 +357,7 @@ export default function Room() {
               ⚡ Study deck
             </Link>
             <Link to={`/arcade?deck=${room.deck_id}`} className="game-button border border-[#faa307]/25 bg-[#370617]/60 px-3 py-2 text-xs font-black text-[#ffba08]">
-              🎮 Arcade
+              🎮 Solo Arcade
             </Link>
           </div>
         </div>
@@ -338,116 +388,127 @@ export default function Room() {
       )}
 
       {isMember && (
-        <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
-          <div className="game-panel flex min-h-[520px] flex-col overflow-hidden">
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
-              <div>
-                <p className="text-sm font-black text-white">💬 Room chat</p>
-                <p className="mt-0.5 text-xs text-slate-500">Messages persist across reconnects.</p>
+        <>
+          <RoomArcadePanel
+            activity={activity}
+            userId={user.id}
+            isHost={isHost}
+            presence={presence}
+            connectionLive={connection === "live" && room.status === "open"}
+            onSend={sendRoomEvent}
+          />
+
+          <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="game-panel flex min-h-[520px] flex-col overflow-hidden">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
+                <div>
+                  <p className="text-sm font-black text-white">💬 Room chat</p>
+                  <p className="mt-0.5 text-xs text-slate-500">Chat stays live while the room plays.</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{connectionLabel}</span>
+                  {room.status === "open" && connection === "offline" && (
+                    <button type="button" className="game-button px-2.5 py-1 text-xs font-black text-[#ffba08]" onClick={() => void connectRealtime()}>
+                      Reconnect
+                    </button>
+                  )}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{connectionLabel}</span>
-                {room.status === "open" && connection === "offline" && (
-                  <button type="button" className="game-button px-2.5 py-1 text-xs font-black text-[#ffba08]" onClick={() => void connectRealtime()}>
-                    Reconnect
+
+              <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-5" aria-live="polite">
+                {messages.length === 0 ? (
+                  <div className="grid min-h-60 place-items-center text-center text-sm text-slate-500">
+                    <div><div className="text-4xl">🌱</div><p className="mt-3">No messages yet. Somebody gets to be first.</p></div>
+                  </div>
+                ) : (
+                  messages.map((message) => {
+                    const mine = message.user_id === user.id;
+                    return (
+                      <article key={message.id} className={`max-w-[88%] rounded-2xl border p-3 ${mine ? "ml-auto border-[#faa307]/25 bg-[#faa307]/10" : "border-white/10 bg-black/20"}`}>
+                        <div className="flex flex-wrap items-center gap-2 text-xs">
+                          <strong className={mine ? "text-[#ffba08]" : "text-slate-200"}>{mine ? "You" : message.author_display_name}</strong>
+                          <span className="text-slate-600">{messageTime(message.created_at)}</span>
+                        </div>
+                        <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">{message.body}</p>
+                      </article>
+                    );
+                  })
+                )}
+              </div>
+
+              <form className="border-t border-white/10 p-3 sm:p-4" onSubmit={sendChat}>
+                <div className="flex gap-2">
+                  <label htmlFor="room-chat" className="sr-only">Message room</label>
+                  <input
+                    id="room-chat"
+                    className="game-input"
+                    maxLength={1000}
+                    value={draft}
+                    disabled={connection !== "live" || room.status !== "open"}
+                    placeholder={connection === "live" ? "Message the room…" : "Reconnect to chat…"}
+                    onChange={(event) => setDraft(event.target.value)}
+                  />
+                  <button
+                    type="submit"
+                    disabled={!draft.trim() || connection !== "live" || room.status !== "open"}
+                    className="game-button bg-[#faa307] px-4 font-black text-[#370617]"
+                  >
+                    Send
+                  </button>
+                </div>
+              </form>
+            </div>
+
+            <aside className="grid content-start gap-4">
+              <section className="game-panel p-4">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="metric-label">Online now</p>
+                  <span className="game-chip px-2 py-0.5 text-xs font-black text-slate-300">{presence.length}</span>
+                </div>
+                <div className="mt-3 space-y-2">
+                  {presence.length === 0 ? (
+                    <p className="text-sm text-slate-500">Presence is offline.</p>
+                  ) : (
+                    presence.map((person) => (
+                      <div key={person.user_id} className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm font-bold text-slate-200">
+                        <span aria-hidden="true">🟢</span>
+                        <span className="truncate">{person.user_id === user.id ? "You" : person.display_name}</span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </section>
+
+              <section className="game-panel p-4">
+                <p className="metric-label">Room controls</p>
+                <p className="mt-2 text-sm text-slate-400">Role: <strong className="text-slate-200">{room.current_user_role}</strong></p>
+                {isHost ? (
+                  <button
+                    type="button"
+                    disabled={busy || room.status === "closed"}
+                    onClick={() => void handleClose()}
+                    className="game-button mt-4 w-full border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm font-black text-rose-200"
+                  >
+                    🔒 Close room
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void handleLeave()}
+                    className="game-button mt-4 w-full border border-white/10 bg-white/[0.04] px-3 py-2 text-sm font-black text-slate-200"
+                  >
+                    Leave room
                   </button>
                 )}
-              </div>
-            </div>
+              </section>
 
-            <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-5" aria-live="polite">
-              {messages.length === 0 ? (
-                <div className="grid min-h-60 place-items-center text-center text-sm text-slate-500">
-                  <div><div className="text-4xl">🌱</div><p className="mt-3">No messages yet. Somebody gets to be first.</p></div>
-                </div>
-              ) : (
-                messages.map((message) => {
-                  const mine = message.user_id === user.id;
-                  return (
-                    <article key={message.id} className={`max-w-[88%] rounded-2xl border p-3 ${mine ? "ml-auto border-[#faa307]/25 bg-[#faa307]/10" : "border-white/10 bg-black/20"}`}>
-                      <div className="flex flex-wrap items-center gap-2 text-xs">
-                        <strong className={mine ? "text-[#ffba08]" : "text-slate-200"}>{mine ? "You" : message.author_display_name}</strong>
-                        <span className="text-slate-600">{messageTime(message.created_at)}</span>
-                      </div>
-                      <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">{message.body}</p>
-                    </article>
-                  );
-                })
-              )}
-            </div>
-
-            <form className="border-t border-white/10 p-3 sm:p-4" onSubmit={sendChat}>
-              <div className="flex gap-2">
-                <label htmlFor="room-chat" className="sr-only">Message room</label>
-                <input
-                  id="room-chat"
-                  className="game-input"
-                  maxLength={1000}
-                  value={draft}
-                  disabled={connection !== "live" || room.status !== "open"}
-                  placeholder={connection === "live" ? "Message the room…" : "Reconnect to chat…"}
-                  onChange={(event) => setDraft(event.target.value)}
-                />
-                <button
-                  type="submit"
-                  disabled={!draft.trim() || connection !== "live" || room.status !== "open"}
-                  className="game-button bg-[#faa307] px-4 font-black text-[#370617]"
-                >
-                  Send
-                </button>
-              </div>
-            </form>
-          </div>
-
-          <aside className="grid content-start gap-4">
-            <section className="game-panel p-4">
-              <div className="flex items-center justify-between gap-2">
-                <p className="metric-label">Online now</p>
-                <span className="game-chip px-2 py-0.5 text-xs font-black text-slate-300">{presence.length}</span>
-              </div>
-              <div className="mt-3 space-y-2">
-                {presence.length === 0 ? (
-                  <p className="text-sm text-slate-500">Presence is offline.</p>
-                ) : (
-                  presence.map((person) => (
-                    <div key={person.user_id} className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm font-bold text-slate-200">
-                      <span aria-hidden="true">🟢</span>
-                      <span className="truncate">{person.user_id === user.id ? "You" : person.display_name}</span>
-                    </div>
-                  ))
-                )}
-              </div>
-            </section>
-
-            <section className="game-panel p-4">
-              <p className="metric-label">Room controls</p>
-              <p className="mt-2 text-sm text-slate-400">Role: <strong className="text-slate-200">{room.current_user_role}</strong></p>
-              {isHost ? (
-                <button
-                  type="button"
-                  disabled={busy || room.status === "closed"}
-                  onClick={() => void handleClose()}
-                  className="game-button mt-4 w-full border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm font-black text-rose-200"
-                >
-                  🔒 Close room
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={() => void handleLeave()}
-                  className="game-button mt-4 w-full border border-white/10 bg-white/[0.04] px-3 py-2 text-sm font-black text-slate-200"
-                >
-                  Leave room
-                </button>
-              )}
-            </section>
-
-            <p className="px-2 text-xs leading-5 text-slate-600">
-              Presence is realtime process state; membership and messages stay durable in PostgreSQL.
-            </p>
-          </aside>
-        </section>
+              <p className="px-2 text-xs leading-5 text-slate-600">
+                Presence and active Arcade runtime are realtime process state; membership and messages stay durable in PostgreSQL.
+              </p>
+            </aside>
+          </section>
+        </>
       )}
 
       {room.status === "closed" && (


### PR DESCRIPTION
## What changed

Implements the first multiplayer Arcade slice of #23 on top of the merged realtime Quest Room foundation.

### Shared game engine, not a second multiplayer fork
- Quest Rooms reuse the existing `ActivityRuntime` / `ActivityPublicState` contract already used by solo Arcade.
- Adds a single-process `room_arcade` host keyed by room id.
- First room-playable activities are **Multiple-Choice Blitz** and **Match Quest**.
- Room activity ids are distinct per hosted run while game construction/scoring still uses the shared deterministic adapters.

### Synchronized spoiler boundary
- Player responses are held server-side as unrevealed pending submissions.
- Submitting broadcasts only who/ how many players are ready — never the submitted answer, correctness, score delta, or answer key.
- Host performs one synchronized reveal.
- At reveal, every pending response is scored through the same existing server-side solo scoring adapter, then answer-bearing fields + scoreboard are broadcast together.
- Correct ids/maps remain absent from `ActivityPublicState.reveal` before reveal.

### Room controls and lifecycle
- Host only: start, reveal, next round, end activity.
- Members: submit responses.
- Activity start always uses the room's existing deck.
- Host can end the activity without closing/recreating the room.
- Completed room activities can be replaced by a new run.
- Every realtime game mutation re-checks durable active membership.

### Reconnect / late join
- `room.snapshot` now includes the current phase-safe activity snapshot.
- Reconnecting/late-joining members recover the same session, round, prompt, submission count, and revealed state when applicable.
- Active runtime/unrevealed submissions remain intentionally ephemeral single-process state in this phase; room/membership/chat stay durable PostgreSQL state.

### Frontend
- Adds an embedded **Room Arcade** panel directly inside the Quest Room page.
- Host can launch Blitz or Match Quest without leaving chat.
- Members see the same prompt/board and a live submitted count.
- Match Quest keeps native selects — no drag-and-drop requirement.
- Host-paced, no-forced-timer presentation preserves a Chill/no-timer path.
- Synchronized reveal and room scoreboard appear in-place while room chat/presence remain usable underneath.
- The existing `/arcade` link is now labeled **Solo Arcade** inside rooms to make the distinction clear.

### Tests
Covers:
- two simultaneous WebSockets playing the same Blitz run
- pre-reveal answer-key/correctness boundary
- separate participant submissions and synchronized scoring
- chat remaining usable during a live game
- next-round submission reset
- late-join snapshot recovery without spoiler leakage
- host-only start/control permissions
- Match Quest running through the same room runtime and scoring at reveal

### Docs
- Updates Quest Room architecture to reflect implemented shared Arcade events/state boundaries.
- Adds `ROOM_ARCADE_V1.md` with the current durability/spoiler contract.

## Still tracked in #23
This intentionally does **not** close #23 yet. Sort the Stack, Boss Battle, Debug Dungeon, and broader shared-game polish remain follow-on work.