### PR TITLE
Add Sort the Stack to solo and Quest Room Arcade

### DIFF
--- a/backend/app/activities.py
+++ b/backend/app/activities.py
@@ -132,7 +132,7 @@ class _ActivityRound:
 
 @dataclass(frozen=True)
 class ActivityRuntime:
-    """Internal runtime shared by solo and future room synchronization hosts."""
+    """Internal runtime shared by solo and room synchronization hosts."""
 
     session_id: str
     definition: ActivityDefinition
@@ -171,9 +171,22 @@ MATCH_DEFINITION = ActivityDefinition(
     supports_teams=True,
 )
 
+SORT_DEFINITION = ActivityDefinition(
+    id="sort-the-stack",
+    type=ActivityType.SORT,
+    title="Sort the Stack",
+    description="Place cards into the learning domain where each one belongs.",
+    min_cards=4,
+    max_cards=12,
+    timer_policy=TimerPolicy.OPTIONAL,
+    supports_hints=False,
+    supports_teams=True,
+)
+
 ACTIVITY_DEFINITIONS: dict[ActivityType, ActivityDefinition] = {
     ActivityType.BLITZ: BLITZ_DEFINITION,
     ActivityType.MATCH: MATCH_DEFINITION,
+    ActivityType.SORT: SORT_DEFINITION,
 }
 
 
@@ -271,6 +284,50 @@ def _build_match_rounds(
     )
 
 
