### PR TITLE
Add secure private and invite-only Quest Room access

### DIFF
--- a/backend/alembic/versions/f1d2a5b6c7e8_add_quest_room_invites.py
+++ b/backend/alembic/versions/f1d2a5b6c7e8_add_quest_room_invites.py
@@ -1,0 +1,64 @@
+"""add quest room invites
+
+Revision ID: f1d2a5b6c7e8
+Revises: e0c1f4a5b6d7
+Create Date: 2026-08-19
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f1d2a5b6c7e8"
+down_revision: Union[str, Sequence[str], None] = "e0c1f4a5b6d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Persist hashed, expiring, revocable invite capabilities."""
+    op.create_table(
+        "room_invite",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("use_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["app_user.id"]),
+        sa.ForeignKeyConstraint(["room_id"], ["study_room.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash", name="uq_room_invite_token_hash"),
+    )
+    op.create_index(op.f("ix_room_invite_room_id"), "room_invite", ["room_id"], unique=False)
+    op.create_index(
+        op.f("ix_room_invite_created_by_user_id"),
+        "room_invite",
+        ["created_by_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_room_invite_token_hash"),
+        "room_invite",
+        ["token_hash"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_room_invite_expires_at"),
+        "room_invite",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove persistent room invite capabilities."""
+    op.drop_index(op.f("ix_room_invite_expires_at"), table_name="room_invite")
+    op.drop_index(op.f("ix_room_invite_token_hash"), table_name="room_invite")
+    op.drop_index(op.f("ix_room_invite_created_by_user_id"), table_name="room_invite")
+    op.drop_index(op.f("ix_room_invite_room_id"), table_name="room_invite")
+    op.drop_table("room_invite")

--- a/backend/app/room_models.py
+++ b/backend/app/room_models.py
@@ -1,8 +1,8 @@
 """Persistent data contracts for deck-linked Quest Rooms.
 
-Room membership and message history are durable PostgreSQL state. Realtime
-presence intentionally lives outside these tables so heartbeats do not become a
-write-amplification problem.
+Room membership, invite capabilities, and message history are durable PostgreSQL
+state. Realtime presence intentionally lives outside these tables so heartbeats
+do not become a write-amplification problem.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Optional
 
 import sqlalchemy as sa
+from pydantic import EmailStr
 from sqlmodel import Field, SQLModel
 
 from .models import utc_now
@@ -80,6 +81,29 @@ class RoomMember(SQLModel, table=True):
     removed_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
 
 
+class RoomInvite(SQLModel, table=True):
+    """Hashed reusable invite capability for an invite-only Quest Room."""
+
+    __tablename__ = "room_invite"
+    __table_args__ = (
+        sa.UniqueConstraint("token_hash", name="uq_room_invite_token_hash"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    room_id: int = Field(
+        foreign_key="study_room.id", index=True, sa_type=sa.Integer
+    )
+    created_by_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    token_hash: str = Field(index=True, sa_type=sa.String)
+    expires_at: datetime = Field(index=True, sa_type=sa.DateTime(timezone=True))
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+    revoked_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+    use_count: int = Field(default=0, sa_type=sa.Integer)
+    last_used_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+
+
 class RoomMessage(SQLModel, table=True):
     """Durable room history independent of any one realtime process."""
 
@@ -141,6 +165,39 @@ class RoomMemberRead(SQLModel):
     status: str
     joined_at: datetime
     last_seen_at: datetime
+    display_name: Optional[str] = None
+
+
+class RoomInviteCreate(SQLModel):
+    """Host request for a reusable invite with bounded lifetime."""
+
+    expires_in_hours: int = Field(default=24, ge=1, le=168)
+
+
+class RoomInviteRead(SQLModel):
+    id: int
+    room_id: int
+    created_by_user_id: int
+    expires_at: datetime
+    created_at: datetime
+    revoked_at: Optional[datetime] = None
+    use_count: int = 0
+    last_used_at: Optional[datetime] = None
+    active: bool
+
+
+class RoomInviteIssued(RoomInviteRead):
+    """Invite metadata plus the raw token returned exactly once at creation."""
+
+    token: str
+
+
+class InviteJoinRequest(SQLModel):
+    token: str
+
+
+class PrivateMemberAddRequest(SQLModel):
+    email: EmailStr
 
 
 class RoomMessageRead(SQLModel):

--- a/backend/app/room_realtime.py
+++ b/backend/app/room_realtime.py
@@ -123,6 +123,22 @@ class RoomConnectionManager:
                 self._connections.pop(room_id, None)
             return True
 
+    async def kick_user(self, room_id: int, user_id: int, code: int = 4403) -> bool:
+        """Immediately detach and close every live socket for one room member."""
+        async with self._lock:
+            room = self._connections.get(room_id)
+            if room is None:
+                return False
+            sockets = list(room.pop(user_id, []))
+            if not room:
+                self._connections.pop(room_id, None)
+        for socket in sockets:
+            try:
+                await socket.close(code=code)
+            except Exception:
+                continue
+        return bool(sockets)
+
     async def online_user_ids(self, room_id: int) -> list[int]:
         async with self._lock:
             return sorted(self._connections.get(room_id, {}).keys())

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -1,6 +1,8 @@
-"""Quest Room REST foundation: ownership, membership, and deck privacy boundaries."""
+"""Quest Room REST boundaries for membership, privacy, and invite capabilities."""
 
 from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func
@@ -10,13 +12,20 @@ from ..db import get_session
 from ..models import Deck, User, utc_now
 from ..room_models import (
     ROOM_VISIBILITIES,
+    InviteJoinRequest,
+    PrivateMemberAddRequest,
     RoomCreate,
+    RoomInvite,
+    RoomInviteCreate,
+    RoomInviteIssued,
+    RoomInviteRead,
     RoomMember,
     RoomMemberRead,
     RoomRead,
     StudyRoom,
 )
-from ..security import get_current_user, require_verified_user
+from ..room_realtime import event_envelope, room_connections
+from ..security import get_current_user, hash_token, new_token, require_verified_user
 
 router = APIRouter(prefix="/rooms", tags=["rooms"])
 
@@ -28,6 +37,12 @@ def _clean_name(value: str) -> str:
     if len(name) > 80:
         raise HTTPException(status_code=422, detail="Room name must be 80 characters or fewer")
     return name
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _room_or_404(session: Session, room_id: int) -> StudyRoom:
@@ -82,6 +97,38 @@ def _read_room(session: Session, room: StudyRoom, user_id: int) -> RoomRead:
     )
 
 
+def _read_member(session: Session, member: RoomMember) -> RoomMemberRead:
+    account = session.get(User, member.user_id)
+    return RoomMemberRead(
+        id=int(member.id or 0),
+        room_id=member.room_id,
+        user_id=member.user_id,
+        role=member.role,
+        status=member.status,
+        joined_at=member.joined_at,
+        last_seen_at=member.last_seen_at,
+        display_name=account.display_name if account is not None else None,
+    )
+
+
+def _invite_active(invite: RoomInvite) -> bool:
+    return invite.revoked_at is None and _aware_utc(invite.expires_at) > utc_now()
+
+
+def _read_invite(invite: RoomInvite) -> RoomInviteRead:
+    return RoomInviteRead(
+        id=int(invite.id or 0),
+        room_id=invite.room_id,
+        created_by_user_id=invite.created_by_user_id,
+        expires_at=invite.expires_at,
+        created_at=invite.created_at,
+        revoked_at=invite.revoked_at,
+        use_count=invite.use_count,
+        last_used_at=invite.last_used_at,
+        active=_invite_active(invite),
+    )
+
+
 def _deck_for_room(
     session: Session,
     *,
@@ -119,6 +166,44 @@ def _require_host(session: Session, room: StudyRoom, user_id: int) -> RoomMember
     if membership.role != "host" or room.host_user_id != user_id:
         raise HTTPException(status_code=403, detail="Only the room host can do that")
     return membership
+
+
+def _activate_membership(
+    session: Session,
+    room: StudyRoom,
+    user_id: int,
+    *,
+    allow_restore_removed: bool,
+) -> RoomMember:
+    """Create/reactivate one durable membership under an already-authorized flow."""
+    existing = _any_membership(session, int(room.id or 0), user_id)
+    if existing is not None:
+        if existing.status == "removed" and not allow_restore_removed:
+            raise HTTPException(status_code=403, detail="Membership was removed")
+        existing.status = "active"
+        existing.role = "member" if existing.role != "host" else existing.role
+        existing.removed_at = None
+        existing.last_seen_at = utc_now()
+        session.add(existing)
+        return existing
+
+    membership = RoomMember(
+        room_id=int(room.id or 0),
+        user_id=user_id,
+        role="member",
+        status="active",
+    )
+    session.add(membership)
+    return membership
+
+
+def _presence_payload(session: Session, user_ids: list[int]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for user_id in user_ids:
+        account = session.get(User, user_id)
+        if account is not None:
+            rows.append({"user_id": user_id, "display_name": account.display_name})
+    return rows
 
 
 @router.post("", response_model=RoomRead, status_code=201)
@@ -182,6 +267,49 @@ def my_rooms(
     return [_read_room(session, room, int(user.id or 0)) for room in rows]
 
 
+@router.post("/invites/join", response_model=RoomRead)
+def join_by_invite(
+    payload: InviteJoinRequest,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomRead:
+    """Join an invite-only room with a valid opaque capability token."""
+    raw = payload.token.strip()
+    if len(raw) < 20:
+        raise HTTPException(status_code=404, detail="Invite not found or unavailable")
+    invite = session.exec(
+        select(RoomInvite).where(RoomInvite.token_hash == hash_token(raw))
+    ).first()
+    if invite is None or not _invite_active(invite):
+        raise HTTPException(status_code=404, detail="Invite not found or unavailable")
+
+    room = session.get(StudyRoom, invite.room_id)
+    if room is None or room.visibility != "invite_only":
+        raise HTTPException(status_code=404, detail="Invite not found or unavailable")
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+
+    user_id = int(user.id or 0)
+    active = _active_member(session, int(room.id or 0), user_id)
+    if active is not None:
+        return _read_room(session, room, user_id)
+
+    _activate_membership(
+        session,
+        room,
+        user_id,
+        allow_restore_removed=False,
+    )
+    now = utc_now()
+    invite.use_count += 1
+    invite.last_used_at = now
+    room.updated_at = now
+    session.add(invite)
+    session.add(room)
+    session.commit()
+    return _read_room(session, room, user_id)
+
+
 @router.get("/{room_id}", response_model=RoomRead)
 def room_detail(
     room_id: int,
@@ -208,37 +336,40 @@ def join_room(
     if room.status != "open":
         raise HTTPException(status_code=409, detail="Room is closed")
 
-    current = _active_member(session, room_id, int(user.id or 0))
+    user_id = int(user.id or 0)
+    current = _active_member(session, room_id, user_id)
     if current is not None:
-        return _read_room(session, room, int(user.id or 0))
+        return _read_room(session, room, user_id)
 
-    prior = _any_membership(session, room_id, int(user.id or 0))
+    prior = _any_membership(session, room_id, user_id)
     if prior is not None:
         if prior.status == "removed":
             raise HTTPException(status_code=403, detail="Membership was removed")
         if prior.status == "left" and room.visibility == "public":
-            prior.status = "active"
-            prior.removed_at = None
-            prior.last_seen_at = utc_now()
-            session.add(prior)
+            _activate_membership(
+                session,
+                room,
+                user_id,
+                allow_restore_removed=False,
+            )
+            room.updated_at = utc_now()
+            session.add(room)
             session.commit()
-            return _read_room(session, room, int(user.id or 0))
+            return _read_room(session, room, user_id)
 
     if room.visibility != "public":
         raise HTTPException(status_code=403, detail="Invite or membership required")
 
-    session.add(
-        RoomMember(
-            room_id=room_id,
-            user_id=int(user.id or 0),
-            role="member",
-            status="active",
-        )
+    _activate_membership(
+        session,
+        room,
+        user_id,
+        allow_restore_removed=False,
     )
     room.updated_at = utc_now()
     session.add(room)
     session.commit()
-    return _read_room(session, room, int(user.id or 0))
+    return _read_room(session, room, user_id)
 
 
 @router.post("/{room_id}/leave", response_model=RoomRead)
@@ -283,6 +414,73 @@ def close_room(
     return _read_room(session, room, int(user.id or 0))
 
 
+@router.post("/{room_id}/invites", response_model=RoomInviteIssued, status_code=201)
+def create_room_invite(
+    room_id: int,
+    payload: RoomInviteCreate,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomInviteIssued:
+    """Issue an expiring reusable invite for an invite-only room."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+    if room.visibility != "invite_only":
+        raise HTTPException(status_code=409, detail="Only invite-only rooms use invite links")
+
+    raw = new_token()
+    invite = RoomInvite(
+        room_id=room_id,
+        created_by_user_id=int(user.id or 0),
+        token_hash=hash_token(raw),
+        expires_at=utc_now() + timedelta(hours=payload.expires_in_hours),
+    )
+    session.add(invite)
+    session.commit()
+    session.refresh(invite)
+    read = _read_invite(invite)
+    return RoomInviteIssued(**read.model_dump(), token=raw)
+
+
+@router.get("/{room_id}/invites", response_model=list[RoomInviteRead])
+def list_room_invites(
+    room_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[RoomInviteRead]:
+    """List invite metadata to the room host without ever returning raw tokens."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    rows = session.exec(
+        select(RoomInvite)
+        .where(RoomInvite.room_id == room_id)
+        .order_by(RoomInvite.created_at.desc())
+    ).all()
+    return [_read_invite(invite) for invite in rows]
+
+
+@router.post("/{room_id}/invites/{invite_id}/revoke", response_model=RoomInviteRead)
+def revoke_room_invite(
+    room_id: int,
+    invite_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomInviteRead:
+    """Revoke one invite capability immediately."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    invite = session.get(RoomInvite, invite_id)
+    if invite is None or invite.room_id != room_id:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    if invite.revoked_at is None:
+        invite.revoked_at = utc_now()
+        session.add(invite)
+        session.commit()
+        session.refresh(invite)
+    return _read_invite(invite)
+
+
 @router.get("/{room_id}/members", response_model=list[RoomMemberRead])
 def room_members(
     room_id: int,
@@ -297,15 +495,90 @@ def room_members(
         .where(RoomMember.room_id == room_id, RoomMember.status == "active")
         .order_by(RoomMember.joined_at.asc())
     ).all()
-    return [
-        RoomMemberRead(
-            id=int(member.id or 0),
-            room_id=member.room_id,
-            user_id=member.user_id,
-            role=member.role,
-            status=member.status,
-            joined_at=member.joined_at,
-            last_seen_at=member.last_seen_at,
+    return [_read_member(session, member) for member in rows]
+
+
+@router.post("/{room_id}/members/add", response_model=RoomMemberRead)
+def add_private_room_member(
+    room_id: int,
+    payload: PrivateMemberAddRequest,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomMemberRead:
+    """Explicitly add a verified existing account to a private room."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+    if room.visibility != "private":
+        raise HTTPException(status_code=409, detail="Direct member adds are for private rooms")
+
+    normalized_email = str(payload.email).strip().lower()
+    target = session.exec(
+        select(User).where(func.lower(User.email) == normalized_email)
+    ).first()
+    if target is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+    if not target.is_verified:
+        raise HTTPException(status_code=422, detail="Member must verify their email first")
+
+    membership = _active_member(session, room_id, int(target.id or 0))
+    if membership is None:
+        membership = _activate_membership(
+            session,
+            room,
+            int(target.id or 0),
+            allow_restore_removed=True,
         )
-        for member in rows
-    ]
+        room.updated_at = utc_now()
+        session.add(room)
+        session.commit()
+        session.refresh(membership)
+    return _read_member(session, membership)
+
+
+@router.post("/{room_id}/members/{target_user_id}/remove", response_model=RoomMemberRead)
+async def remove_room_member(
+    room_id: int,
+    target_user_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> RoomMemberRead:
+    """Remove a member and revoke every live room socket immediately."""
+    room = _room_or_404(session, room_id)
+    _require_host(session, room, int(user.id or 0))
+    if target_user_id == room.host_user_id:
+        raise HTTPException(status_code=409, detail="The room host cannot remove themselves")
+
+    membership = _active_member(session, room_id, target_user_id)
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Active member not found")
+
+    now = utc_now()
+    membership.status = "removed"
+    membership.removed_at = now
+    membership.last_seen_at = now
+    room.updated_at = now
+    session.add(membership)
+    session.add(room)
+    session.commit()
+    session.refresh(membership)
+
+    await room_connections.kick_user(room_id, target_user_id)
+    online_ids = await room_connections.online_user_ids(room_id)
+    target = session.get(User, target_user_id)
+    await room_connections.broadcast(
+        room_id,
+        event_envelope(
+            room_id,
+            "presence.left",
+            {
+                "user": {
+                    "user_id": target_user_id,
+                    "display_name": target.display_name if target is not None else "Removed member",
+                },
+                "presence": _presence_payload(session, online_ids),
+            },
+        ),
+    )
+    return _read_member(session, membership)

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -145,7 +145,6 @@ def _deck_for_room(
     if not owns_deck and not shareable:
         raise HTTPException(status_code=403, detail="You cannot create a room for this deck")
 
-    # A room must never widen the discoverability of its backing deck.
     if room_visibility == "public" and not (deck.is_builtin or deck.visibility == "public"):
         raise HTTPException(
             status_code=422,
@@ -320,7 +319,6 @@ def room_detail(
     room = _room_or_404(session, room_id)
     member = _active_member(session, room_id, int(user.id or 0))
     if member is None and not (room.visibility == "public" and room.status == "open"):
-        # Hide private/invite-only room existence from non-members.
         raise HTTPException(status_code=404, detail="Room not found")
     return _read_room(session, room, int(user.id or 0))
 
@@ -331,21 +329,23 @@ def join_room(
     user: User = Depends(get_current_user),
     session: Session = Depends(get_session),
 ) -> RoomRead:
-    """Join an open public room. Invite/private membership is handled separately."""
+    """Join an open public room; hidden room ids remain non-enumerable."""
     room = _room_or_404(session, room_id)
-    if room.status != "open":
-        raise HTTPException(status_code=409, detail="Room is closed")
-
     user_id = int(user.id or 0)
     current = _active_member(session, room_id, user_id)
     if current is not None:
         return _read_room(session, room, user_id)
 
+    if room.visibility != "public":
+        raise HTTPException(status_code=404, detail="Room not found")
+    if room.status != "open":
+        raise HTTPException(status_code=409, detail="Room is closed")
+
     prior = _any_membership(session, room_id, user_id)
     if prior is not None:
         if prior.status == "removed":
             raise HTTPException(status_code=403, detail="Membership was removed")
-        if prior.status == "left" and room.visibility == "public":
+        if prior.status == "left":
             _activate_membership(
                 session,
                 room,
@@ -356,9 +356,6 @@ def join_room(
             session.add(room)
             session.commit()
             return _read_room(session, room, user_id)
-
-    if room.visibility != "public":
-        raise HTTPException(status_code=403, detail="Invite or membership required")
 
     _activate_membership(
         session,

--- a/backend/tests/test_quest_rooms.py
+++ b/backend/tests/test_quest_rooms.py
@@ -205,8 +205,8 @@ def test_private_and_invite_rooms_reject_generic_join(client, sqlite_session: Se
             name=f"{visibility} room",
         ).json()
         response = client.post(f"/rooms/{room['id']}/join", headers=headers)
-        assert response.status_code == 403
-        assert "invite" in response.json()["detail"].lower()
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Room not found"
 
 
 def test_private_room_is_not_enumerable_by_non_member(client, sqlite_session: Session):

--- a/backend/tests/test_room_invites.py
+++ b/backend/tests/test_room_invites.py
@@ -187,7 +187,8 @@ def test_private_room_host_adds_verified_account_by_email(client, sqlite_session
         f"/rooms/{room['id']}/join",
         headers=_headers(sqlite_session, member),
     )
-    assert generic.status_code == 403
+    assert generic.status_code == 404
+    assert generic.json()["detail"] == "Room not found"
 
     added = client.post(
         f"/rooms/{room['id']}/members/add",

--- a/backend/tests/test_room_invites.py
+++ b/backend/tests/test_room_invites.py
@@ -1,0 +1,329 @@
+"""Private/invite-only Quest Room access and live revocation tests."""
+
+from datetime import timedelta
+
+import pytest
+from sqlmodel import Session, select
+from starlette.websockets import WebSocketDisconnect
+
+from app.models import Deck, User, utc_now
+from app.room_models import RoomInvite, RoomMember
+from app.security import create_auth_session, hash_password, hash_token
+
+
+def _user(session: Session, suffix: str, *, verified: bool = True) -> User:
+    user = User(
+        email=f"invite-{suffix}@example.com",
+        display_name=f"Invite {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=verified,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck(session: Session, owner: User, slug: str) -> Deck:
+    deck = Deck(
+        owner_id=owner.id,
+        title=f"Invite Deck {slug}",
+        slug=slug,
+        description="Invite room test deck",
+        is_builtin=False,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public",
+        tags=["invites"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return deck
+
+
+def _room(client, session: Session, host: User, visibility: str, slug: str) -> dict:
+    deck = _deck(session, host, slug)
+    response = client.post(
+        "/rooms",
+        headers=_headers(session, host),
+        json={
+            "deck_id": int(deck.id or 0),
+            "name": f"{visibility} study room",
+            "visibility": visibility,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _invite(client, session: Session, host: User, room_id: int, hours: int = 24) -> dict:
+    response = client.post(
+        f"/rooms/{room_id}/invites",
+        headers=_headers(session, host),
+        json={"expires_in_hours": hours},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _ticket(client, session: Session, user: User, room_id: int) -> str:
+    response = client.post(
+        f"/rooms/{room_id}/ws-ticket",
+        headers=_headers(session, user),
+    )
+    assert response.status_code == 200
+    return response.json()["ticket"]
+
+
+def test_invite_token_is_hashed_at_rest_and_returned_only_when_issued(
+    client, sqlite_session: Session
+):
+    host = _user(sqlite_session, "hash-host")
+    room = _room(client, sqlite_session, host, "invite_only", "hash-room")
+
+    issued = _invite(client, sqlite_session, host, room["id"])
+    assert len(issued["token"]) >= 20
+    stored = sqlite_session.get(RoomInvite, issued["id"])
+    assert stored is not None
+    assert stored.token_hash == hash_token(issued["token"])
+    assert stored.token_hash != issued["token"]
+
+    listing = client.get(
+        f"/rooms/{room['id']}/invites",
+        headers=_headers(sqlite_session, host),
+    )
+    assert listing.status_code == 200
+    assert listing.json()[0]["id"] == issued["id"]
+    assert "token" not in listing.json()[0]
+    assert "token_hash" not in listing.json()[0]
+
+
+def test_valid_invite_joins_hidden_room_and_is_reusable_for_group(
+    client, sqlite_session: Session
+):
+    host = _user(sqlite_session, "group-host")
+    first = _user(sqlite_session, "group-first")
+    second = _user(sqlite_session, "group-second")
+    room = _room(client, sqlite_session, host, "invite_only", "group-room")
+    issued = _invite(client, sqlite_session, host, room["id"])
+
+    # Knowing the id alone does not make the room readable.
+    hidden = client.get(
+        f"/rooms/{room['id']}",
+        headers=_headers(sqlite_session, first),
+    )
+    assert hidden.status_code == 404
+
+    for member in (first, second):
+        joined = client.post(
+            "/rooms/invites/join",
+            headers=_headers(sqlite_session, member),
+            json={"token": issued["token"]},
+        )
+        assert joined.status_code == 200
+        assert joined.json()["id"] == room["id"]
+        assert joined.json()["current_user_role"] == "member"
+
+    stored = sqlite_session.get(RoomInvite, issued["id"])
+    assert stored is not None
+    assert stored.use_count == 2
+    assert stored.last_used_at is not None
+
+
+def test_revoked_invite_stops_working_immediately(client, sqlite_session: Session):
+    host = _user(sqlite_session, "revoke-host")
+    outsider = _user(sqlite_session, "revoke-outsider")
+    room = _room(client, sqlite_session, host, "invite_only", "revoke-room")
+    issued = _invite(client, sqlite_session, host, room["id"])
+
+    revoked = client.post(
+        f"/rooms/{room['id']}/invites/{issued['id']}/revoke",
+        headers=_headers(sqlite_session, host),
+    )
+    assert revoked.status_code == 200
+    assert revoked.json()["active"] is False
+    assert revoked.json()["revoked_at"] is not None
+
+    denied = client.post(
+        "/rooms/invites/join",
+        headers=_headers(sqlite_session, outsider),
+        json={"token": issued["token"]},
+    )
+    assert denied.status_code == 404
+
+
+def test_expired_invite_stops_working(client, sqlite_session: Session):
+    host = _user(sqlite_session, "expired-host")
+    outsider = _user(sqlite_session, "expired-outsider")
+    room = _room(client, sqlite_session, host, "invite_only", "expired-room")
+    issued = _invite(client, sqlite_session, host, room["id"])
+
+    stored = sqlite_session.get(RoomInvite, issued["id"])
+    assert stored is not None
+    stored.expires_at = utc_now() - timedelta(seconds=1)
+    sqlite_session.add(stored)
+    sqlite_session.commit()
+
+    denied = client.post(
+        "/rooms/invites/join",
+        headers=_headers(sqlite_session, outsider),
+        json={"token": issued["token"]},
+    )
+    assert denied.status_code == 404
+
+
+def test_private_room_host_adds_verified_account_by_email(client, sqlite_session: Session):
+    host = _user(sqlite_session, "private-host")
+    member = _user(sqlite_session, "private-member")
+    room = _room(client, sqlite_session, host, "private", "private-room")
+
+    generic = client.post(
+        f"/rooms/{room['id']}/join",
+        headers=_headers(sqlite_session, member),
+    )
+    assert generic.status_code == 403
+
+    added = client.post(
+        f"/rooms/{room['id']}/members/add",
+        headers=_headers(sqlite_session, host),
+        json={"email": member.email},
+    )
+    assert added.status_code == 200
+    assert added.json()["user_id"] == member.id
+    assert added.json()["display_name"] == member.display_name
+    assert added.json()["status"] == "active"
+
+    detail = client.get(
+        f"/rooms/{room['id']}",
+        headers=_headers(sqlite_session, member),
+    )
+    assert detail.status_code == 200
+    assert detail.json()["current_user_role"] == "member"
+
+
+def test_private_room_rejects_unverified_direct_member(client, sqlite_session: Session):
+    host = _user(sqlite_session, "unverified-host")
+    member = _user(sqlite_session, "unverified-member", verified=False)
+    room = _room(client, sqlite_session, host, "private", "unverified-room")
+
+    response = client.post(
+        f"/rooms/{room['id']}/members/add",
+        headers=_headers(sqlite_session, host),
+        json={"email": member.email},
+    )
+    assert response.status_code == 422
+    assert "verify" in response.json()["detail"].lower()
+
+
+def test_only_invite_only_rooms_can_issue_invite_links(client, sqlite_session: Session):
+    host = _user(sqlite_session, "mode-host")
+    private_room = _room(client, sqlite_session, host, "private", "mode-private")
+    public_room = _room(client, sqlite_session, host, "public", "mode-public")
+
+    for room in (private_room, public_room):
+        response = client.post(
+            f"/rooms/{room['id']}/invites",
+            headers=_headers(sqlite_session, host),
+            json={"expires_in_hours": 24},
+        )
+        assert response.status_code == 409
+
+
+def test_host_removal_kicks_live_socket_and_member_cannot_reconnect(
+    client, sqlite_session: Session
+):
+    host = _user(sqlite_session, "kick-host")
+    member = _user(sqlite_session, "kick-member")
+    room = _room(client, sqlite_session, host, "private", "kick-room")
+    host_headers = _headers(sqlite_session, host)
+    member_headers = _headers(sqlite_session, member)
+
+    added = client.post(
+        f"/rooms/{room['id']}/members/add",
+        headers=host_headers,
+        json={"email": member.email},
+    )
+    assert added.status_code == 200
+
+    host_ticket = client.post(
+        f"/rooms/{room['id']}/ws-ticket", headers=host_headers
+    ).json()["ticket"]
+    member_ticket = client.post(
+        f"/rooms/{room['id']}/ws-ticket", headers=member_headers
+    ).json()["ticket"]
+
+    with client.websocket_connect(
+        f"/rooms/{room['id']}/ws?ticket={host_ticket}"
+    ) as host_ws:
+        assert host_ws.receive_json()["type"] == "room.snapshot"
+        assert host_ws.receive_json()["type"] == "presence.joined"
+
+        with client.websocket_connect(
+            f"/rooms/{room['id']}/ws?ticket={member_ticket}"
+        ) as member_ws:
+            assert member_ws.receive_json()["type"] == "room.snapshot"
+            assert host_ws.receive_json()["type"] == "presence.joined"
+            assert member_ws.receive_json()["type"] == "presence.joined"
+
+            removed = client.post(
+                f"/rooms/{room['id']}/members/{member.id}/remove",
+                headers=host_headers,
+            )
+            assert removed.status_code == 200
+            assert removed.json()["status"] == "removed"
+
+            presence_left = host_ws.receive_json()
+            assert presence_left["type"] == "presence.left"
+            assert presence_left["payload"]["user"]["user_id"] == member.id
+            assert [person["user_id"] for person in presence_left["payload"]["presence"]] == [host.id]
+
+            with pytest.raises(WebSocketDisconnect):
+                member_ws.receive_json()
+
+    membership = sqlite_session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room["id"],
+            RoomMember.user_id == member.id,
+        )
+    ).one()
+    assert membership.status == "removed"
+
+    ticket_denied = client.post(
+        f"/rooms/{room['id']}/ws-ticket",
+        headers=member_headers,
+    )
+    assert ticket_denied.status_code == 403
+
+
+def test_non_host_cannot_issue_invite_or_remove_member(client, sqlite_session: Session):
+    host = _user(sqlite_session, "permission-host")
+    member = _user(sqlite_session, "permission-member")
+    room = _room(client, sqlite_session, host, "invite_only", "permission-room")
+    issued = _invite(client, sqlite_session, host, room["id"])
+
+    joined = client.post(
+        "/rooms/invites/join",
+        headers=_headers(sqlite_session, member),
+        json={"token": issued["token"]},
+    )
+    assert joined.status_code == 200
+    member_headers = _headers(sqlite_session, member)
+
+    denied_invite = client.post(
+        f"/rooms/{room['id']}/invites",
+        headers=member_headers,
+        json={"expires_in_hours": 24},
+    )
+    assert denied_invite.status_code == 403
+
+    denied_remove = client.post(
+        f"/rooms/{room['id']}/members/{host.id}/remove",
+        headers=member_headers,
+    )
+    assert denied_remove.status_code == 403

--- a/docs/QUEST_ROOMS_ARCHITECTURE.md
+++ b/docs/QUEST_ROOMS_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Quest Rooms architecture
 
-Quest Rooms are **deck-linked study session containers**. Chat, card sharing, presence, and synchronized Arcade activities all live inside the same room boundary rather than becoming separate social systems.
+Quest Rooms are **deck-linked study session containers**. Chat, card sharing, presence, synchronized Arcade activities, and access control all live inside the same room boundary rather than becoming separate social systems.
 
 ## State boundaries
 
@@ -8,6 +8,7 @@ Quest Rooms are **deck-linked study session containers**. Chat, card sharing, pr
 | --- | --- | --- |
 | Room identity, host, deck, visibility, status | PostgreSQL | Must survive deploys/restarts |
 | Membership and roles | PostgreSQL | Permissions cannot depend on a socket being connected |
+| Invite token hashes + lifecycle metadata | PostgreSQL | Invite expiry/revocation must survive restarts without storing raw secrets |
 | Message/card-share history | PostgreSQL | Reconnect/history must be durable |
 | Presence and connection counts | Ephemeral realtime process | Heartbeats should not write to the database continuously |
 | Shared Arcade runtime + unrevealed submissions | Ephemeral realtime process | Uses the same activity contract as solo Arcade without persisting answer-bearing round state |
@@ -38,6 +39,18 @@ Membership is durable permission state, not connection state.
 
 A reconnect or second browser tab does not create a second membership row.
 
+### `RoomInvite`
+
+Invite-only admission uses durable metadata with a one-way token hash.
+
+- `room_id`
+- `created_by_user_id`
+- SHA-256 `token_hash`
+- creation/expiry/revocation timestamps
+- use count and last-used timestamp
+
+The raw invite token is returned exactly once at creation and is never returned by invite-list APIs.
+
 ### `RoomMessage`
 
 Messages are durable history with room/user attribution.
@@ -58,15 +71,46 @@ A room must never widen the discoverability of its backing deck.
 - Private decks may only be used by their owner and may not back public rooms.
 - Server-side checks enforce these rules; the UI is not the security boundary.
 
-There is intentionally no public room-discovery endpoint in the foundation. Broad public-room discovery remains blocked until moderation/reporting work is ready.
+There is intentionally no broad public room-discovery endpoint yet. Public rooms are reachable through a shared room link/number until moderation/reporting work is ready.
 
-## Membership lifecycle
+## Room access modes
+
+The three visibility modes have deliberately different admission semantics.
+
+### Public
+
+Any signed-in learner with the shared room link/number may join an open public room. A voluntarily-left public member may rejoin; a member marked `removed` cannot self-rejoin.
+
+### Invite only
+
+Invite-only rooms are non-enumerable to non-members. Generic `GET /rooms/{id}` and `POST /rooms/{id}/join` requests return `404`.
+
+Only the host may issue expiring reusable invite capabilities. The server stores only the token hash. A valid, unexpired, unrevoked token may admit authenticated users until the host revokes it or it expires. Revocation blocks future admission but does not eject learners who already became members.
+
+A removed member cannot use an otherwise-valid invite to restore themselves.
+
+### Private
+
+Private rooms are also non-enumerable to non-members and do not use generic invite links. The host explicitly admits an existing verified FlashQuest account by email. That durable membership then allows the account to open the hidden room normally.
+
+An explicit host add may restore a previously removed account; this is a new host decision rather than self-service re-entry.
+
+See [Quest Room access modes](QUEST_ROOM_ACCESS.md) for the user-facing and security contract.
+
+## Membership lifecycle and live revocation
 
 Verified accounts may create rooms. The creator becomes the persistent `host` member in the same transaction.
 
-Authenticated accounts may join open public rooms. Generic join does not bypass private/invite-only membership. A member who voluntarily left a public room may rejoin; a member marked `removed` cannot self-rejoin.
+Only the host closes a room. Closed rooms preserve membership/history but reject new joins and realtime tickets.
 
-Only the host closes a room in the foundation. Closed rooms preserve membership/history but reject new joins.
+Host removal is both durable and live:
+
+1. The member row becomes `removed`.
+2. Every active socket for that `(room, user)` is detached and closed with `4403`.
+3. Remaining participants receive an updated `presence.left` event.
+4. New WebSocket tickets and room mutations are denied.
+
+This prevents removed learners from continuing to receive realtime room events merely because a socket was already open.
 
 ## Realtime authentication
 
@@ -87,7 +131,7 @@ Presence is an in-memory connection registry keyed by room and user, while chat 
 
 - Multiple tabs may create multiple live connections for one member.
 - `presence.joined` is emitted only for the first live connection for that user.
-- `presence.left` is emitted only after the final live connection closes.
+- `presence.left` is emitted only after the final live connection closes, except host removal explicitly broadcasts revocation state after kicking all target sockets.
 - Reconnect requests a fresh one-use ticket and receives a `room.snapshot` containing current presence, the latest durable messages, and the current phase-safe Arcade snapshot when a game is active.
 - `RoomMember.last_seen_at` is updated opportunistically rather than on every network event.
 - Every chat/game mutation re-checks durable room membership, so a user removed while connected cannot keep posting or playing with an old socket.
@@ -137,7 +181,7 @@ Sort the Stack uses the card's domain as its hidden answer. A compatible Sort de
 
 Correct answer ids/maps stay server-internal until synchronized reveal. Room Arcade score remains separate from each learner's spaced-repetition mastery. Future mastery updates go through the dedicated per-card progress adapter rather than mutating bins from room UI state.
 
-The active room activity is intentionally ephemeral in this phase. A realtime process restart may end an in-progress room game even though the room, membership, and chat history remain durable.
+The active room activity is intentionally ephemeral in this phase. A realtime process restart may end an in-progress room game even though the room, membership, invites, and chat history remain durable.
 
 ## Moderation launch gate
 
@@ -150,4 +194,4 @@ Before broad public-room discovery ships, the realtime/message layer must includ
 - permission-checked message/card posting
 - report/block/ban support from the moderation workstream
 
-The first two controls and membership-checked chat/game mutations exist in the realtime foundation. Broad public-room discovery remains blocked until the remaining moderation/reporting controls are implemented.
+Length/rate limits, host removal, room close, and membership-checked chat/game mutations exist. Broad public-room discovery remains blocked until report/block/ban support and the remaining moderation UX are implemented.

--- a/docs/QUEST_ROOM_ACCESS.md
+++ b/docs/QUEST_ROOM_ACCESS.md
@@ -1,0 +1,65 @@
+# Quest Room access modes
+
+Quest Rooms use three intentionally different access models. The browser UI mirrors these rules, but the FastAPI permission layer is the security boundary.
+
+## Public
+
+Public rooms are open to any signed-in learner who has the shared room link or room number.
+
+- `GET /rooms/{id}` may return an open public room summary before membership.
+- `POST /rooms/{id}/join` creates or restores normal public membership.
+- A host may remove a member; a removed member cannot self-rejoin.
+- Broad public-room directory/discovery remains deferred until the moderation workstream is ready.
+
+## Invite only
+
+Invite-only rooms are hidden from non-members and use explicit high-entropy capabilities for admission.
+
+- Generic room-id reads and joins return `404` to non-members.
+- Only the host can issue invite links.
+- Invite tokens expire after a host-selected lifetime of 1–168 hours; the UI offers 24 hours, 3 days, and 7 days.
+- The raw token is returned exactly once when an invite is created.
+- PostgreSQL stores only the SHA-256 token hash plus metadata.
+- Host invite listings expose expiry, usage, and revocation state but never the raw token or token hash.
+- A token can be reused by a study group until it expires or is revoked.
+- Revoking an invite blocks future admissions immediately; it does not eject people who already became members.
+- A member marked `removed` cannot use an otherwise-valid invite to restore themselves.
+
+The browser invite route accepts `/rooms/invite?token=...`, stores the capability in `sessionStorage`, and immediately replaces the visible URL with `/rooms/invite`. This keeps the shareable link practical while reducing token exposure in browser history and screenshots. After sign-in, the stored capability is exchanged for durable room membership and then removed from session storage.
+
+## Private
+
+Private rooms do not use generic join links.
+
+- Generic room-id reads and joins return `404` to non-members.
+- The host explicitly adds an existing verified FlashQuest account by email.
+- The admitted account receives normal durable room membership and can then open the room directly.
+- An explicit host add may restore a previously removed account; this is treated as a new host decision rather than self-service re-entry.
+
+## Member removal and live revocation
+
+Membership is durable PostgreSQL state, but removal also has to affect an already-open WebSocket.
+
+When a host removes a member:
+
+1. The membership row becomes `removed`.
+2. Every live socket for that room/user is detached and closed with code `4403`.
+3. Remaining room participants receive updated presence.
+4. The removed browser returns to the Rooms hub.
+5. New WebSocket tickets, chat, Arcade mutations, room history, and hidden-room reads are denied until the host explicitly restores membership where allowed.
+
+This prevents the common failure mode where a user is removed in the database but keeps receiving realtime room events until they manually disconnect.
+
+## Invite lifecycle and auditing
+
+`RoomInvite` stores:
+
+- room id
+- issuing host id
+- token hash
+- creation and expiration timestamps
+- optional revocation timestamp
+- use count
+- last-used timestamp
+
+The invite is an admission capability, not a login session. Account authentication is still required before the capability can create room membership.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Login from "./pages/Login";
 import MyDecks from "./pages/MyDecks";
 import Preferences from "./pages/Preferences";
 import Room from "./pages/Room";
+import RoomInvite from "./pages/RoomInvite";
 import Rooms from "./pages/Rooms";
 import Signup from "./pages/Signup";
 import Status from "./pages/Status";
@@ -84,6 +85,7 @@ function Shell() {
           <Route path="/library" element={<Library />} />
           <Route path="/library/:slug" element={<LibraryDeck />} />
           <Route path="/rooms" element={<Rooms />} />
+          <Route path="/rooms/invite" element={<RoomInvite />} />
           <Route path="/rooms/:roomId" element={<Room />} />
           <Route path="/deck-lab" element={<Admin />} />
           <Route path="/admin" element={<Navigate to="/deck-lab" replace />} />

--- a/frontend/src/components/RoomAccessPanel.tsx
+++ b/frontend/src/components/RoomAccessPanel.tsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useState } from "react";
+import type { FormEvent } from "react";
+
+import {
+  addPrivateRoomMember,
+  createRoomInvite,
+  getRoomInvites,
+  getRoomMembers,
+  removeRoomMember,
+  revokeRoomInvite,
+  type RoomInviteRead,
+  type RoomMemberRead,
+  type RoomRead,
+} from "../roomApi";
+
+type Props = {
+  room: RoomRead;
+  currentUserId: number;
+  onMembershipChanged?: () => void;
+};
+
+function expiresLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown expiry";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function RoomAccessPanel({
+  room,
+  currentUserId,
+  onMembershipChanged,
+}: Props) {
+  const isHost = room.current_user_role === "host";
+  const [members, setMembers] = useState<RoomMemberRead[]>([]);
+  const [invites, setInvites] = useState<RoomInviteRead[]>([]);
+  const [email, setEmail] = useState("");
+  const [expiryHours, setExpiryHours] = useState(24);
+  const [freshInviteUrl, setFreshInviteUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const nextMembers = await getRoomMembers(room.id);
+      setMembers(nextMembers);
+      if (isHost && room.visibility === "invite_only") {
+        setInvites(await getRoomInvites(room.id));
+      } else {
+        setInvites([]);
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not load room access controls");
+    }
+  }, [isHost, room.id, room.visibility]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function addMember(event: FormEvent) {
+    event.preventDefault();
+    if (!email.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await addPrivateRoomMember(room.id, email.trim());
+      setEmail("");
+      await refresh();
+      onMembershipChanged?.();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not add that member");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function createInvite() {
+    setBusy(true);
+    setError(null);
+    try {
+      const issued = await createRoomInvite(room.id, expiryHours);
+      const url = `${window.location.origin}/rooms/invite?token=${encodeURIComponent(issued.token)}`;
+      setFreshInviteUrl(url);
+      setInvites((current) => [issued, ...current.filter((item) => item.id !== issued.id)]);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not create invite link");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyFreshInvite() {
+    if (!freshInviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(freshInviteUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setError("Could not copy the invite link on this device");
+    }
+  }
+
+  async function revoke(inviteId: number) {
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await revokeRoomInvite(room.id, inviteId);
+      setInvites((current) =>
+        current.map((item) => (item.id === inviteId ? updated : item))
+      );
+      if (freshInviteUrl) setFreshInviteUrl(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not revoke invite");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeMember(userId: number) {
+    setBusy(true);
+    setError(null);
+    try {
+      await removeRoomMember(room.id, userId);
+      await refresh();
+      onMembershipChanged?.();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not remove member");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="game-panel p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="metric-label">Room access</p>
+          <h3 className="mt-1 text-lg font-black text-white">
+            {room.visibility === "public"
+              ? "Public membership"
+              : room.visibility === "invite_only"
+                ? "Invite-only membership"
+                : "Private membership"}
+          </h3>
+        </div>
+        <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">
+          {members.length} member{members.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {error && (
+        <p className="mt-3 rounded-xl border border-rose-400/25 bg-rose-500/10 p-3 text-xs leading-5 text-rose-200">
+          🛡️ {error}
+        </p>
+      )}
+
+      {isHost && room.status === "open" && room.visibility === "invite_only" && (
+        <div className="mt-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.05] p-4">
+          <p className="text-sm font-black text-white">✉️ Share an expiring invite</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            The secret token is shown only when the invite is created. If you lose the link, create a new one.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <select
+              className="game-input max-w-44"
+              aria-label="Invite lifetime"
+              value={expiryHours}
+              onChange={(event) => setExpiryHours(Number(event.target.value))}
+            >
+              <option value={24}>24 hours</option>
+              <option value={72}>3 days</option>
+              <option value={168}>7 days</option>
+            </select>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void createInvite()}
+              className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]"
+            >
+              Create invite link
+            </button>
+          </div>
+          {freshInviteUrl && (
+            <div className="mt-3 rounded-xl border border-emerald-300/20 bg-emerald-300/[0.06] p-3">
+              <p className="break-all text-xs leading-5 text-emerald-100">{freshInviteUrl}</p>
+              <button
+                type="button"
+                onClick={() => void copyFreshInvite()}
+                className="game-button mt-2 border border-emerald-300/20 px-3 py-1.5 text-xs font-black text-emerald-100"
+              >
+                {copied ? "✅ Copied" : "📋 Copy invite"}
+              </button>
+            </div>
+          )}
+          {invites.length > 0 && (
+            <div className="mt-4 space-y-2">
+              {invites.slice(0, 5).map((invite) => (
+                <div key={invite.id} className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/15 px-3 py-2">
+                  <div className="min-w-0 text-xs">
+                    <p className="font-black text-slate-200">
+                      Invite #{invite.id} · {invite.active ? "active" : "inactive"}
+                    </p>
+                    <p className="mt-0.5 text-slate-500">
+                      Expires {expiresLabel(invite.expires_at)} · {invite.use_count} use{invite.use_count === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                  {invite.active && (
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void revoke(invite.id)}
+                      className="game-button border border-rose-400/20 px-2.5 py-1.5 text-xs font-black text-rose-200"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {isHost && room.status === "open" && room.visibility === "private" && (
+        <form className="mt-4 rounded-2xl border border-cyan-300/15 bg-cyan-300/[0.04] p-4" onSubmit={addMember}>
+          <p className="text-sm font-black text-white">🔐 Add a verified account</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">
+            Private rooms do not accept generic links. The host explicitly admits an existing FlashQuest account.
+          </p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+            <label htmlFor="private-member-email" className="sr-only">Member email</label>
+            <input
+              id="private-member-email"
+              className="game-input"
+              type="email"
+              autoComplete="off"
+              placeholder="friend@example.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+            <button
+              type="submit"
+              disabled={busy || !email.trim()}
+              className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]"
+            >
+              Add member
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="mt-4 space-y-2">
+        {members.map((member) => (
+          <div key={member.id} className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/15 px-3 py-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-bold text-slate-200">
+                {member.user_id === currentUserId ? "You" : member.display_name ?? `Player #${member.user_id}`}
+              </p>
+              <p className="mt-0.5 text-xs capitalize text-slate-500">{member.role}</p>
+            </div>
+            {isHost && member.role !== "host" && room.status === "open" && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void removeMember(member.user_id)}
+                className="game-button border border-rose-400/20 px-2.5 py-1.5 text-xs font-black text-rose-200"
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {room.visibility === "public" && (
+        <p className="mt-3 text-xs leading-5 text-slate-500">
+          🌐 Any signed-in learner with the shared room link/number can join while this room is open.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import RoomAccessPanel from "../components/RoomAccessPanel";
 import RoomArcadePanel, {
   type RoomActivitySnapshot,
 } from "../components/RoomArcadePanel";
@@ -200,17 +201,20 @@ export default function Room() {
           setError("Realtime connection hit a network error");
         }
       };
-      socket.onclose = () => {
+      socket.onclose = (closeEvent) => {
         if (socketRef.current === socket) {
           socketRef.current = null;
           setConnection("offline");
+          if (closeEvent.code === 4403) {
+            navigate("/rooms", { replace: true });
+          }
         }
       };
     } catch (cause) {
       setConnection("offline");
       setError(cause instanceof Error ? cause.message : "Could not connect to realtime room");
     }
-  }, [handleRealtimeEvent, room, roomId, user]);
+  }, [handleRealtimeEvent, navigate, room, roomId, user]);
 
   useEffect(() => {
     if (room?.current_user_role && room.status === "open") {
@@ -350,9 +354,11 @@ export default function Room() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <button type="button" onClick={() => void copyRoomLink()} className="game-button game-chip px-3 py-2 text-xs font-black text-slate-200">
-              {copied ? "✅ Copied" : "🔗 Copy room link"}
-            </button>
+            {room.visibility === "public" && (
+              <button type="button" onClick={() => void copyRoomLink()} className="game-button game-chip px-3 py-2 text-xs font-black text-slate-200">
+                {copied ? "✅ Copied" : "🔗 Copy public room link"}
+              </button>
+            )}
             <Link to={`/study?deck=${room.deck_id}`} className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white">
               ⚡ Study deck
             </Link>
@@ -374,7 +380,7 @@ export default function Room() {
           <div className="text-4xl">🚪</div>
           <h2 className="mt-3 text-2xl font-black text-white">You found a public Quest Room</h2>
           <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-400">
-            Join to receive live presence and chat. Membership is persistent; disconnecting your browser does not create or remove membership rows.
+            Join to receive live presence, chat, and room Arcade. Membership is persistent; disconnecting your browser does not create or remove membership rows.
           </p>
           <button
             type="button"
@@ -398,7 +404,7 @@ export default function Room() {
             onSend={sendRoomEvent}
           />
 
-          <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
             <div className="game-panel flex min-h-[520px] flex-col overflow-hidden">
               <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
                 <div>
@@ -479,6 +485,12 @@ export default function Room() {
                 </div>
               </section>
 
+              <RoomAccessPanel
+                room={room}
+                currentUserId={user.id}
+                onMembershipChanged={() => void loadRoom()}
+              />
+
               <section className="game-panel p-4">
                 <p className="metric-label">Room controls</p>
                 <p className="mt-2 text-sm text-slate-400">Role: <strong className="text-slate-200">{room.current_user_role}</strong></p>
@@ -504,7 +516,7 @@ export default function Room() {
               </section>
 
               <p className="px-2 text-xs leading-5 text-slate-600">
-                Presence and active Arcade runtime are realtime process state; membership and messages stay durable in PostgreSQL.
+                Presence and active Arcade runtime are realtime process state; room membership, invites, and messages stay durable in PostgreSQL.
               </p>
             </aside>
           </section>

--- a/frontend/src/pages/RoomInvite.tsx
+++ b/frontend/src/pages/RoomInvite.tsx
@@ -21,6 +21,7 @@ export default function RoomInvite() {
   const location = useLocation();
   const navigate = useNavigate();
   const [token] = useState(() => initialInviteToken(location.search));
+  const [attempt, setAttempt] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [joining, setJoining] = useState(false);
 
@@ -36,7 +37,7 @@ export default function RoomInvite() {
   }, [location.search, navigate]);
 
   useEffect(() => {
-    if (!user || !token || joining) return;
+    if (!user || !token) return;
     let cancelled = false;
     setJoining(true);
     setError(null);
@@ -59,7 +60,7 @@ export default function RoomInvite() {
     return () => {
       cancelled = true;
     };
-  }, [joining, navigate, token, user]);
+  }, [attempt, navigate, token, user]);
 
   if (!token) {
     return (
@@ -112,7 +113,8 @@ export default function RoomInvite() {
           <button
             type="button"
             className="game-button bg-[#ffba08] px-4 py-2 font-black text-[#370617]"
-            onClick={() => setJoining(false)}
+            disabled={joining}
+            onClick={() => setAttempt((value) => value + 1)}
           >
             Try again
           </button>

--- a/frontend/src/pages/RoomInvite.tsx
+++ b/frontend/src/pages/RoomInvite.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+
+import { useAuth } from "../auth";
+import { joinRoomByInvite } from "../roomApi";
+
+const INVITE_SESSION_KEY = "flashquest-room-invite";
+
+function initialInviteToken(search: string): string {
+  const fromUrl = new URLSearchParams(search).get("token")?.trim() ?? "";
+  if (fromUrl) return fromUrl;
+  try {
+    return window.sessionStorage.getItem(INVITE_SESSION_KEY)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export default function RoomInvite() {
+  const { user } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [token] = useState(() => initialInviteToken(location.search));
+  const [error, setError] = useState<string | null>(null);
+  const [joining, setJoining] = useState(false);
+
+  useEffect(() => {
+    const fromUrl = new URLSearchParams(location.search).get("token")?.trim() ?? "";
+    if (!fromUrl) return;
+    try {
+      window.sessionStorage.setItem(INVITE_SESSION_KEY, fromUrl);
+    } catch {
+      // The in-memory state still carries this navigation's token.
+    }
+    navigate("/rooms/invite", { replace: true });
+  }, [location.search, navigate]);
+
+  useEffect(() => {
+    if (!user || !token || joining) return;
+    let cancelled = false;
+    setJoining(true);
+    setError(null);
+    void joinRoomByInvite(token)
+      .then((room) => {
+        if (cancelled) return;
+        try {
+          window.sessionStorage.removeItem(INVITE_SESSION_KEY);
+        } catch {
+          // No-op: joining already succeeded.
+        }
+        navigate(`/rooms/${room.id}`, { replace: true });
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : "Could not use this invite");
+          setJoining(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [joining, navigate, token, user]);
+
+  if (!token) {
+    return (
+      <section className="game-panel mx-auto max-w-xl p-8 text-center">
+        <div className="text-5xl" aria-hidden="true">🧭</div>
+        <h1 className="mt-4 text-2xl font-black text-white">Invite link missing</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-400">
+          Open the full Quest Room invite link your host shared with you.
+        </p>
+        <Link to="/rooms" className="game-button mt-6 inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]">
+          Quest Rooms
+        </Link>
+      </section>
+    );
+  }
+
+  if (!user) {
+    return (
+      <section className="quest-card mx-auto max-w-2xl p-8 text-center">
+        <div className="relative z-10">
+          <div className="text-5xl" aria-hidden="true">✉️</div>
+          <p className="metric-label mt-4">Quest Room invite</p>
+          <h1 className="mt-2 text-3xl font-black text-white">You’ve been invited to study.</h1>
+          <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-400">
+            Sign in first. FlashQuest has temporarily kept this invite in this browser session and removed the secret token from the visible URL.
+          </p>
+          <Link
+            to="/login"
+            state={{ from: "/rooms/invite" }}
+            className="game-button mt-6 inline-flex bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          >
+            Sign in and join →
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="game-panel mx-auto max-w-xl p-8 text-center">
+      <div className="text-5xl" aria-hidden="true">{error ? "🛡️" : "🚪"}</div>
+      <h1 className="mt-4 text-2xl font-black text-white">
+        {error ? "Invite unavailable" : "Joining Quest Room…"}
+      </h1>
+      <p className={`mt-3 text-sm leading-6 ${error ? "text-rose-200" : "text-slate-400"}`}>
+        {error ?? "Validating the invite and creating your room membership."}
+      </p>
+      {error && (
+        <div className="mt-6 flex flex-wrap justify-center gap-2">
+          <button
+            type="button"
+            className="game-button bg-[#ffba08] px-4 py-2 font-black text-[#370617]"
+            onClick={() => setJoining(false)}
+          >
+            Try again
+          </button>
+          <Link to="/rooms" className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 font-black text-white">
+            Quest Rooms
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -158,7 +158,7 @@ export default function Rooms() {
           Study together. <span className="ember-text">Same deck, same room.</span>
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
-          Rooms are deck-linked spaces for live chat and presence. Public rooms are joinable by shared link or room number; FlashQuest is not publishing a global room directory yet.
+          Rooms are deck-linked spaces for live chat, presence, and multiplayer Arcade. Public rooms use a shared room link/number; invite-only rooms use expiring secret links; private rooms admit specific accounts.
         </p>
       </section>
 
@@ -210,12 +210,19 @@ export default function Rooms() {
             value={visibility}
             onChange={(event) => setVisibility(event.target.value as RoomVisibility)}
           >
-            <option value="private">Private · host only for now</option>
-            <option value="invite_only">Invite only · invite UX arrives next</option>
+            <option value="private">Private · host adds specific accounts</option>
+            <option value="invite_only">Invite only · share an expiring secret link</option>
             <option value="public" disabled={!canPublic}>
               Public by link/ID · signed-in learners can join
             </option>
           </select>
+          <p className="mt-2 text-xs leading-5 text-slate-500">
+            {visibility === "private"
+              ? "After creation, add verified FlashQuest accounts by email from the room's access controls."
+              : visibility === "invite_only"
+                ? "After creation, generate a 24-hour, 3-day, or 7-day invite link. You can revoke it whenever you want."
+                : "Public rooms remain link/ID based until broad room discovery ships with moderation controls."}
+          </p>
           {!canPublic && selectedDeck && (
             <p className="mt-2 text-xs leading-5 text-slate-500">
               This deck is {selectedDeck.visibility}; FlashQuest will not widen it through a public room.
@@ -232,13 +239,13 @@ export default function Rooms() {
         </form>
 
         <form className="game-panel p-5 sm:p-6" onSubmit={submitJoin}>
-          <p className="metric-label">Join a shared room</p>
+          <p className="metric-label">Join a public room</p>
           <h2 className="mt-2 text-2xl font-black text-white">Got a room number?</h2>
           <p className="mt-3 text-sm leading-6 text-slate-400">
-            Public rooms are intentionally link/ID based in this phase. Private and invite-only rooms do not become enumerable just because you know a nearby number.
+            This box is only for public rooms. Invite-only links go through their secret invite URL, and private rooms require the host to add your account first.
           </p>
           <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="join-room-id">
-            Room number
+            Public room number
           </label>
           <input
             id="join-room-id"
@@ -253,7 +260,7 @@ export default function Rooms() {
             disabled={loading || !joinId}
             className="game-button mt-5 border border-[#faa307]/30 bg-[#370617]/70 px-5 py-3 font-black text-[#ffba08]"
           >
-            🔗 Open shared room
+            🔗 Open public room
           </button>
         </form>
       </section>
@@ -271,7 +278,7 @@ export default function Rooms() {
 
         {rooms.length === 0 ? (
           <div className="game-panel mt-4 p-7 text-center text-slate-400">
-            No rooms yet. Create one above, or open a room number somebody shared with you.
+            No rooms yet. Create one above, join a public room, or open an invite link somebody shared with you.
           </div>
         ) : (
           <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/roomApi.ts
+++ b/frontend/src/roomApi.ts
@@ -25,6 +25,23 @@ export interface RoomMemberRead {
   status: "active" | "left" | "removed";
   joined_at: string;
   last_seen_at: string;
+  display_name: string | null;
+}
+
+export interface RoomInviteRead {
+  id: number;
+  room_id: number;
+  created_by_user_id: number;
+  expires_at: string;
+  created_at: string;
+  revoked_at: string | null;
+  use_count: number;
+  last_used_at: string | null;
+  active: boolean;
+}
+
+export interface RoomInviteIssued extends RoomInviteRead {
+  token: string;
 }
 
 export interface RoomMessageRead {
@@ -52,6 +69,11 @@ export type RoomRealtimeEvent = {
 };
 
 function normalizeRoomError(error: unknown): Error {
+  if (error && typeof error === "object" && "response" in error) {
+    const response = (error as { response?: { data?: { detail?: unknown } } }).response;
+    const detail = response?.data?.detail;
+    if (typeof detail === "string" && detail.trim()) return new Error(detail);
+  }
   if (error instanceof Error) return error;
   return new Error("Quest Room request failed");
 }
@@ -96,6 +118,15 @@ export async function joinRoom(roomId: number): Promise<RoomRead> {
   }
 }
 
+export async function joinRoomByInvite(token: string): Promise<RoomRead> {
+  try {
+    const { data } = await api.post<RoomRead>("/rooms/invites/join", { token });
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
 export async function leaveRoom(roomId: number): Promise<RoomRead> {
   try {
     const { data } = await api.post<RoomRead>(`/rooms/${roomId}/leave`);
@@ -117,6 +148,71 @@ export async function closeRoom(roomId: number): Promise<RoomRead> {
 export async function getRoomMembers(roomId: number): Promise<RoomMemberRead[]> {
   try {
     const { data } = await api.get<RoomMemberRead[]>(`/rooms/${roomId}/members`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function addPrivateRoomMember(
+  roomId: number,
+  email: string
+): Promise<RoomMemberRead> {
+  try {
+    const { data } = await api.post<RoomMemberRead>(`/rooms/${roomId}/members/add`, {
+      email,
+    });
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function removeRoomMember(
+  roomId: number,
+  userId: number
+): Promise<RoomMemberRead> {
+  try {
+    const { data } = await api.post<RoomMemberRead>(
+      `/rooms/${roomId}/members/${userId}/remove`
+    );
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function createRoomInvite(
+  roomId: number,
+  expiresInHours = 24
+): Promise<RoomInviteIssued> {
+  try {
+    const { data } = await api.post<RoomInviteIssued>(`/rooms/${roomId}/invites`, {
+      expires_in_hours: expiresInHours,
+    });
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function getRoomInvites(roomId: number): Promise<RoomInviteRead[]> {
+  try {
+    const { data } = await api.get<RoomInviteRead[]>(`/rooms/${roomId}/invites`);
+    return data;
+  } catch (error) {
+    throw normalizeRoomError(error);
+  }
+}
+
+export async function revokeRoomInvite(
+  roomId: number,
+  inviteId: number
+): Promise<RoomInviteRead> {
+  try {
+    const { data } = await api.post<RoomInviteRead>(
+      `/rooms/${roomId}/invites/${inviteId}/revoke`
+    );
     return data;
   } catch (error) {
     throw normalizeRoomError(error);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Product:
       - Make Your Own Deck: MAKE_YOUR_OWN_DECK.md
       - Accounts & Email Verification: AUTHENTICATION.md
+      - Quest Room Access: QUEST_ROOM_ACCESS.md
   - Featured Platform Engineering:
       - Curriculum: CURRICULUM.md
       - Break/Fix Labs: LABS.md


### PR DESCRIPTION
## What changed

Completes #18 with distinct, server-enforced access semantics for public, invite-only, and private Quest Rooms.

### Three real access modes
- **Public:** any signed-in learner with the shared room link/number can join while the room is open.
- **Invite only:** hidden from non-members; admission requires a valid expiring/revocable secret invite capability.
- **Private:** hidden from non-members; the host explicitly adds an existing verified FlashQuest account by email.
- Generic reads and room-number joins return `404` for private/invite-only rooms, so hidden room ids are not an enumeration surface.

### Persistent invite capabilities
- Adds `RoomInvite` plus Alembic revision `f1d2a5b6c7e8` after the Quest Room schema head.
- Invite tokens are high entropy; PostgreSQL stores only SHA-256 hashes.
- Raw tokens are returned exactly once at creation and never appear in invite listings.
- Host chooses a bounded 1–168 hour lifetime; UI offers 24 hours, 3 days, and 7 days.
- Invites track creation/expiry/revocation, use count, and last-used time.
- Revoked or expired invites stop admitting new members immediately.
- Invite links are reusable for a study group until expiry/revocation.
- Removed members cannot use an otherwise-valid invite to self-restore.

### Private-room admission
- Host may add an existing verified account by email.
- Direct adds are private-room-only.
- Explicit host admission may restore a previously removed account; that is treated as a fresh host decision rather than self-service re-entry.

### Live removal, not eventual removal
- Host member removal persists `removed` state **and** immediately detaches/closes every live room socket for that user with WebSocket code `4403`.
- Remaining room participants receive updated presence.
- Removed users cannot obtain new WS tickets, read hidden-room state/history, chat, or mutate Arcade state.
- The browser returns a kicked learner to the Rooms hub instead of leaving a stale reconnectable room screen.

### Frontend
- Adds `/rooms/invite` invite-admission flow.
- The shareable URL may contain `?token=...`, but FlashQuest immediately stores it in `sessionStorage` and replaces the visible URL before sign-in/join to reduce token exposure in history/screenshots.
- Adds a Room Access panel inside the live room:
  - invite-only hosts create/copy/revoke expiring links and see invite usage metadata;
  - private hosts add verified accounts by email;
  - members are listed by display name/role;
  - hosts can remove non-host members in every room mode.
- Room creation copy now explains the three access models accurately.
- Generic room-number join UI is explicitly public-only.

### Tests
Covers:
- raw invite token returned only when issued and hashed at rest
- invite listings never exposing token/token hash
- reusable group invite admission
- revoked invite denial
- expired invite denial
- private explicit account admission
- unverified private-account denial
- invite creation limited to invite-only rooms
- hidden GET **and generic join** non-enumerability
- host-only invite/removal controls
- live WebSocket kick on removal + updated presence
- removed member unable to obtain a new realtime ticket

### Docs
- Adds `QUEST_ROOM_ACCESS.md` as the product/security contract.
- Updates Quest Room architecture and MkDocs navigation.
- Broad public-room directory/discovery remains intentionally deferred to the moderation workstream; public rooms remain shared-link/ID based in this phase.

Closes #18