### PR TITLE
Fix anonymous Study sessions on PostgreSQL

### DIFF
--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -16,6 +16,7 @@ from ..security import DEMO_USER_ID, get_optional_user
 
 router = APIRouter(prefix="/study", tags=["study"])
 VALID_TRACKS = {"mixed", "concept", "lab"}
+POSTGRES_INTEGER_MAX = (1 << 31) - 1
 
 
 def _now_utc() -> datetime:
@@ -51,13 +52,15 @@ def _demo_user_id(demo_session: str | None) -> int:
     """Map one browser-session token to a stable negative demo user id.
 
     Real account ids are positive. Negative ids keep anonymous progress isolated
-    per browser session without creating throwaway account rows.
+    per browser session without creating throwaway account rows. Keep the mapped
+    value inside PostgreSQL's signed INTEGER range because usercard.user_id and
+    review.user_id are INTEGER columns rather than BIGINT columns.
     """
     token = (demo_session or "").strip()[:128]
     if not token:
         return DEMO_USER_ID
-    digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
-    value = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+    digest = hashlib.blake2b(token.encode("utf-8"), digest_size=4).digest()
+    value = int.from_bytes(digest, "big") & POSTGRES_INTEGER_MAX
     return -(value or 1)
 
 

--- a/backend/tests/test_api_study.py
+++ b/backend/tests/test_api_study.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.models import Card, Deck, UserCard
+from app.routers.study import POSTGRES_INTEGER_MAX, _demo_user_id
 from app.security import DEMO_USER_ID
 
 
@@ -53,6 +54,37 @@ def _mk_card(
     session.add(UserCard(user_id=DEMO_USER_ID, card_id=int(card.id or 0), bin=0))
     session.commit()
     return card
+
+
+def test_demo_session_ids_fit_postgres_integer_range() -> None:
+    first = _demo_user_id("browser-session-a")
+    second = _demo_user_id("browser-session-b")
+
+    assert -POSTGRES_INTEGER_MAX <= first <= -1
+    assert -POSTGRES_INTEGER_MAX <= second <= -1
+    assert first == _demo_user_id("browser-session-a")
+    assert first != second
+
+
+def test_demo_session_header_creates_safe_progress_id(
+    client: TestClient, sqlite_session: Session
+) -> None:
+    card = _mk_card(sqlite_session, "session-safe", "safe")
+    token = "browser-session-a"
+    expected_user_id = _demo_user_id(token)
+
+    response = client.get("/study/next", headers={"X-Demo-Session": token})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert -POSTGRES_INTEGER_MAX <= expected_user_id <= -1
+    progress = sqlite_session.exec(
+        select(UserCard).where(
+            UserCard.user_id == expected_user_id,
+            cast(Any, UserCard.card_id) == card.id,
+        )
+    ).first()
+    assert progress is not None
 
 
 def test_next_returns_new_when_nothing_due(


### PR DESCRIPTION
## What changed
- Keeps deterministic anonymous demo-session IDs inside PostgreSQL's signed 32-bit `INTEGER` range.
- Preserves negative IDs for anonymous sessions and positive IDs for real accounts.
- Adds regression coverage for the PostgreSQL integer boundary and the `X-Demo-Session` study path.

## Why
`_demo_user_id()` previously generated a 63-bit negative value, while `usercard.user_id` and `review.user_id` are `INTEGER` columns. SQLite accepts those values, but PostgreSQL `INTEGER` is 32-bit, so the live `/study/next` path could fail when anonymous progress was first inserted.

This matches the production symptom: the deck list loads successfully, then the first Study card request fails with a browser `Network Error`.

## Scope
Backend hotfix only. No schema migration is required.