+def _build_sort_rounds(
+    cards: list[ActivityCard], rng: random.Random, item_count: int
+) -> tuple[_ActivityRound, ...]:
+    """Build a domain-sorting board without exposing each card's bucket early."""
+    domains = {card.domain.strip() or "General" for card in cards}
+    if len(domains) < 2:
+        raise ValueError("Sort the Stack needs cards from at least two distinct domains")
+
+    selected = cards[:]
+    rng.shuffle(selected)
+    selected = selected[:item_count]
+    selected_domains = {card.domain.strip() or "General" for card in selected}
+
+    # A small sample can randomly land in one domain. Force one card from a second
+    # domain so every generated board remains a real sorting challenge.
+    if len(selected_domains) < 2:
+        first_domain = next(iter(selected_domains))
+        replacement = next(
+            card for card in cards if (card.domain.strip() or "General") != first_domain
+        )
+        selected[-1] = replacement
+        selected_domains = {card.domain.strip() or "General" for card in selected}
+
+    items = [
+        {
+            "card_id": card.id,
+            "prompt": card.word,
+            "clue": card.definition,
+        }
+        for card in selected
+    ]
+    rng.shuffle(items)
+    buckets = sorted(selected_domains, key=str.casefold)
+    answer_map = {
+        str(card.id): card.domain.strip() or "General" for card in selected
+    }
+    return (
+        _ActivityRound(
+            payload={"items": items, "buckets": buckets, "axis": "domain"},
+            reveal={"answer_map": answer_map},
+        ),
+    )
+
+
 def build_activity_runtime(
     *,
     activity_type: ActivityType,
@@ -298,6 +355,12 @@ def build_activity_runtime(
     elif activity_type == ActivityType.MATCH:
         rounds = _build_match_rounds(
             rows, rng, min(max(definition.min_cards, round_count), len(rows))
+        )
+    elif activity_type == ActivityType.SORT:
+        rounds = _build_sort_rounds(
+            rows,
+            rng,
+            min(max(definition.min_cards, round_count), len(rows)),
         )
     else:  # pragma: no cover - guarded by the registry above
         raise ValueError(f"No adapter for activity type: {activity_type.value}")
@@ -406,6 +469,45 @@ def _score_match_response(
     )
 
 
+def _score_sort_response(
+    runtime: ActivityRuntime, event: ActivityEvent
+) -> ActivityRuntime:
+    """Score domain placements using the hidden card-to-domain answer map."""
+    current = runtime.rounds[runtime.round_index]
+    raw_placements = event.payload.get("placements")
+    submitted = raw_placements if isinstance(raw_placements, dict) else {}
+    answer_map = current.reveal["answer_map"]
+    correct_count = sum(
+        1
+        for card_id, domain in answer_map.items()
+        if str(submitted.get(card_id) or "") == domain
+    )
+    total = len(answer_map)
+    points = round((correct_count / total) * 500) if total else 0
+    perfect = correct_count == total and total > 0
+    participant_id = event.participant_id or "solo"
+    participant = _participant(runtime, participant_id)
+    updated = participant.model_copy(
+        update={
+            "score": participant.score + points,
+            "streak": participant.streak + 1 if perfect else 0,
+            "response": f"{correct_count}/{total}",
+            "round_complete": True,
+        }
+    )
+    return replace(
+        runtime,
+        phase=ActivityPhase.RESULT,
+        participants=_with_participant(runtime, updated),
+        round_result={
+            "correct_count": correct_count,
+            "total": total,
+            "perfect": perfect,
+            "points": points,
+        },
+    )
+
+
 def public_activity_state(runtime: ActivityRuntime) -> ActivityPublicState:
     """Serialize only data safe for the runtime's current phase."""
     if runtime.phase == ActivityPhase.COMPLETE:
@@ -447,6 +549,8 @@ def apply_activity_event(runtime: ActivityRuntime, event: ActivityEvent) -> Acti
             return _score_blitz_response(runtime, event)
         if runtime.definition.type == ActivityType.MATCH:
             return _score_match_response(runtime, event)
+        if runtime.definition.type == ActivityType.SORT:
+            return _score_sort_response(runtime, event)
         raise ValueError(
             f"No scoring adapter for activity type: {runtime.definition.type.value}"
         )

--- a/backend/tests/test_activities.py
+++ b/backend/tests/test_activities.py
@@ -153,6 +153,112 @@ def test_match_quest_uses_same_phase_safe_runtime_contract():
     assert len(reveal_state.reveal["answer_map"]) == 5
 
 
+def test_sort_stack_hides_domain_answer_map_until_reveal():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.SORT,
+        deck_id=91,
+        cards=_cards(8),
+        mode=ActivityMode.ROOM,
+        seed=321,
+        round_count=6,
+    )
+    state = public_activity_state(runtime)
+    serialized = json.dumps(state.model_dump())
+
+    assert state.definition.type == ActivityType.SORT
+    assert state.total_rounds == 1
+    assert len(state.payload["items"]) == 6
+    assert len(state.payload["buckets"]) == 2
+    assert state.payload["axis"] == "domain"
+    assert state.reveal is None
+    assert "answer_map" not in serialized
+    # Domain is the answer in this activity, so it must not ride inside an item.
+    assert all("domain" not in item for item in state.payload["items"])
+
+    revealed = apply_activity_event(runtime, ActivityEvent(type="answer.revealed"))
+    reveal_state = public_activity_state(revealed)
+    assert reveal_state.reveal is not None
+    assert len(reveal_state.reveal["answer_map"]) == 6
+
+
+def test_sort_stack_scores_domain_placements_through_shared_runtime():
+    runtime = build_activity_runtime(
+        activity_type=ActivityType.SORT,
+        deck_id=92,
+        cards=_cards(8),
+        mode=ActivityMode.SOLO,
+        seed=654,
+        round_count=6,
+    )
+    hidden = runtime.rounds[runtime.round_index].reveal["answer_map"]
+    placements = dict(hidden)
+    first_card_id = next(iter(placements))
+    placements[first_card_id] = "Definitely Wrong"
+
+    scored = apply_activity_event(
+        runtime,
+        ActivityEvent(
+            type="response.submitted",
+            participant_id="learner-1",
+            payload={"placements": placements},
+        ),
+    )
+    state = public_activity_state(scored)
+    result = state.reveal["result"] if state.reveal else {}
+
+    assert state.phase == ActivityPhase.RESULT
+    assert result["correct_count"] == 5
+    assert result["total"] == 6
+    assert result["perfect"] is False
+    assert result["points"] == 417
+    assert state.participants[0].response == "5/6"
+    assert state.participants[0].score == 417
+
+
+def test_sort_stack_same_adapter_runs_in_solo_and_room_mode():
+    solo = build_activity_runtime(
+        activity_type=ActivityType.SORT,
+        deck_id=93,
+        cards=_cards(8),
+        mode=ActivityMode.SOLO,
+        seed=111,
+        round_count=6,
+    )
+    room = build_activity_runtime(
+        activity_type=ActivityType.SORT,
+        deck_id=93,
+        cards=_cards(8),
+        mode=ActivityMode.ROOM,
+        seed=111,
+        round_count=6,
+    )
+
+    assert public_activity_state(solo).payload == public_activity_state(room).payload
+    assert solo.definition == room.definition
+    assert solo.mode == ActivityMode.SOLO
+    assert room.mode == ActivityMode.ROOM
+
+
+def test_sort_stack_rejects_single_domain_deck():
+    cards = [
+        ActivityCard(
+            id=index,
+            word=f"One domain {index}",
+            definition=f"Definition {index}",
+            domain="Only Domain",
+            kind="concept",
+        )
+        for index in range(1, 6)
+    ]
+    with pytest.raises(ValueError, match="at least two distinct domains"):
+        build_activity_runtime(
+            activity_type=ActivityType.SORT,
+            deck_id=94,
+            cards=cards,
+            seed=9,
+        )
+
+
 def test_activity_rejects_too_few_cards():
     with pytest.raises(ValueError, match="needs at least 4 unique cards"):
         build_activity_runtime(

--- a/backend/tests/test_arcade_sort_stack.py
+++ b/backend/tests/test_arcade_sort_stack.py
@@ -1,0 +1,205 @@
+"""End-to-end coverage for Sort the Stack in solo Arcade and Quest Rooms."""
+
+from sqlmodel import Session
+
+from app.models import Card, Deck, User
+from app.room_arcade import clear_room_activity
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"sort-{suffix}@example.com",
+        display_name=f"Sort {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck(
+    session: Session,
+    *,
+    slug: str,
+    owner: User | None = None,
+    split_domains: bool = True,
+) -> tuple[Deck, dict[int, str]]:
+    deck = Deck(
+        owner_id=None if owner is None else owner.id,
+        title=f"Sort Stack {slug}",
+        slug=slug,
+        description="Sort the Stack test deck",
+        is_builtin=owner is None,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public",
+        tags=["sort", "arcade"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+
+    domain_by_id: dict[int, str] = {}
+    for index in range(1, 7):
+        domain = "Foundations" if not split_domains or index <= 3 else "Operations"
+        card = Card(
+            deck_id=deck.id,
+            word=f"Sort prompt {index}",
+            definition=f"Sort clue {index}",
+            topic=deck.title,
+            domain=domain,
+            kind="concept",
+            is_builtin=deck.is_builtin,
+        )
+        session.add(card)
+        session.commit()
+        session.refresh(card)
+        domain_by_id[int(card.id or 0)] = domain
+    return deck, domain_by_id
+
+
+def _room(client, session: Session, host: User, deck: Deck) -> dict:
+    response = client.post(
+        "/rooms",
+        headers=_headers(session, host),
+        json={
+            "deck_id": int(deck.id or 0),
+            "name": "Sort Party",
+            "visibility": "public",
+        },
+    )
+    assert response.status_code == 201
+    room = response.json()
+    clear_room_activity(room["id"])
+    return room
+
+
+def _ticket(client, room_id: int, headers: dict[str, str]) -> str:
+    response = client.post(f"/rooms/{room_id}/ws-ticket", headers=headers)
+    assert response.status_code == 200
+    return response.json()["ticket"]
+
+
+def test_solo_sort_stack_hides_domains_then_scores_perfect_board(
+    client, sqlite_session: Session
+):
+    deck, domain_by_id = _deck(sqlite_session, slug="solo")
+    headers = {"X-Demo-Session": "sort-stack-solo-browser"}
+
+    start = client.post(
+        "/activities/start",
+        headers=headers,
+        json={
+            "deck_id": deck.id,
+            "activity_type": "sort",
+            "round_count": 6,
+            "seed": 2468,
+        },
+    )
+    assert start.status_code == 201
+    prompt = start.json()
+    assert prompt["definition"]["type"] == "sort"
+    assert prompt["mode"] == "solo"
+    assert prompt["reveal"] is None
+    assert prompt["payload"]["buckets"] == ["Foundations", "Operations"]
+    assert all("domain" not in item for item in prompt["payload"]["items"])
+    assert "answer_map" not in str(prompt)
+
+    placements = {
+        str(item["card_id"]): domain_by_id[item["card_id"]]
+        for item in prompt["payload"]["items"]
+    }
+    result = client.post(
+        f"/activities/{prompt['session_id']}/events",
+        headers=headers,
+        json={
+            "type": "response.submitted",
+            "payload": {"placements": placements},
+        },
+    )
+    assert result.status_code == 200
+    payload = result.json()
+    assert payload["phase"] == "result"
+    assert payload["reveal"]["answer_map"] == placements
+    assert payload["reveal"]["result"]["perfect"] is True
+    assert payload["reveal"]["result"]["correct_count"] == 6
+    assert payload["participants"][0]["score"] == 500
+
+
+def test_solo_sort_stack_rejects_deck_without_two_domains(client, sqlite_session: Session):
+    deck, _domains = _deck(
+        sqlite_session,
+        slug="one-domain",
+        split_domains=False,
+    )
+    response = client.post(
+        "/activities/start",
+        headers={"X-Demo-Session": "sort-stack-one-domain"},
+        json={"deck_id": deck.id, "activity_type": "sort"},
+    )
+    assert response.status_code == 422
+    assert "at least two distinct domains" in response.json()["detail"]
+
+
+def test_room_sort_stack_uses_pending_submission_and_synchronized_reveal(
+    client, sqlite_session: Session
+):
+    host = _user(sqlite_session, "room-host")
+    deck, domain_by_id = _deck(sqlite_session, slug="room", owner=host)
+    room = _room(client, sqlite_session, host, deck)
+    headers = _headers(sqlite_session, host)
+
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={_ticket(client, room['id'], headers)}"
+    ) as websocket:
+        assert websocket.receive_json()["type"] == "room.snapshot"
+        assert websocket.receive_json()["type"] == "presence.joined"
+
+        websocket.send_json(
+            {
+                "type": "activity.start",
+                "payload": {"activity_type": "sort", "round_count": 6},
+            }
+        )
+        started = websocket.receive_json()
+        assert started["type"] == "activity.started"
+        activity = started["payload"]["activity"]
+        state = activity["state"]
+        assert state["definition"]["type"] == "sort"
+        assert state["mode"] == "room"
+        assert state["reveal"] is None
+        assert all("domain" not in item for item in state["payload"]["items"])
+
+        placements = {
+            str(item["card_id"]): domain_by_id[item["card_id"]]
+            for item in state["payload"]["items"]
+        }
+        websocket.send_json(
+            {"type": "activity.submit", "payload": {"placements": placements}}
+        )
+        submitted = websocket.receive_json()
+        assert submitted["type"] == "activity.submitted"
+        assert submitted["payload"]["submitted_count"] == 1
+        assert "placements" not in str(submitted)
+
+        websocket.send_json({"type": "activity.reveal", "payload": {}})
+        revealed_event = websocket.receive_json()
+        assert revealed_event["type"] == "activity.state"
+        revealed = revealed_event["payload"]["activity"]["state"]
+        assert revealed["phase"] == "reveal"
+        assert revealed["reveal"]["answer_map"] == placements
+        assert revealed["participants"][0]["score"] == 500
+        assert revealed["participants"][0]["response"] == "6/6"
+
+        websocket.send_json({"type": "activity.next", "payload": {}})
+        completed = websocket.receive_json()
+        assert completed["type"] == "activity.completed"
+        assert completed["payload"]["activity"]["state"]["phase"] == "complete"

--- a/docs/ARCADE_ACTIVITY_CONTRACT.md
+++ b/docs/ARCADE_ACTIVITY_CONTRACT.md
@@ -15,7 +15,7 @@ Activity adapter
     ▼
 ActivityRuntime
     ├── solo host
-    └── Quest Room host (future realtime adapter)
+    └── Quest Room realtime host
               │
               ▼
       ActivityPublicState
@@ -27,7 +27,7 @@ ActivityRuntime
 
 - `ActivityDefinition` — capabilities, card requirements, timer policy, and scoring identity.
 - `ActivityRuntime` — internal deterministic runtime state. This object may contain answer-bearing round data and must not be serialized directly to clients.
-- `ActivityPublicState` — the only phase-safe state intended for a browser or future room participant.
+- `ActivityPublicState` — the only phase-safe state intended for a browser or room participant.
 - `ActivityEvent` — explicit lifecycle transitions such as `round.locked`, `answer.revealed`, and `round.completed`.
 - `ActivityParticipantState` — per-player score/streak/response state. It is intentionally separate from durable FlashQuest mastery.
 
@@ -37,7 +37,7 @@ The frontend mirror lives in `frontend/src/activityTypes.ts`.
 
 Correct-answer metadata is an internal runtime concern until reveal. Before a runtime reaches `reveal` or `result`, `ActivityPublicState.reveal` is `null`.
 
-For Multiple-Choice Blitz, the prompt may contain the four possible answer texts because the learner needs to choose among them, but it does **not** contain the correct choice id or a separate answer field. For Match Quest, the prompt contains shuffled terms and definitions but not the answer mapping.
+For Multiple-Choice Blitz, the prompt may contain the four possible answer texts because the learner needs to choose among them, but it does **not** contain the correct choice id or a separate answer field. For Match Quest, the prompt contains shuffled terms and definitions but not the answer mapping. For Sort the Stack, each item contains its term and definition clue plus the available domain buckets, but the item's own domain is withheld until reveal because that domain is the answer.
 
 This matters for Quest Rooms: hiding an answer with CSS is not security. The room server must avoid sending answer-bearing payloads until the synchronized reveal transition.
 
@@ -52,7 +52,7 @@ Activities accept a session seed. The same deck content and seed produce the sam
 
 If a caller does not supply a seed, FlashQuest derives one from the activity/deck/card identity.
 
-## First adapters
+## Playable adapters
 
 ### Multiple-Choice Blitz
 
@@ -60,14 +60,25 @@ If a caller does not supply a seed, FlashQuest derives one from the activity/dec
 - A target prompt is paired with its correct definition and up to three distractors from compatible cards.
 - Choices are shuffled deterministically.
 - The correct choice id and answer appear only after reveal.
+- Correct responses earn 100 Arcade points per round.
 
 ### Match Quest
 
 - Minimum: 3 cards.
 - Prompts and definitions are shuffled independently into one matching board.
 - The term-to-definition answer map appears only after reveal.
+- The board awards up to 500 Arcade points proportionally to correct pairs.
 
-Both adapters can be built in `solo` or `room` mode from the same definition/runtime code.
+### Sort the Stack
+
+- Minimum: 4 cards across at least 2 distinct domains.
+- A board presents terms plus definition clues and the domain buckets represented by the selected cards.
+- The domain is intentionally omitted from each pre-reveal item.
+- The hidden card-to-domain answer map appears only after reveal.
+- The board awards up to 500 Arcade points proportionally to correct placements.
+- The adapter rejects one-domain decks instead of creating a meaningless one-bucket challenge.
+
+All playable adapters can be built in `solo` or `room` mode from the same definition/runtime code.
 
 ## Progress boundary
 
@@ -85,18 +96,10 @@ Activities should consume shared platform behavior rather than invent local alte
 - visible/text feedback that does not rely only on color or sound,
 - optional/no-timer presentation where the activity definition permits it.
 
-These concerns are tracked by the adaptable-mode/accessibility work and remain presentation choices; they do not change the learning content stored in a deck.
+Match Quest and Sort the Stack use native select controls as the baseline interaction, so drag-and-drop is never required for keyboard, touch, switch-control, or screen-reader use.
 
-## What is intentionally not in V1
+## Runtime hosting boundary
 
-This contract does **not** add:
+Solo activity sessions and Quest Room activity sessions are currently ephemeral runtime state. Quest Room membership and chat history remain durable PostgreSQL state, while active synchronized game state and unrevealed submissions remain process-local until a shared realtime state/pub-sub layer is introduced.
 
-- database persistence for activity sessions,
-- WebSocket transport,
-- room membership/presence,
-- matchmaking,
-- leaderboards,
-- a payment boundary,
-- game-specific fields on every card.
-
-Those features can build around the runtime after the contract is proven, rather than forcing the contract to depend on them first.
+This contract still does **not** add game-specific columns to durable deck/card models, persistent leaderboards, matchmaking, or a payment boundary.

--- a/docs/QUEST_ROOMS_ARCHITECTURE.md
+++ b/docs/QUEST_ROOMS_ARCHITECTURE.md
@@ -121,17 +121,19 @@ Every mutation is authorized server-side regardless of what controls the client 
 
 Room games do **not** get a second multiplayer game engine. Quest Rooms host the same `ActivityRuntime` and `ActivityPublicState` used by solo Arcade.
 
-The first room-playable adapters are **Multiple-Choice Blitz** and **Match Quest**:
+The current room-playable adapters are **Multiple-Choice Blitz**, **Match Quest**, and **Sort the Stack**:
 
 - the host starts the activity against the room's existing deck;
 - all members receive the same prompt/board state;
 - participant responses are stored server-side as pending round submissions;
-- submitting does **not** expose correctness, score changes, or answer ids;
+- submitting does **not** expose correctness, score changes, answer ids, match maps, or domain placements;
 - the host performs one synchronized reveal, which scores every pending submission through the shared solo scoring adapter and publishes the answer plus room scoreboard together;
 - the host advances or ends the activity without recreating/closing the room;
 - reconnecting or joining late restores the current phase-safe activity snapshot;
 - room chat remains available while the game is active;
 - room rounds are host-paced and untimed by default, preserving a Chill/no-timer path for activities whose timers are optional.
+
+Sort the Stack uses the card's domain as its hidden answer. A compatible Sort deck needs at least four cards across two or more distinct domains; one-domain decks are rejected server-side rather than generating a fake one-bucket game.
 
 Correct answer ids/maps stay server-internal until synchronized reveal. Room Arcade score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
 

--- a/docs/ROOM_ARCADE_V1.md
+++ b/docs/ROOM_ARCADE_V1.md
@@ -1,11 +1,12 @@
 # Quest Room Arcade V1
 
-This slice makes the first two shared FlashQuest Arcade activities playable inside an existing Quest Room.
+This slice makes the first three shared FlashQuest Arcade activities playable inside an existing Quest Room.
 
 ## Included
 
 - Multiple-Choice Blitz in room mode
 - Match Quest in room mode
+- Sort the Stack in room mode
 - host-controlled start, synchronized reveal, next round, and end
 - server-held pending submissions before reveal
 - shared `ActivityRuntime` / `ActivityPublicState` contract with solo Arcade
@@ -13,6 +14,12 @@ This slice makes the first two shared FlashQuest Arcade activities playable insi
 - room scoreboard after synchronized reveal
 - live chat and presence while an activity is running
 - host-paced, no-forced-timer presentation
+
+## Sort the Stack
+
+Sort the Stack presents terms and definitions, then asks the learner to place each card into its correct learning-domain bucket. The card's domain is the answer for this activity, so it is intentionally absent from the pre-reveal item payload. A compatible deck needs at least four cards across at least two distinct domains.
+
+The same Sort adapter runs in solo Arcade and Quest Rooms. Room submissions follow the same synchronized spoiler boundary as Blitz and Match Quest.
 
 ## Spoiler boundary
 
@@ -24,7 +31,6 @@ The room, membership, and chat history remain durable PostgreSQL state. Active r
 
 ## Still tracked in #23
 
-- Sort the Stack
 - Boss Battle
 - Debug Dungeon for compatible decks
 - additional shared-game polish and room challenge variants

--- a/frontend/src/components/RoomArcadePanel.tsx
+++ b/frontend/src/components/RoomArcadePanel.tsx
@@ -28,6 +28,9 @@ type MatchPayload = {
   choices: BlitzChoice[];
 };
 type MatchMap = Record<string, string>;
+type SortItem = { card_id: number; prompt: string; clue: string };
+type SortPayload = { items: SortItem[]; buckets: string[]; axis: "domain" };
+type SortMap = Record<string, string>;
 
 type Props = {
   activity: RoomActivitySnapshot | null;
@@ -46,10 +49,20 @@ function matchPayload(state: ActivityPublicState): MatchPayload {
   return state.payload as unknown as MatchPayload;
 }
 
+function sortPayload(state: ActivityPublicState): SortPayload {
+  return state.payload as unknown as SortPayload;
+}
+
 function displayName(userId: string, currentUserId: number, presence: PresenceUser[]): string {
   const numericId = Number(userId);
   if (numericId === currentUserId) return "You";
   return presence.find((person) => person.user_id === numericId)?.display_name ?? `Player #${userId}`;
+}
+
+function gameBadge(state: ActivityPublicState): string {
+  if (state.definition.type === "blitz") return "⚡ BLITZ";
+  if (state.definition.type === "match") return "🧩 MATCH QUEST";
+  return "🗃️ SORT THE STACK";
 }
 
 function Scoreboard({
@@ -96,11 +109,13 @@ export default function RoomArcadePanel({
   onSend,
 }: Props) {
   const [matches, setMatches] = useState<MatchMap>({});
+  const [placements, setPlacements] = useState<SortMap>({});
   const state = activity?.state ?? null;
   const submitted = activity?.submitted_user_ids.includes(userId) ?? false;
 
   useEffect(() => {
     setMatches({});
+    setPlacements({});
   }, [state?.session_id, state?.round_index]);
 
   const presenceNames = useMemo(
@@ -108,7 +123,7 @@ export default function RoomArcadePanel({
     [presence]
   );
 
-  function start(activityType: "blitz" | "match") {
+  function start(activityType: "blitz" | "match" | "sort") {
     onSend("activity.start", { activity_type: activityType, round_count: 5 });
   }
 
@@ -122,7 +137,7 @@ export default function RoomArcadePanel({
               {state?.phase === "complete" ? "Quest cleared. Run it back?" : "Same room. Same question. Everybody plays."}
             </h2>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
-              Blitz and Match Quest use the same server-authoritative activity runtime as solo Arcade. Room rounds are host-paced and untimed by default.
+              Blitz, Match Quest, and Sort the Stack use the same server-authoritative runtime as solo Arcade. Room rounds are host-paced and untimed by default.
             </p>
             {state?.phase === "complete" && (
               <Scoreboard state={state} userId={userId} presence={presence} />
@@ -146,6 +161,14 @@ export default function RoomArcadePanel({
               >
                 🧩 Start Match Quest
               </button>
+              <button
+                type="button"
+                disabled={!connectionLive}
+                onClick={() => start("sort")}
+                className="game-button border border-violet-300/25 bg-violet-300/[0.08] px-4 py-3 text-sm font-black text-violet-100"
+              >
+                🗃️ Start Sort the Stack
+              </button>
             </div>
           ) : (
             <div className="game-chip px-4 py-3 text-sm font-black text-slate-300">
@@ -166,7 +189,7 @@ export default function RoomArcadePanel({
           <div>
             <div className="flex flex-wrap gap-2">
               <span className="game-chip px-2.5 py-1 text-xs font-black text-[#ffba08]">
-                {state.definition.type === "blitz" ? "⚡ BLITZ" : "🧩 MATCH QUEST"}
+                {gameBadge(state)}
               </span>
               <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">
                 Round {state.round_index + 1}/{state.total_rounds}
@@ -190,7 +213,7 @@ export default function RoomArcadePanel({
             connectionLive={connectionLive}
             onSubmit={(choiceId) => onSend("activity.submit", { choice_id: choiceId })}
           />
-        ) : (
+        ) : state.definition.type === "match" ? (
           <MatchRound
             state={state}
             matches={matches}
@@ -200,6 +223,17 @@ export default function RoomArcadePanel({
               setMatches((current) => ({ ...current, [String(cardId)]: choiceId }))
             }
             onSubmit={() => onSend("activity.submit", { matches })}
+          />
+        ) : (
+          <SortRound
+            state={state}
+            placements={placements}
+            submitted={submitted}
+            connectionLive={connectionLive}
+            onPlace={(cardId, domain) =>
+              setPlacements((current) => ({ ...current, [String(cardId)]: domain }))
+            }
+            onSubmit={() => onSend("activity.submit", { placements })}
           />
         )}
 
@@ -379,6 +413,81 @@ function MatchRound({
             className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
           >
             🧩 Submit matches
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SortRound({
+  state,
+  placements,
+  submitted,
+  connectionLive,
+  onPlace,
+  onSubmit,
+}: {
+  state: ActivityPublicState;
+  placements: SortMap;
+  submitted: boolean;
+  connectionLive: boolean;
+  onPlace: (cardId: number, domain: string) => void;
+  onSubmit: () => void;
+}) {
+  const payload = sortPayload(state);
+  const answerMap = (state.reveal?.answer_map ?? {}) as Record<string, string>;
+  const revealed = state.phase === "reveal" || state.phase === "result";
+  const completeBoard = payload.items.every((item) => Boolean(placements[String(item.card_id)]));
+
+  return (
+    <div className="mt-6">
+      <p className="text-sm leading-6 text-slate-400">
+        Sort each card into its correct domain. The domain itself stays hidden until synchronized reveal; selects keep the game usable without drag-and-drop.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {payload.buckets.map((bucket) => (
+          <span key={bucket} className="game-chip px-3 py-1.5 text-xs font-black text-cyan-100">📚 {bucket}</span>
+        ))}
+      </div>
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        {payload.items.map((item) => {
+          const correctDomain = answerMap[String(item.card_id)] ?? "";
+          return (
+            <label key={item.card_id} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <span className="text-sm font-black text-white">{item.prompt}</span>
+              <span className="mt-2 block text-sm leading-6 text-slate-400">{item.clue}</span>
+              {revealed ? (
+                <span className="mt-3 block rounded-xl border border-emerald-300/20 bg-emerald-300/[0.07] px-3 py-2 text-sm text-emerald-100">
+                  ✓ {correctDomain || "Correct domain"}
+                </span>
+              ) : (
+                <select
+                  className="game-input mt-3"
+                  aria-label={`Domain for ${item.prompt}`}
+                  value={placements[String(item.card_id)] ?? ""}
+                  disabled={!connectionLive || submitted}
+                  onChange={(event) => onPlace(item.card_id, event.target.value)}
+                >
+                  <option value="">Choose domain…</option>
+                  {payload.buckets.map((bucket) => (
+                    <option key={bucket} value={bucket}>{bucket}</option>
+                  ))}
+                </select>
+              )}
+            </label>
+          );
+        })}
+      </div>
+      {!revealed && (
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            disabled={!connectionLive || submitted || !completeBoard}
+            onClick={onSubmit}
+            className="game-button bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          >
+            🗃️ Submit stack
           </button>
         </div>
       )}

--- a/frontend/src/pages/Arcade.tsx
+++ b/frontend/src/pages/Arcade.tsx
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
-import {
-  getLibraryDecks,
-  getMyDecks,
-} from "../api";
-import {
-  sendActivityEvent,
-  startActivity,
-} from "../arcadeApi";
+import { getLibraryDecks, getMyDecks } from "../api";
+import { sendActivityEvent, startActivity } from "../arcadeApi";
 import {
   shouldUseActivityTimer,
   type ActivityPublicState,
@@ -19,6 +13,7 @@ import { useExperience } from "../experienceContext";
 import { useGameFeel } from "../gameFeelContext";
 import type { DeckRead } from "../types";
 
+type PlayableActivityType = Extract<ActivityType, "blitz" | "match" | "sort">;
 type BlitzChoice = { id: string; text: string };
 type BlitzPayload = {
   card_id: number;
@@ -38,9 +33,20 @@ type MatchPayload = {
   choices: BlitzChoice[];
 };
 type MatchMap = Record<string, string>;
+type SortItem = {
+  card_id: number;
+  prompt: string;
+  clue: string;
+};
+type SortPayload = {
+  items: SortItem[];
+  buckets: string[];
+  axis: "domain";
+};
+type SortMap = Record<string, string>;
 
 type GameOption = {
-  type: Extract<ActivityType, "blitz" | "match">;
+  type: PlayableActivityType;
   icon: string;
   title: string;
   detail: string;
@@ -62,6 +68,13 @@ const games: GameOption[] = [
     detail: "Pair prompts with definitions using a keyboard- and touch-friendly board.",
     minCards: 3,
   },
+  {
+    type: "sort",
+    icon: "🗃️",
+    title: "Sort the Stack",
+    detail: "Place cards into their correct learning domains without seeing the answer key.",
+    minCards: 4,
+  },
 ];
 
 function blitzPayload(state: ActivityPublicState): BlitzPayload {
@@ -70,6 +83,10 @@ function blitzPayload(state: ActivityPublicState): BlitzPayload {
 
 function matchPayload(state: ActivityPublicState): MatchPayload {
   return state.payload as unknown as MatchPayload;
+}
+
+function sortPayload(state: ActivityPublicState): SortPayload {
+  return state.payload as unknown as SortPayload;
 }
 
 function participantScore(state: ActivityPublicState | null): number {
@@ -93,6 +110,17 @@ function uniqueDecks(rows: DeckRead[]): DeckRead[] {
   });
 }
 
+function requestedActivity(value: string | null): PlayableActivityType {
+  if (value === "match" || value === "sort") return value;
+  return "blitz";
+}
+
+function nextGameType(current: PlayableActivityType): PlayableActivityType {
+  if (current === "blitz") return "match";
+  if (current === "match") return "sort";
+  return "blitz";
+}
+
 export default function Arcade() {
   const { user } = useAuth();
   const { policy, preferences } = useExperience();
@@ -100,13 +128,14 @@ export default function Arcade() {
   const [params, setParams] = useSearchParams();
 
   const requestedDeck = Number(params.get("deck") || 0) || null;
-  const requestedGame = params.get("game") === "match" ? "match" : "blitz";
+  const requestedGame = requestedActivity(params.get("game"));
 
   const [decks, setDecks] = useState<DeckRead[]>([]);
   const [deckId, setDeckId] = useState<number | null>(requestedDeck);
-  const [gameType, setGameType] = useState<"blitz" | "match">(requestedGame);
+  const [gameType, setGameType] = useState<PlayableActivityType>(requestedGame);
   const [activity, setActivity] = useState<ActivityPublicState | null>(null);
   const [matches, setMatches] = useState<MatchMap>({});
+  const [placements, setPlacements] = useState<SortMap>({});
   const [timerEnabled, setTimerEnabled] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
@@ -150,6 +179,7 @@ export default function Arcade() {
 
   useEffect(() => {
     setMatches({});
+    setPlacements({});
   }, [activity?.round_index, activity?.session_id]);
 
   const submitResponse = useCallback(
@@ -183,7 +213,7 @@ export default function Arcade() {
       setSecondsLeft(null);
       return;
     }
-    const duration = gameType === "match" ? 45 : 20;
+    const duration = gameType === "blitz" ? 20 : 45;
     let remaining = duration;
     let expired = false;
     setSecondsLeft(remaining);
@@ -195,12 +225,22 @@ export default function Arcade() {
       window.clearInterval(timer);
       if (gameType === "match") {
         void submitResponse({ matches });
+      } else if (gameType === "sort") {
+        void submitResponse({ placements });
       } else {
         void submitResponse({ choice_id: "" });
       }
     }, 1000);
     return () => window.clearInterval(timer);
-  }, [activity, gameType, loading, matches, submitResponse, timerEnabled]);
+  }, [
+    activity,
+    gameType,
+    loading,
+    matches,
+    placements,
+    submitResponse,
+    timerEnabled,
+  ]);
 
   useEffect(() => {
     if (!activity || activity.phase !== "prompt" || gameType !== "blitz") return;
@@ -223,6 +263,7 @@ export default function Arcade() {
     setLoading(true);
     setError(null);
     setMatches({});
+    setPlacements({});
     try {
       const next = await startActivity({
         deck_id: selectedDeck.id,
@@ -267,6 +308,7 @@ export default function Arcade() {
       });
       setActivity(next);
       setMatches({});
+      setPlacements({});
       if (next.phase === "complete") play("complete");
       else play("roundStart");
     } catch (cause) {
@@ -276,10 +318,11 @@ export default function Arcade() {
     }
   }
 
-  function resetGame(nextType?: "blitz" | "match") {
+  function resetGame(nextType?: PlayableActivityType) {
     const resolved = nextType ?? gameType;
     setActivity(null);
     setMatches({});
+    setPlacements({});
     setSecondsLeft(null);
     setGameType(resolved);
     if (deckId) setParams({ deck: String(deckId), game: resolved }, { replace: true });
@@ -340,7 +383,7 @@ export default function Arcade() {
 
           <div>
             <p className="metric-label">2 · Pick a game</p>
-            <div className="mt-2 grid gap-3 sm:grid-cols-2">
+            <div className="mt-2 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {games.map((game) => {
                 const active = gameType === game.type;
                 const enoughCards = (selectedDeck?.card_count ?? 0) >= game.minCards;
@@ -364,6 +407,9 @@ export default function Arcade() {
                     </div>
                     <h2 className="mt-4 text-xl font-black text-white">{game.title}</h2>
                     <p className="mt-2 text-sm leading-6 text-slate-400">{game.detail}</p>
+                    {game.type === "sort" && enoughCards && (
+                      <p className="mt-2 text-xs text-slate-500">Requires at least two domains in the deck.</p>
+                    )}
                   </button>
                 );
               })}
@@ -442,7 +488,7 @@ export default function Arcade() {
               onReveal={() => void revealWithoutScore()}
               onNext={() => void nextRound()}
             />
-          ) : (
+          ) : gameType === "match" ? (
             <MatchBoard
               state={activity}
               matches={matches}
@@ -451,6 +497,18 @@ export default function Arcade() {
                 setMatches((current) => ({ ...current, [String(cardId)]: choiceId }))
               }
               onSubmit={() => void submitResponse({ matches })}
+              onReveal={() => void revealWithoutScore()}
+              onNext={() => void nextRound()}
+            />
+          ) : (
+            <SortBoard
+              state={activity}
+              placements={placements}
+              loading={loading}
+              onPlace={(cardId, domain) =>
+                setPlacements((current) => ({ ...current, [String(cardId)]: domain }))
+              }
+              onSubmit={() => void submitResponse({ placements })}
               onReveal={() => void revealWithoutScore()}
               onNext={() => void nextRound()}
             />
@@ -477,7 +535,7 @@ export default function Arcade() {
               </button>
               <button
                 className="game-button border border-cyan-300/25 bg-cyan-300/[0.08] px-5 py-3 font-black text-cyan-100"
-                onClick={() => resetGame(gameType === "blitz" ? "match" : "blitz")}
+                onClick={() => resetGame(nextGameType(gameType))}
               >
                 🎲 Switch game
               </button>
@@ -680,6 +738,122 @@ function MatchBoard({
                 onClick={onReveal}
               >
                 👀 Reveal board
+              </button>
+            </>
+          ) : (
+            <button
+              className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+              disabled={loading}
+              onClick={onNext}
+            >
+              Finish quest →
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SortBoard({
+  state,
+  placements,
+  loading,
+  onPlace,
+  onSubmit,
+  onReveal,
+  onNext,
+}: {
+  state: ActivityPublicState;
+  placements: SortMap;
+  loading: boolean;
+  onPlace: (cardId: number, domain: string) => void;
+  onSubmit: () => void;
+  onReveal: () => void;
+  onNext: () => void;
+}) {
+  const payload = sortPayload(state);
+  const result = resultRecord(state);
+  const answerMap = (state.reveal?.answer_map ?? {}) as Record<string, string>;
+  const showResult = state.phase === "result" || state.phase === "reveal";
+  const completeBoard = payload.items.every((item) => Boolean(placements[String(item.card_id)]));
+
+  return (
+    <section className="quest-card p-5 sm:p-8">
+      <div className="relative z-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-[#ffba08]">🗃️ SORT THE STACK</span>
+          <span className="game-chip px-3 py-1.5 text-xs font-black text-slate-300">{payload.items.length} cards · {payload.buckets.length} domains</span>
+        </div>
+        <h2 className="mt-6 text-2xl font-black text-white sm:text-3xl">Which domain does each card belong to?</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-400">
+          The domain is intentionally hidden from each card until reveal. Use the term and definition as your clue; drag-and-drop is optional, not required.
+        </p>
+
+        <div className="mt-5 flex flex-wrap gap-2" aria-label="Available domains">
+          {payload.buckets.map((bucket) => (
+            <span key={bucket} className="game-chip px-3 py-1.5 text-xs font-black text-cyan-100">📚 {bucket}</span>
+          ))}
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          {payload.items.map((item, index) => {
+            const selected = placements[String(item.card_id)] ?? "";
+            const correctDomain = answerMap[String(item.card_id)] ?? "";
+            const correct = showResult && selected === correctDomain;
+            return (
+              <div key={item.card_id} className="game-panel p-4">
+                <p className="metric-label">Card {index + 1}</p>
+                <h3 className="mt-2 text-lg font-black text-white">{item.prompt}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-400">{item.clue}</p>
+                <label className="mt-4 block text-xs font-black text-slate-300" htmlFor={`sort-${item.card_id}`}>Place in domain</label>
+                <select
+                  id={`sort-${item.card_id}`}
+                  className="game-input mt-1.5"
+                  disabled={loading || showResult}
+                  value={selected}
+                  onChange={(event) => onPlace(item.card_id, event.target.value)}
+                >
+                  <option value="">Choose a domain…</option>
+                  {payload.buckets.map((bucket) => <option key={bucket} value={bucket}>{bucket}</option>)}
+                </select>
+                {showResult && (
+                  <div className="mt-2 text-xs leading-5">
+                    <strong className={correct ? "text-emerald-200" : "text-rose-200"}>{correct ? "✓ Correct bucket" : "✕ Different bucket"}</strong>
+                    <span className="ml-2 text-slate-400">Correct: {correctDomain || "—"}</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {showResult && (
+          <div className="answer-pop mt-5 rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.08] p-5">
+            <p className="font-black text-white">
+              {state.phase === "result"
+                ? `🗃️ ${Number(result.correct_count ?? 0)}/${Number(result.total ?? payload.items.length)} sorted · +${Number(result.points ?? 0)} Arcade points`
+                : "👀 Stack revealed — no Arcade points awarded."}
+            </p>
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {!showResult ? (
+            <>
+              <button
+                className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]"
+                disabled={loading || !completeBoard}
+                onClick={onSubmit}
+              >
+                Check my stack
+              </button>
+              <button
+                className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white"
+                disabled={loading}
+                onClick={onReveal}
+              >
+                👀 Reveal stack
               </button>
             </>
           ) : (


### PR DESCRIPTION
## What changed

Extends #23 with a third shared Arcade adapter: **Sort the Stack**, playable both solo and inside Quest Rooms from the same `ActivityRuntime` contract.

### Shared Sort adapter
- Adds `SORT_DEFINITION` to the central activity registry.
- Sort the Stack presents terms + definition clues and asks learners to place each card into its correct learning-domain bucket.
- Requires at least 4 cards across at least 2 distinct domains.
- A sampled board is forced to contain at least two represented domains so a valid deck cannot accidentally produce a one-bucket challenge.
- Board size follows the existing board-game `round_count` convention and awards up to 500 Arcade points proportionally to correct placements.

### Spoiler boundary
- A card's domain is the answer for Sort the Stack.
- Pre-reveal item payloads intentionally omit `domain`.
- Public state exposes only the available bucket names plus term/definition clues.
- The hidden card→domain `answer_map` appears only after result/reveal.
- Quest Room submissions continue to use the existing pending-submission flow, so player placements/correctness never broadcast before synchronized reveal.

### Solo Arcade
- Adds Sort the Stack as a third game choice beside Blitz and Match Quest.
- Supports `?game=sort` deep links.
- Uses native select controls for domain placement; drag-and-drop is never required.
- Supports the same optional timer policy as the existing board game while Chill/Focus can stay untimed.
- Completion now cycles across all three playable games.
- UI tells learners that Sort requires at least two domains; the server remains the authority.

### Quest Rooms
- Hosts can launch Sort the Stack from the existing Room Arcade panel.
- All participants receive the same phase-safe sorting board.
- Players submit privately; room sees only who is ready.
- Host synchronized reveal publishes the correct domain map + scoreboard together.
- Room chat/presence remain unchanged and usable alongside the game.

### Tests
Covers:
- pre-reveal domain/answer-map secrecy
- proportional Sort scoring through the shared runtime
- deterministic solo/room adapter parity
- rejection of one-domain decks
- anonymous solo HTTP start/submit flow with a perfect Sort board
- one-domain HTTP rejection
- Quest Room WebSocket start → private submit → synchronized reveal → completion

### Docs
- Updates the shared Arcade activity contract.
- Updates Quest Room architecture and Room Arcade V1 docs to list Sort the Stack as implemented.

## Still tracked in #23
Boss Battle, Debug Dungeon, and broader shared challenge/polish work remain follow-ups. This PR does not close #23.