### PR TITLE
Add Quest Room reporting, blocking, and moderation review

### DIFF
--- a/backend/alembic/versions/g2e3b6c7d8f9_add_room_moderation.py
+++ b/backend/alembic/versions/g2e3b6c7d8f9_add_room_moderation.py
@@ -1,0 +1,139 @@
+"""add quest room moderation
+
+Revision ID: g2e3b6c7d8f9
+Revises: f1d2a5b6c7e8
+Create Date: 2026-08-19
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "g2e3b6c7d8f9"
+down_revision: Union[str, Sequence[str], None] = "f1d2a5b6c7e8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_block",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("blocker_user_id", sa.Integer(), nullable=False),
+        sa.Column("blocked_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("blocker_user_id <> blocked_user_id", name="ck_user_block_not_self"),
+        sa.ForeignKeyConstraint(["blocked_user_id"], ["app_user.id"]),
+        sa.ForeignKeyConstraint(["blocker_user_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("blocker_user_id", "blocked_user_id", name="uq_user_block_pair"),
+    )
+    op.create_index(op.f("ix_user_block_blocker_user_id"), "user_block", ["blocker_user_id"], unique=False)
+    op.create_index(op.f("ix_user_block_blocked_user_id"), "user_block", ["blocked_user_id"], unique=False)
+
+    op.create_table(
+        "moderation_report",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("reporter_user_id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("message_id", sa.Integer(), nullable=True),
+        sa.Column("target_user_id", sa.Integer(), nullable=True),
+        sa.Column("reason", sa.String(), nullable=False),
+        sa.Column("details", sa.Text(), nullable=False),
+        sa.Column("room_name_snapshot", sa.String(), nullable=False),
+        sa.Column("message_body_snapshot", sa.Text(), nullable=True),
+        sa.Column("message_author_user_id", sa.Integer(), nullable=True),
+        sa.Column("target_display_name_snapshot", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("review_note", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "kind IN ('room', 'message', 'user')",
+            name="ck_moderation_report_kind",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'reviewed', 'dismissed', 'actioned')",
+            name="ck_moderation_report_status",
+        ),
+        sa.ForeignKeyConstraint(["message_id"], ["room_message.id"]),
+        sa.ForeignKeyConstraint(["reporter_user_id"], ["app_user.id"]),
+        sa.ForeignKeyConstraint(["reviewed_by_user_id"], ["app_user.id"]),
+        sa.ForeignKeyConstraint(["room_id"], ["study_room.id"]),
+        sa.ForeignKeyConstraint(["target_user_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    for column in (
+        "reporter_user_id",
+        "room_id",
+        "kind",
+        "message_id",
+        "target_user_id",
+        "status",
+        "created_at",
+        "reviewed_by_user_id",
+    ):
+        op.create_index(op.f(f"ix_moderation_report_{column}"), "moderation_report", [column], unique=False)
+
+    op.create_table(
+        "moderation_audit",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("actor_user_id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=True),
+        sa.Column("target_user_id", sa.Integer(), nullable=True),
+        sa.Column("report_id", sa.Integer(), nullable=True),
+        sa.Column("detail", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "action IN ('member_removed', 'report_reviewed', 'report_dismissed', 'report_actioned')",
+            name="ck_moderation_audit_action",
+        ),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["app_user.id"]),
+        sa.ForeignKeyConstraint(["report_id"], ["moderation_report.id"]),
+        sa.ForeignKeyConstraint(["room_id"], ["study_room.id"]),
+        sa.ForeignKeyConstraint(["target_user_id"], ["app_user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    for column in (
+        "action",
+        "actor_user_id",
+        "room_id",
+        "target_user_id",
+        "report_id",
+        "created_at",
+    ):
+        op.create_index(op.f(f"ix_moderation_audit_{column}"), "moderation_audit", [column], unique=False)
+
+
+def downgrade() -> None:
+    for column in (
+        "created_at",
+        "report_id",
+        "target_user_id",
+        "room_id",
+        "actor_user_id",
+        "action",
+    ):
+        op.drop_index(op.f(f"ix_moderation_audit_{column}"), table_name="moderation_audit")
+    op.drop_table("moderation_audit")
+
+    for column in (
+        "reviewed_by_user_id",
+        "created_at",
+        "status",
+        "target_user_id",
+        "message_id",
+        "kind",
+        "room_id",
+        "reporter_user_id",
+    ):
+        op.drop_index(op.f(f"ix_moderation_report_{column}"), table_name="moderation_report")
+    op.drop_table("moderation_report")
+
+    op.drop_index(op.f("ix_user_block_blocked_user_id"), table_name="user_block")
+    op.drop_index(op.f("ix_user_block_blocker_user_id"), table_name="user_block")
+    op.drop_table("user_block")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
     VERIFICATION_TOKEN_MINUTES: int = 60
     FRONTEND_URL: str = "http://localhost:5173"
 
+    # Comma-separated account emails allowed to review moderation reports.
+    # This is a server-side privilege bootstrap, not a user-controlled role.
+    MODERATOR_EMAILS: str = ""
+
     # Server-side only. Built-in demo cards cannot be deleted/reset when blank.
     DEMO_DELETE_PASSWORD: str = ""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlmodel import Session
 
 from .config import settings
 from .db import get_session
-from .routers import activities, auth, cards, decks, room_realtime, rooms, study
+from .routers import activities, auth, cards, decks, moderation, room_realtime, rooms, study
 
 
 def _allowed_origins() -> list[str]:
@@ -76,6 +76,7 @@ app.include_router(study.router)
 app.include_router(activities.router)
 app.include_router(rooms.router)
 app.include_router(room_realtime.router)
+app.include_router(moderation.router)
 
 
 @app.get("/health")

--- a/backend/app/moderation_models.py
+++ b/backend/app/moderation_models.py
@@ -1,0 +1,166 @@
+"""Persistent moderation contracts for Quest Rooms.
+
+Reports snapshot enough context for later human review. Blocks are user-scoped
+visibility preferences. Audit rows record consequential moderation actions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+
+from .models import utc_now
+
+REPORT_KINDS = {"room", "message", "user"}
+REPORT_STATUSES = {"open", "reviewed", "dismissed", "actioned"}
+MODERATION_ACTIONS = {
+    "member_removed",
+    "report_reviewed",
+    "report_dismissed",
+    "report_actioned",
+}
+
+
+class UserBlock(SQLModel, table=True):
+    """One-way user block controlling the blocker's chat visibility."""
+
+    __tablename__ = "user_block"
+    __table_args__ = (
+        sa.UniqueConstraint("blocker_user_id", "blocked_user_id", name="uq_user_block_pair"),
+        sa.CheckConstraint(
+            "blocker_user_id <> blocked_user_id",
+            name="ck_user_block_not_self",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    blocker_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    blocked_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    created_at: datetime = Field(default_factory=utc_now, sa_type=sa.DateTime(timezone=True))
+
+
+class ModerationReport(SQLModel, table=True):
+    """User report with immutable snapshots needed for later review."""
+
+    __tablename__ = "moderation_report"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "kind IN ('room', 'message', 'user')",
+            name="ck_moderation_report_kind",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'reviewed', 'dismissed', 'actioned')",
+            name="ck_moderation_report_status",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    reporter_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    room_id: int = Field(foreign_key="study_room.id", index=True, sa_type=sa.Integer)
+    kind: str = Field(index=True, sa_type=sa.String)
+    message_id: Optional[int] = Field(
+        default=None, foreign_key="room_message.id", index=True, sa_type=sa.Integer
+    )
+    target_user_id: Optional[int] = Field(
+        default=None, foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    reason: str = Field(sa_type=sa.String)
+    details: str = Field(default="", sa_column=sa.Column(sa.Text(), nullable=False))
+    room_name_snapshot: str = Field(sa_type=sa.String)
+    message_body_snapshot: Optional[str] = Field(
+        default=None, sa_column=sa.Column(sa.Text(), nullable=True)
+    )
+    message_author_user_id: Optional[int] = Field(default=None, sa_type=sa.Integer)
+    target_display_name_snapshot: Optional[str] = Field(default=None, sa_type=sa.String)
+    status: str = Field(default="open", index=True, sa_type=sa.String)
+    created_at: datetime = Field(
+        default_factory=utc_now, index=True, sa_type=sa.DateTime(timezone=True)
+    )
+    reviewed_at: Optional[datetime] = Field(default=None, sa_type=sa.DateTime(timezone=True))
+    reviewed_by_user_id: Optional[int] = Field(
+        default=None, foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    review_note: str = Field(default="", sa_column=sa.Column(sa.Text(), nullable=False))
+
+
+class ModerationAudit(SQLModel, table=True):
+    """Append-only audit trail for host/moderator actions."""
+
+    __tablename__ = "moderation_audit"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "action IN ('member_removed', 'report_reviewed', 'report_dismissed', 'report_actioned')",
+            name="ck_moderation_audit_action",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    action: str = Field(index=True, sa_type=sa.String)
+    actor_user_id: int = Field(
+        foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    room_id: Optional[int] = Field(
+        default=None, foreign_key="study_room.id", index=True, sa_type=sa.Integer
+    )
+    target_user_id: Optional[int] = Field(
+        default=None, foreign_key="app_user.id", index=True, sa_type=sa.Integer
+    )
+    report_id: Optional[int] = Field(
+        default=None, foreign_key="moderation_report.id", index=True, sa_type=sa.Integer
+    )
+    detail: str = Field(default="", sa_column=sa.Column(sa.Text(), nullable=False))
+    created_at: datetime = Field(
+        default_factory=utc_now, index=True, sa_type=sa.DateTime(timezone=True)
+    )
+
+
+class ReportCreate(SQLModel):
+    kind: str
+    message_id: Optional[int] = None
+    target_user_id: Optional[int] = None
+    reason: str
+    details: str = ""
+
+
+class ReportRead(SQLModel):
+    id: int
+    reporter_user_id: int
+    room_id: int
+    kind: str
+    message_id: Optional[int] = None
+    target_user_id: Optional[int] = None
+    reason: str
+    details: str
+    room_name_snapshot: str
+    message_body_snapshot: Optional[str] = None
+    message_author_user_id: Optional[int] = None
+    target_display_name_snapshot: Optional[str] = None
+    status: str
+    created_at: datetime
+    reviewed_at: Optional[datetime] = None
+    reviewed_by_user_id: Optional[int] = None
+    review_note: str
+
+
+class ReportReview(SQLModel):
+    status: str
+    note: str = ""
+
+
+class BlockRead(SQLModel):
+    user_id: int
+    display_name: str
+    created_at: datetime
+
+
+class ModerationCapability(SQLModel):
+    moderator: bool

--- a/backend/app/room_realtime.py
+++ b/backend/app/room_realtime.py
@@ -143,12 +143,20 @@ class RoomConnectionManager:
         async with self._lock:
             return sorted(self._connections.get(room_id, {}).keys())
 
-    async def broadcast(self, room_id: int, event: dict[str, Any]) -> None:
-        """Broadcast best-effort to sockets attached to this process."""
+    async def broadcast(
+        self,
+        room_id: int,
+        event: dict[str, Any],
+        *,
+        exclude_user_ids: set[int] | None = None,
+    ) -> None:
+        """Broadcast best-effort, optionally filtering recipient user ids."""
+        excluded = exclude_user_ids or set()
         async with self._lock:
             sockets = [
                 socket
-                for user_sockets in self._connections.get(room_id, {}).values()
+                for user_id, user_sockets in self._connections.get(room_id, {}).items()
+                if user_id not in excluded
                 for socket in user_sockets
             ]
         for socket in sockets:

--- a/backend/app/routers/moderation.py
+++ b/backend/app/routers/moderation.py
@@ -1,0 +1,289 @@
+"""Quest Room moderation APIs: reports, blocks, and human review hooks."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlmodel import Session, delete, select
+
+from ..config import settings
+from ..db import get_session
+from ..models import User, utc_now
+from ..moderation_models import (
+    REPORT_KINDS,
+    REPORT_STATUSES,
+    BlockRead,
+    ModerationAudit,
+    ModerationCapability,
+    ModerationReport,
+    ReportCreate,
+    ReportRead,
+    ReportReview,
+    UserBlock,
+)
+from ..room_models import RoomMember, RoomMessage, StudyRoom
+from ..security import get_current_user
+from .rooms import _active_member, _room_or_404
+
+router = APIRouter(prefix="/moderation", tags=["moderation"])
+VALID_REVIEW_STATUSES = {"reviewed", "dismissed", "actioned"}
+
+
+def _moderator_emails() -> set[str]:
+    return {
+        value.strip().lower()
+        for value in (settings.MODERATOR_EMAILS or "").split(",")
+        if value.strip()
+    }
+
+
+def _is_moderator(user: User) -> bool:
+    return user.email.strip().lower() in _moderator_emails()
+
+
+def _require_moderator(user: User = Depends(get_current_user)) -> User:
+    if not _is_moderator(user):
+        raise HTTPException(status_code=403, detail="Moderator access required")
+    return user
+
+
+def _clean_text(value: str, *, field: str, max_length: int, required: bool) -> str:
+    cleaned = " ".join(value.strip().split())
+    if required and not cleaned:
+        raise HTTPException(status_code=422, detail=f"{field} is required")
+    if len(cleaned) > max_length:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{field} must be {max_length} characters or fewer",
+        )
+    return cleaned
+
+
+def _report_read(report: ModerationReport) -> ReportRead:
+    return ReportRead(**report.model_dump())
+
+
+def _shared_room_membership(session: Session, first: int, second: int) -> bool:
+    first_rooms = select(RoomMember.room_id).where(
+        RoomMember.user_id == first,
+        RoomMember.status == "active",
+    )
+    return (
+        session.exec(
+            select(RoomMember.id).where(
+                RoomMember.user_id == second,
+                RoomMember.status == "active",
+                RoomMember.room_id.in_(first_rooms),
+            )
+        ).first()
+        is not None
+    )
+
+
+@router.get("/capabilities", response_model=ModerationCapability)
+def moderation_capabilities(
+    user: User = Depends(get_current_user),
+) -> ModerationCapability:
+    return ModerationCapability(moderator=_is_moderator(user))
+
+
+@router.post("/rooms/{room_id}/reports", response_model=ReportRead, status_code=201)
+def create_report(
+    room_id: int,
+    payload: ReportCreate,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> ReportRead:
+    """Report a room, message, or user while snapshotting review context."""
+    room = _room_or_404(session, room_id)
+    reporter_id = int(user.id or 0)
+    if _active_member(session, room_id, reporter_id) is None:
+        raise HTTPException(status_code=403, detail="Active room membership required")
+
+    kind = payload.kind.strip().lower()
+    if kind not in REPORT_KINDS:
+        raise HTTPException(status_code=422, detail="Report kind must be room, message, or user")
+    reason = _clean_text(payload.reason, field="Reason", max_length=80, required=True)
+    details = _clean_text(payload.details, field="Details", max_length=1000, required=False)
+
+    message: RoomMessage | None = None
+    target: User | None = None
+    target_user_id = payload.target_user_id
+
+    if kind == "message":
+        if payload.message_id is None:
+            raise HTTPException(status_code=422, detail="Message report requires message_id")
+        message = session.get(RoomMessage, payload.message_id)
+        if message is None or message.room_id != room_id:
+            raise HTTPException(status_code=404, detail="Message not found")
+        target_user_id = message.user_id
+    elif kind == "user":
+        if target_user_id is None:
+            raise HTTPException(status_code=422, detail="User report requires target_user_id")
+        if target_user_id == reporter_id:
+            raise HTTPException(status_code=422, detail="You cannot report yourself")
+        if _active_member(session, room_id, target_user_id) is None:
+            raise HTTPException(status_code=404, detail="Room member not found")
+    else:
+        if payload.message_id is not None or target_user_id is not None:
+            raise HTTPException(status_code=422, detail="Room reports do not take a message or user target")
+
+    if target_user_id is not None:
+        target = session.get(User, target_user_id)
+        if target is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+    report = ModerationReport(
+        reporter_user_id=reporter_id,
+        room_id=room_id,
+        kind=kind,
+        message_id=int(message.id or 0) if message is not None else None,
+        target_user_id=target_user_id,
+        reason=reason,
+        details=details,
+        room_name_snapshot=room.name,
+        message_body_snapshot=message.body if message is not None else None,
+        message_author_user_id=message.user_id if message is not None else None,
+        target_display_name_snapshot=target.display_name if target is not None else None,
+        status="open",
+    )
+    session.add(report)
+    session.commit()
+    session.refresh(report)
+    return _report_read(report)
+
+
+@router.get("/reports/mine", response_model=list[ReportRead])
+def my_reports(
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[ReportRead]:
+    rows = session.exec(
+        select(ModerationReport)
+        .where(ModerationReport.reporter_user_id == int(user.id or 0))
+        .order_by(ModerationReport.created_at.desc())
+    ).all()
+    return [_report_read(row) for row in rows]
+
+
+@router.get("/reports", response_model=list[ReportRead])
+def review_queue(
+    status: str = Query("open"),
+    _moderator: User = Depends(_require_moderator),
+    session: Session = Depends(get_session),
+) -> list[ReportRead]:
+    normalized = status.strip().lower()
+    if normalized not in REPORT_STATUSES:
+        raise HTTPException(status_code=422, detail="Invalid report status")
+    rows = session.exec(
+        select(ModerationReport)
+        .where(ModerationReport.status == normalized)
+        .order_by(ModerationReport.created_at.asc())
+        .limit(200)
+    ).all()
+    return [_report_read(row) for row in rows]
+
+
+@router.post("/reports/{report_id}/review", response_model=ReportRead)
+def review_report(
+    report_id: int,
+    payload: ReportReview,
+    moderator: User = Depends(_require_moderator),
+    session: Session = Depends(get_session),
+) -> ReportRead:
+    report = session.get(ModerationReport, report_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    status = payload.status.strip().lower()
+    if status not in VALID_REVIEW_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail="Review status must be reviewed, dismissed, or actioned",
+        )
+    note = _clean_text(payload.note, field="Review note", max_length=1000, required=False)
+    now = utc_now()
+    report.status = status
+    report.reviewed_at = now
+    report.reviewed_by_user_id = int(moderator.id or 0)
+    report.review_note = note
+    session.add(report)
+    session.add(
+        ModerationAudit(
+            action=f"report_{status}",
+            actor_user_id=int(moderator.id or 0),
+            room_id=report.room_id,
+            target_user_id=report.target_user_id,
+            report_id=int(report.id or 0),
+            detail=note,
+        )
+    )
+    session.commit()
+    session.refresh(report)
+    return _report_read(report)
+
+
+@router.post("/blocks/{target_user_id}", response_model=BlockRead, status_code=201)
+def block_user(
+    target_user_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> BlockRead:
+    blocker_id = int(user.id or 0)
+    if target_user_id == blocker_id:
+        raise HTTPException(status_code=422, detail="You cannot block yourself")
+    target = session.get(User, target_user_id)
+    if target is None or not _shared_room_membership(session, blocker_id, target_user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    existing = session.exec(
+        select(UserBlock).where(
+            UserBlock.blocker_user_id == blocker_id,
+            UserBlock.blocked_user_id == target_user_id,
+        )
+    ).first()
+    if existing is None:
+        existing = UserBlock(blocker_user_id=blocker_id, blocked_user_id=target_user_id)
+        session.add(existing)
+        session.commit()
+        session.refresh(existing)
+    return BlockRead(
+        user_id=target_user_id,
+        display_name=target.display_name,
+        created_at=existing.created_at,
+    )
+
+
+@router.delete("/blocks/{target_user_id}", status_code=204)
+def unblock_user(
+    target_user_id: int,
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> None:
+    session.exec(
+        delete(UserBlock).where(
+            UserBlock.blocker_user_id == int(user.id or 0),
+            UserBlock.blocked_user_id == target_user_id,
+        )
+    )
+    session.commit()
+
+
+@router.get("/blocks", response_model=list[BlockRead])
+def my_blocks(
+    user: User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+) -> list[BlockRead]:
+    rows = session.exec(
+        select(UserBlock).where(UserBlock.blocker_user_id == int(user.id or 0))
+    ).all()
+    result: list[BlockRead] = []
+    for row in rows:
+        target = session.get(User, row.blocked_user_id)
+        if target is not None:
+            result.append(
+                BlockRead(
+                    user_id=row.blocked_user_id,
+                    display_name=target.display_name,
+                    created_at=row.created_at,
+                )
+            )
+    return result

--- a/backend/tests/test_room_moderation.py
+++ b/backend/tests/test_room_moderation.py
@@ -1,0 +1,269 @@
+"""Quest Room moderation report, block, and human review coverage."""
+
+from sqlmodel import Session, select
+
+from app.config import settings
+from app.models import Deck, User
+from app.moderation_models import ModerationAudit, ModerationReport, UserBlock
+from app.room_models import RoomMessage
+from app.security import create_auth_session, hash_password
+
+
+def _user(session: Session, suffix: str) -> User:
+    user = User(
+        email=f"moderation-{suffix}@example.com",
+        display_name=f"Moderation {suffix.title()}",
+        password_hash=hash_password("strong-pass-123"),
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _headers(session: Session, user: User) -> dict[str, str]:
+    token = create_auth_session(session, int(user.id or 0))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _deck(session: Session, host: User, slug: str) -> Deck:
+    deck = Deck(
+        owner_id=host.id,
+        title=f"Moderation Deck {slug}",
+        slug=slug,
+        description="Moderation test deck",
+        is_builtin=False,
+        subject="Testing",
+        difficulty="beginner",
+        visibility="public",
+        tags=["moderation"],
+    )
+    session.add(deck)
+    session.commit()
+    session.refresh(deck)
+    return deck
+
+
+def _room(client, session: Session, host: User, slug: str) -> dict:
+    deck = _deck(session, host, slug)
+    response = client.post(
+        "/rooms",
+        headers=_headers(session, host),
+        json={
+            "deck_id": int(deck.id or 0),
+            "name": f"Moderation Room {slug}",
+            "visibility": "public",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _join(client, session: Session, room_id: int, user: User) -> None:
+    response = client.post(f"/rooms/{room_id}/join", headers=_headers(session, user))
+    assert response.status_code == 200
+
+
+def test_message_report_snapshots_context_for_later_review(client, sqlite_session: Session):
+    host = _user(sqlite_session, "report-host")
+    reporter = _user(sqlite_session, "reporter")
+    target = _user(sqlite_session, "report-target")
+    room = _room(client, sqlite_session, host, "report")
+    _join(client, sqlite_session, room["id"], reporter)
+    _join(client, sqlite_session, room["id"], target)
+
+    message = RoomMessage(
+        room_id=room["id"],
+        user_id=int(target.id or 0),
+        kind="chat",
+        body="Context that should survive later message removal",
+    )
+    sqlite_session.add(message)
+    sqlite_session.commit()
+    sqlite_session.refresh(message)
+
+    response = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=_headers(sqlite_session, reporter),
+        json={
+            "kind": "message",
+            "message_id": message.id,
+            "reason": "harassment",
+            "details": "Repeated unwanted comments",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["kind"] == "message"
+    assert payload["target_user_id"] == target.id
+    assert payload["message_author_user_id"] == target.id
+    assert payload["message_body_snapshot"] == message.body
+    assert payload["target_display_name_snapshot"] == target.display_name
+    assert payload["room_name_snapshot"] == room["name"]
+    assert payload["status"] == "open"
+
+
+def test_room_and_user_reports_validate_targets(client, sqlite_session: Session):
+    host = _user(sqlite_session, "target-host")
+    reporter = _user(sqlite_session, "target-reporter")
+    target = _user(sqlite_session, "target-member")
+    stranger = _user(sqlite_session, "target-stranger")
+    room = _room(client, sqlite_session, host, "targets")
+    _join(client, sqlite_session, room["id"], reporter)
+    _join(client, sqlite_session, room["id"], target)
+    headers = _headers(sqlite_session, reporter)
+
+    room_report = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=headers,
+        json={"kind": "room", "reason": "spam"},
+    )
+    assert room_report.status_code == 201
+    assert room_report.json()["target_user_id"] is None
+
+    user_report = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=headers,
+        json={
+            "kind": "user",
+            "target_user_id": target.id,
+            "reason": "abuse",
+        },
+    )
+    assert user_report.status_code == 201
+    assert user_report.json()["target_display_name_snapshot"] == target.display_name
+
+    outsider = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=headers,
+        json={
+            "kind": "user",
+            "target_user_id": stranger.id,
+            "reason": "abuse",
+        },
+    )
+    assert outsider.status_code == 404
+
+
+def test_non_member_cannot_report_hidden_room_context(client, sqlite_session: Session):
+    host = _user(sqlite_session, "nonmember-host")
+    outsider = _user(sqlite_session, "nonmember-outsider")
+    room = _room(client, sqlite_session, host, "nonmember")
+
+    response = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=_headers(sqlite_session, outsider),
+        json={"kind": "room", "reason": "spam"},
+    )
+    assert response.status_code == 403
+
+
+def test_block_requires_shared_room_and_is_idempotent(client, sqlite_session: Session):
+    host = _user(sqlite_session, "block-host")
+    blocker = _user(sqlite_session, "blocker")
+    target = _user(sqlite_session, "blocked")
+    stranger = _user(sqlite_session, "block-stranger")
+    room = _room(client, sqlite_session, host, "blocks")
+    _join(client, sqlite_session, room["id"], blocker)
+    _join(client, sqlite_session, room["id"], target)
+    headers = _headers(sqlite_session, blocker)
+
+    first = client.post(f"/moderation/blocks/{target.id}", headers=headers)
+    second = client.post(f"/moderation/blocks/{target.id}", headers=headers)
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["display_name"] == target.display_name
+
+    rows = sqlite_session.exec(
+        select(UserBlock).where(UserBlock.blocker_user_id == blocker.id)
+    ).all()
+    assert len(rows) == 1
+
+    denied = client.post(f"/moderation/blocks/{stranger.id}", headers=headers)
+    assert denied.status_code == 404
+
+    listed = client.get("/moderation/blocks", headers=headers)
+    assert listed.status_code == 200
+    assert [item["user_id"] for item in listed.json()] == [target.id]
+
+    unblocked = client.delete(f"/moderation/blocks/{target.id}", headers=headers)
+    assert unblocked.status_code == 204
+    assert client.get("/moderation/blocks", headers=headers).json() == []
+
+
+def test_moderator_queue_is_server_gated_and_review_is_audited(
+    client, sqlite_session: Session, monkeypatch
+):
+    host = _user(sqlite_session, "review-host")
+    reporter = _user(sqlite_session, "review-reporter")
+    moderator = _user(sqlite_session, "review-moderator")
+    room = _room(client, sqlite_session, host, "review")
+    _join(client, sqlite_session, room["id"], reporter)
+
+    created = client.post(
+        f"/moderation/rooms/{room['id']}/reports",
+        headers=_headers(sqlite_session, reporter),
+        json={"kind": "room", "reason": "spam", "details": "Automated link flood"},
+    ).json()
+
+    denied = client.get(
+        "/moderation/reports",
+        headers=_headers(sqlite_session, reporter),
+    )
+    assert denied.status_code == 403
+
+    monkeypatch.setattr(settings, "MODERATOR_EMAILS", moderator.email)
+    moderator_headers = _headers(sqlite_session, moderator)
+    capability = client.get("/moderation/capabilities", headers=moderator_headers)
+    assert capability.status_code == 200
+    assert capability.json()["moderator"] is True
+
+    queue = client.get("/moderation/reports", headers=moderator_headers)
+    assert queue.status_code == 200
+    assert [report["id"] for report in queue.json()] == [created["id"]]
+
+    reviewed = client.post(
+        f"/moderation/reports/{created['id']}/review",
+        headers=moderator_headers,
+        json={"status": "actioned", "note": "Reviewed and room host contacted"},
+    )
+    assert reviewed.status_code == 200
+    assert reviewed.json()["status"] == "actioned"
+    assert reviewed.json()["reviewed_by_user_id"] == moderator.id
+
+    report = sqlite_session.get(ModerationReport, created["id"])
+    assert report is not None
+    assert report.review_note == "Reviewed and room host contacted"
+
+    audit = sqlite_session.exec(
+        select(ModerationAudit).where(ModerationAudit.report_id == created["id"])
+    ).one()
+    assert audit.action == "report_actioned"
+    assert audit.actor_user_id == moderator.id
+    assert audit.room_id == room["id"]
+
+
+def test_my_reports_returns_only_current_reporter(client, sqlite_session: Session):
+    host = _user(sqlite_session, "mine-host")
+    first = _user(sqlite_session, "mine-first")
+    second = _user(sqlite_session, "mine-second")
+    room = _room(client, sqlite_session, host, "mine")
+    _join(client, sqlite_session, room["id"], first)
+    _join(client, sqlite_session, room["id"], second)
+
+    for reporter, reason in ((first, "spam"), (second, "abuse")):
+        response = client.post(
+            f"/moderation/rooms/{room['id']}/reports",
+            headers=_headers(sqlite_session, reporter),
+            json={"kind": "room", "reason": reason},
+        )
+        assert response.status_code == 201
+
+    mine = client.get(
+        "/moderation/reports/mine",
+        headers=_headers(sqlite_session, first),
+    )
+    assert mine.status_code == 200
+    assert len(mine.json()) == 1
+    assert mine.json()[0]["reporter_user_id"] == first.id

--- a/docs/QUEST_ROOM_MODERATION.md
+++ b/docs/QUEST_ROOM_MODERATION.md
@@ -1,0 +1,59 @@
+# Quest Room moderation
+
+Quest Room moderation starts with explicit, reviewable controls rather than automatic punishment. The V1 separates **personal blocking**, **host room control**, and **platform review** so each action has a clear meaning.
+
+## User reports
+
+Active room members can report:
+
+- the room itself,
+- one durable chat message,
+- one active room member.
+
+A report stores immutable review context at submission time:
+
+- room name,
+- message body and author when reporting a message,
+- target display name when reporting a user,
+- reporter reason/details,
+- creation and later review metadata.
+
+This snapshot means a moderator can still understand the original report even if a message is later removed from normal room history.
+
+Reports begin in `open` state. Configured moderators can mark them `reviewed`, `dismissed`, or `actioned`, with an optional review note. Each review transition creates an append-only `ModerationAudit` row.
+
+## Moderator bootstrap
+
+Moderator review endpoints are protected server-side by the comma-separated `MODERATOR_EMAILS` environment setting. There is intentionally no user-facing control that can grant moderator privileges.
+
+The capability endpoint lets a signed-in frontend determine whether the current account is a configured moderator without exposing the configured email list.
+
+## Blocking
+
+A user block is **one-way personal visibility**, not a room ban.
+
+- A learner may block another active learner only when they currently share a room.
+- Blocks are idempotent and durable in PostgreSQL.
+- The Room UI removes the blocked learner's retained messages from the blocker's current chat view and ignores future live chat from that user.
+- Unblocking restores retained room history on the next history refresh immediately triggered by the UI.
+- Blocking does not eject the other learner, change their role, or alter what other room members see.
+
+This keeps a personal safety preference distinct from host moderation.
+
+## Host removal
+
+Host **Remove** remains the room-level ban mechanism.
+
+- membership becomes `removed`,
+- every live socket for that room/user is closed immediately,
+- remaining participants receive updated presence,
+- the removed account cannot self-rejoin a public room or use an invite to restore itself,
+- private-room restoration requires a fresh explicit host decision.
+
+Membership status plus removal/last-seen timestamps provide durable room-level history. Platform report-review actions use the separate moderation audit table.
+
+## Realtime and privacy boundary
+
+A block does not reveal hidden room ids or bypass room membership. Reporting requires active room membership, and message reports verify that the target message belongs to the named room.
+
+Broad public-room discovery remains disabled until this moderation foundation is proven in production. Shared-link public rooms continue to use the same rate limits, host removal controls, reporting, and block behavior.

--- a/frontend/src/moderationApi.ts
+++ b/frontend/src/moderationApi.ts
@@ -1,0 +1,87 @@
+import { api } from "./api";
+
+export type ReportKind = "room" | "message" | "user";
+export type ReportStatus = "open" | "reviewed" | "dismissed" | "actioned";
+
+export interface ModerationReportRead {
+  id: number;
+  reporter_user_id: number;
+  room_id: number;
+  kind: ReportKind;
+  message_id: number | null;
+  target_user_id: number | null;
+  reason: string;
+  details: string;
+  room_name_snapshot: string;
+  message_body_snapshot: string | null;
+  message_author_user_id: number | null;
+  target_display_name_snapshot: string | null;
+  status: ReportStatus;
+  created_at: string;
+  reviewed_at: string | null;
+  reviewed_by_user_id: number | null;
+  review_note: string;
+}
+
+export interface BlockRead {
+  user_id: number;
+  display_name: string;
+  created_at: string;
+}
+
+function moderationError(error: unknown): Error {
+  if (error && typeof error === "object" && "response" in error) {
+    const response = (error as { response?: { data?: { detail?: unknown } } }).response;
+    const detail = response?.data?.detail;
+    if (typeof detail === "string" && detail.trim()) return new Error(detail);
+  }
+  if (error instanceof Error) return error;
+  return new Error("Moderation request failed");
+}
+
+export async function reportRoomContent(
+  roomId: number,
+  payload: {
+    kind: ReportKind;
+    message_id?: number;
+    target_user_id?: number;
+    reason: string;
+    details?: string;
+  }
+): Promise<ModerationReportRead> {
+  try {
+    const { data } = await api.post<ModerationReportRead>(
+      `/moderation/rooms/${roomId}/reports`,
+      payload
+    );
+    return data;
+  } catch (error) {
+    throw moderationError(error);
+  }
+}
+
+export async function getBlockedUsers(): Promise<BlockRead[]> {
+  try {
+    const { data } = await api.get<BlockRead[]>("/moderation/blocks");
+    return data;
+  } catch (error) {
+    throw moderationError(error);
+  }
+}
+
+export async function blockUser(userId: number): Promise<BlockRead> {
+  try {
+    const { data } = await api.post<BlockRead>(`/moderation/blocks/${userId}`);
+    return data;
+  } catch (error) {
+    throw moderationError(error);
+  }
+}
+
+export async function unblockUser(userId: number): Promise<void> {
+  try {
+    await api.delete(`/moderation/blocks/${userId}`);
+  } catch (error) {
+    throw moderationError(error);
+  }
+}


### PR DESCRIPTION
## What changed

Completes #19 with a focused Quest Room moderation layer built on the existing rate limits, host removal, private/invite access controls, and durable chat history.

### Reports with durable context
- Adds room, message, and user report flows for active room members.
- Message reports verify the message belongs to the named room and infer the reported author server-side.
- User reports require the target to be an active member of that room.
- Reports snapshot room name, message body/author, target display name, reason, and optional details at submission time so later review still has context even if normal room content changes.
- Reporters can see their own submitted reports.

### Human moderator review hooks
- Adds a server-side `MODERATOR_EMAILS` bootstrap setting; there is no user-facing privilege-escalation control.
- Adds a capability endpoint so future/admin UI can determine whether the signed-in account is a configured moderator without exposing the configured email list.
- Configured moderators can list reports by status and mark them `reviewed`, `dismissed`, or `actioned` with a review note.
- Every report review transition writes an append-only `ModerationAudit` record.

### Personal block / mute behavior
- Adds durable one-way `UserBlock` rows with a unique blocker→blocked pair.
- Blocking is allowed only for another learner who currently shares an active room with the blocker; self-block and arbitrary user-id probing are rejected.
- Room UI immediately removes the blocked learner’s retained messages from the blocker’s chat view and ignores new realtime chat from that learner.
- Unblocking restores retained room history immediately.
- Blocking is intentionally **not** a room ban and does not change the other learner’s membership or what anyone else sees.

### Host moderation already integrated
- Existing host **Remove** remains the room-level ban: durable `removed` membership, immediate WebSocket eviction, updated presence, and no self-rejoin through public/invite flows.
- Existing chat length and burst rate limits remain in force.
- This PR does not duplicate host removals into the platform report-review audit table; room membership already retains removal/last-seen timestamps, while platform report review has its own explicit audit trail.

### Room UX
- Adds `Report room`, `Report message`, `Report user`, `Block`, and `Unblock` controls directly inside the existing live Room screen.
- Report form explains that context is saved for later human review.
- Blocked users appear in a small personal block list with one-click Unblock.
- The UI states clearly that blocking affects only the learner’s chat view; hosts use Remove for a room-level ban.

### Persistence
Adds Alembic revision `g2e3b6c7d8f9` after the invite/access migration head with:
- `user_block`
- `moderation_report`
- `moderation_audit`

### Tests
Covers:
- message report context snapshots
- room/user report target validation
- non-member reporting denial
- block idempotency and shared-room requirement
- block list + unblock lifecycle
- server-gated moderator capabilities/queue
- moderator review state + audit record
- reporter-only report history

### Docs
Adds `QUEST_ROOM_MODERATION.md` and links it from MkDocs navigation.

Broad public-room directory/discovery remains intentionally separate; public rooms are still shared-link/ID based while this moderation foundation proves itself.

Closes #19