### PR TITLE
Add sandboxed Quest Rooms demo login and signup funnel

### DIFF
--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -127,20 +127,15 @@ def get_current_user(
     return user
 
 
-def require_verified_user(user: User = Depends(get_current_user)) -> User:
-    """Require an authenticated account with a verified email address."""
-    if not user.is_verified:
-        raise HTTPException(status_code=403, detail="Verify your email first")
-    return user
-
-
 def is_demo_account(user: User) -> bool:
     """Return whether this is the intentionally public sandbox account."""
     return user.email.strip().lower() == DEMO_LOGIN_EMAIL
 
 
-def require_creator_user(user: User = Depends(require_verified_user)) -> User:
-    """Require a verified non-demo account for content/room creation."""
+def require_verified_user(user: User = Depends(get_current_user)) -> User:
+    """Require a verified creator account; the public demo stays sandboxed."""
+    if not user.is_verified:
+        raise HTTPException(status_code=403, detail="Verify your email first")
     if is_demo_account(user):
         raise HTTPException(
             status_code=403,

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -19,6 +19,12 @@ from .models import AuthSession, User
 
 PBKDF2_ITERATIONS = 600_000
 DEMO_USER_ID = 0
+DEMO_LOGIN_EMAIL = "demo@flashquest.app"
+DEMO_LOGIN_PASSWORD = "QuestRoomDemo!"
+DEMO_DISPLAY_NAME = "Demo Explorer"
+DEMO_GUIDE_EMAIL = "guide@flashquest.internal"
+DEMO_GUIDE_NAME = "FlashQuest Guide"
+DEMO_ROOM_NAME = "FlashQuest Demo Room"
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
@@ -125,4 +131,19 @@ def require_verified_user(user: User = Depends(get_current_user)) -> User:
     """Require an authenticated account with a verified email address."""
     if not user.is_verified:
         raise HTTPException(status_code=403, detail="Verify your email first")
+    return user
+
+
+def is_demo_account(user: User) -> bool:
+    """Return whether this is the intentionally public sandbox account."""
+    return user.email.strip().lower() == DEMO_LOGIN_EMAIL
+
+
+def require_creator_user(user: User = Depends(require_verified_user)) -> User:
+    """Require a verified non-demo account for content/room creation."""
+    if is_demo_account(user):
+        raise HTTPException(
+            status_code=403,
+            detail="The public demo account is read-only outside its demo room",
+        )
     return user

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,4 +1,4 @@
-"""Seed FlashQuest Official curricula into the configured database.
+"""Seed FlashQuest Official curricula and the safe Quest Room demo.
 
 Run with Docker:
     docker compose exec api python -m app.seed
@@ -18,7 +18,18 @@ from typing import Any
 from sqlmodel import Session, select
 
 from .db import engine
-from .models import Card, Deck, UserCard, utc_now
+from .models import Card, Deck, User, UserCard, utc_now
+from .room_models import RoomMember, RoomMessage, StudyRoom
+from .security import (
+    DEMO_DISPLAY_NAME,
+    DEMO_GUIDE_EMAIL,
+    DEMO_GUIDE_NAME,
+    DEMO_LOGIN_EMAIL,
+    DEMO_LOGIN_PASSWORD,
+    DEMO_ROOM_NAME,
+    hash_password,
+    verify_password,
+)
 
 DATA_DIR = Path(__file__).parent / "data"
 CONCEPT_DECK_PATH = DATA_DIR / "platform_engineering_cards.json"
@@ -247,8 +258,6 @@ def seed_curriculum(session: Session, spec: CurriculumSpec) -> dict[str, int | s
     deck = _official_deck(session, spec)
     deck_id = int(deck.id or 0)
 
-    # Prompt identity is scoped to the deck. Different subjects may legitimately
-    # use the same wording without colliding during seed repair.
     existing_cards = {
         card.word: card
         for card in session.exec(select(Card).where(Card.deck_id == deck_id)).all()
@@ -334,10 +343,141 @@ def seed_all_curricula(session: Session) -> list[dict[str, int | str]]:
     return [seed_curriculum(session, spec) for spec in OFFICIAL_CURRICULA]
 
 
+def _ensure_membership(
+    session: Session,
+    *,
+    room_id: int,
+    user_id: int,
+    role: str,
+) -> RoomMember:
+    member = session.exec(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.user_id == user_id,
+        )
+    ).first()
+    if member is None:
+        member = RoomMember(
+            room_id=room_id,
+            user_id=user_id,
+            role=role,
+            status="active",
+        )
+    else:
+        member.role = role
+        member.status = "active"
+        member.removed_at = None
+        member.last_seen_at = utc_now()
+    session.add(member)
+    return member
+
+
+def seed_demo_room(session: Session) -> dict[str, int | str]:
+    """Create a stable, sandboxed account and private room for product demos."""
+    deck = session.exec(select(Deck).where(Deck.slug == "platform-engineering")).first()
+    if deck is None or deck.id is None:
+        raise RuntimeError("Platform Engineering deck must be seeded before the demo room")
+
+    guide = session.exec(select(User).where(User.email == DEMO_GUIDE_EMAIL)).first()
+    if guide is None:
+        guide = User(
+            email=DEMO_GUIDE_EMAIL,
+            display_name=DEMO_GUIDE_NAME,
+            password_hash="disabled",
+            is_verified=True,
+        )
+    else:
+        guide.display_name = DEMO_GUIDE_NAME
+        guide.password_hash = "disabled"
+        guide.is_verified = True
+    session.add(guide)
+    session.flush()
+
+    demo = session.exec(select(User).where(User.email == DEMO_LOGIN_EMAIL)).first()
+    if demo is None:
+        demo = User(
+            email=DEMO_LOGIN_EMAIL,
+            display_name=DEMO_DISPLAY_NAME,
+            password_hash=hash_password(DEMO_LOGIN_PASSWORD),
+            is_verified=True,
+        )
+    else:
+        demo.display_name = DEMO_DISPLAY_NAME
+        demo.is_verified = True
+        if not verify_password(DEMO_LOGIN_PASSWORD, demo.password_hash):
+            demo.password_hash = hash_password(DEMO_LOGIN_PASSWORD)
+    session.add(demo)
+    session.flush()
+
+    guide_id = int(guide.id or 0)
+    demo_id = int(demo.id or 0)
+    room = session.exec(
+        select(StudyRoom).where(
+            StudyRoom.name == DEMO_ROOM_NAME,
+            StudyRoom.host_user_id == guide_id,
+        )
+    ).first()
+    if room is None:
+        room = StudyRoom(
+            host_user_id=guide_id,
+            deck_id=int(deck.id),
+            name=DEMO_ROOM_NAME,
+            visibility="private",
+            status="open",
+        )
+        session.add(room)
+        session.flush()
+    else:
+        room.deck_id = int(deck.id)
+        room.visibility = "private"
+        room.status = "open"
+        room.closed_at = None
+        room.updated_at = utc_now()
+        session.add(room)
+        session.flush()
+
+    room_id = int(room.id or 0)
+    _ensure_membership(session, room_id=room_id, user_id=guide_id, role="host")
+    _ensure_membership(session, room_id=room_id, user_id=demo_id, role="member")
+
+    starter_messages = (
+        "👋 Welcome to the FlashQuest Demo Room. This is a safe sandbox for trying realtime chat and room features.",
+        "🎮 Quest Rooms can run the same Blitz, Match Quest, and Sort the Stack activities used in solo Arcade.",
+        "💬 Send a message below to test realtime chat. The public demo account cannot create decks or new rooms.",
+    )
+    existing_bodies = set(
+        session.exec(
+            select(RoomMessage.body).where(RoomMessage.room_id == room_id)
+        ).all()
+    )
+    created_messages = 0
+    for body in starter_messages:
+        if body in existing_bodies:
+            continue
+        session.add(
+            RoomMessage(
+                room_id=room_id,
+                user_id=guide_id,
+                kind="system",
+                body=body,
+            )
+        )
+        created_messages += 1
+
+    session.commit()
+    return {
+        "room_id": room_id,
+        "demo_user_id": demo_id,
+        "guide_user_id": guide_id,
+        "created_messages": created_messages,
+    }
+
+
 def run() -> None:
     """Seed the configured database and print one compact summary per deck."""
     with Session(engine) as session:
         results = seed_all_curricula(session)
+        demo_result = seed_demo_room(session)
 
     total_cards = sum(int(result["deck_size"]) for result in results)
     print(
@@ -351,6 +491,9 @@ def run() -> None:
             f"{result['updated_cards']} repaired, "
             f"{result['existing_cards']} already present)."
         )
+    print(
+        f"- demo-room: room #{demo_result['room_id']} ready for {DEMO_LOGIN_EMAIL}."
+    )
 
 
 if __name__ == "__main__":

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -376,7 +376,9 @@ def seed_demo_room(session: Session) -> dict[str, int | str]:
     """Create a stable, sandboxed account and private room for product demos."""
     deck = session.exec(select(Deck).where(Deck.slug == "platform-engineering")).first()
     if deck is None or deck.id is None:
-        raise RuntimeError("Platform Engineering deck must be seeded before the demo room")
+        raise RuntimeError(
+            "Platform Engineering deck must be seeded before the demo room"
+        )
 
     guide = session.exec(select(User).where(User.email == DEMO_GUIDE_EMAIL)).first()
     if guide is None:
@@ -491,9 +493,7 @@ def run() -> None:
             f"{result['updated_cards']} repaired, "
             f"{result['existing_cards']} already present)."
         )
-    print(
-        f"- demo-room: room #{demo_result['room_id']} ready for {DEMO_LOGIN_EMAIL}."
-    )
+    print(f"- demo-room: room #{demo_result['room_id']} ready for {DEMO_LOGIN_EMAIL}.")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -2,7 +2,8 @@
 
 from sqlmodel import select
 
-from app.models import Card, Deck, UserCard
+from app.models import Card, Deck, User, UserCard
+from app.room_models import RoomMember, RoomMessage, StudyRoom
 from app.seed import (
     DEMO_USER_ID,
     OFFICIAL_CURRICULA,
@@ -13,7 +14,16 @@ from app.seed import (
     PLATFORM_ENGINEERING_LABS_BY_DOMAIN,
     load_deck,
     seed_all_curricula,
+    seed_demo_room,
     seed_platform_deck,
+)
+from app.security import (
+    DEMO_DISPLAY_NAME,
+    DEMO_GUIDE_EMAIL,
+    DEMO_LOGIN_EMAIL,
+    DEMO_LOGIN_PASSWORD,
+    DEMO_ROOM_NAME,
+    verify_password,
 )
 
 
@@ -206,3 +216,87 @@ def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
     sqlite_session.refresh(second_card)
     assert first_card.deck_id == original_first_deck_id
     assert second_card.deck_id == original_second_deck_id
+
+
+def test_seed_demo_room_is_login_ready_idempotent_and_non_creator(client, sqlite_session):
+    seed_all_curricula(sqlite_session)
+    first = seed_demo_room(sqlite_session)
+
+    demo = sqlite_session.exec(select(User).where(User.email == DEMO_LOGIN_EMAIL)).one()
+    guide = sqlite_session.exec(select(User).where(User.email == DEMO_GUIDE_EMAIL)).one()
+    room = sqlite_session.exec(
+        select(StudyRoom).where(StudyRoom.name == DEMO_ROOM_NAME)
+    ).one()
+    members = sqlite_session.exec(
+        select(RoomMember).where(RoomMember.room_id == room.id).order_by(RoomMember.user_id)
+    ).all()
+    messages = sqlite_session.exec(
+        select(RoomMessage).where(RoomMessage.room_id == room.id).order_by(RoomMessage.id)
+    ).all()
+
+    assert demo.display_name == DEMO_DISPLAY_NAME
+    assert demo.is_verified is True
+    assert verify_password(DEMO_LOGIN_PASSWORD, demo.password_hash) is True
+    assert guide.is_verified is True
+    assert verify_password(DEMO_LOGIN_PASSWORD, guide.password_hash) is False
+    assert room.visibility == "private"
+    assert room.status == "open"
+    assert room.host_user_id == guide.id
+    assert {(member.user_id, member.role, member.status) for member in members} == {
+        (guide.id, "host", "active"),
+        (demo.id, "member", "active"),
+    }
+    assert len(messages) == 3
+    assert all(message.user_id == guide.id for message in messages)
+    assert first["created_messages"] == 3
+
+    login = client.post(
+        "/auth/login",
+        json={"email": DEMO_LOGIN_EMAIL, "password": DEMO_LOGIN_PASSWORD},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    mine = client.get("/rooms/mine", headers=headers)
+    assert mine.status_code == 200
+    assert [item["name"] for item in mine.json()] == [DEMO_ROOM_NAME]
+
+    create_room = client.post(
+        "/rooms",
+        json={
+            "deck_id": room.deck_id,
+            "name": "Should not exist",
+            "visibility": "private",
+        },
+        headers=headers,
+    )
+    assert create_room.status_code == 403
+
+    create_deck = client.post(
+        "/decks",
+        json={
+            "title": "Should not exist",
+            "description": "demo sandbox",
+            "subject": "Testing",
+            "difficulty": "beginner",
+            "tags": [],
+        },
+        headers=headers,
+    )
+    assert create_deck.status_code == 403
+
+    second = seed_demo_room(sqlite_session)
+    assert second["room_id"] == first["room_id"]
+    assert second["demo_user_id"] == first["demo_user_id"]
+    assert second["created_messages"] == 0
+    assert len(
+        sqlite_session.exec(
+            select(StudyRoom).where(StudyRoom.name == DEMO_ROOM_NAME)
+        ).all()
+    ) == 1
+    assert len(
+        sqlite_session.exec(
+            select(RoomMessage).where(RoomMessage.room_id == room.id)
+        ).all()
+    ) == 3

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -218,20 +218,28 @@ def test_seed_scopes_prompt_identity_to_each_deck(sqlite_session):
     assert second_card.deck_id == original_second_deck_id
 
 
-def test_seed_demo_room_is_login_ready_idempotent_and_non_creator(client, sqlite_session):
+def test_seed_demo_room_is_login_ready_idempotent_and_non_creator(
+    client, sqlite_session
+):
     seed_all_curricula(sqlite_session)
     first = seed_demo_room(sqlite_session)
 
     demo = sqlite_session.exec(select(User).where(User.email == DEMO_LOGIN_EMAIL)).one()
-    guide = sqlite_session.exec(select(User).where(User.email == DEMO_GUIDE_EMAIL)).one()
+    guide = sqlite_session.exec(
+        select(User).where(User.email == DEMO_GUIDE_EMAIL)
+    ).one()
     room = sqlite_session.exec(
         select(StudyRoom).where(StudyRoom.name == DEMO_ROOM_NAME)
     ).one()
     members = sqlite_session.exec(
-        select(RoomMember).where(RoomMember.room_id == room.id).order_by(RoomMember.user_id)
+        select(RoomMember)
+        .where(RoomMember.room_id == room.id)
+        .order_by(RoomMember.user_id)
     ).all()
     messages = sqlite_session.exec(
-        select(RoomMessage).where(RoomMessage.room_id == room.id).order_by(RoomMessage.id)
+        select(RoomMessage)
+        .where(RoomMessage.room_id == room.id)
+        .order_by(RoomMessage.id)
     ).all()
 
     assert demo.display_name == DEMO_DISPLAY_NAME
@@ -290,13 +298,19 @@ def test_seed_demo_room_is_login_ready_idempotent_and_non_creator(client, sqlite
     assert second["room_id"] == first["room_id"]
     assert second["demo_user_id"] == first["demo_user_id"]
     assert second["created_messages"] == 0
-    assert len(
-        sqlite_session.exec(
-            select(StudyRoom).where(StudyRoom.name == DEMO_ROOM_NAME)
-        ).all()
-    ) == 1
-    assert len(
-        sqlite_session.exec(
-            select(RoomMessage).where(RoomMessage.room_id == room.id)
-        ).all()
-    ) == 3
+    assert (
+        len(
+            sqlite_session.exec(
+                select(StudyRoom).where(StudyRoom.name == DEMO_ROOM_NAME)
+            ).all()
+        )
+        == 1
+    )
+    assert (
+        len(
+            sqlite_session.exec(
+                select(RoomMessage).where(RoomMessage.room_id == room.id)
+            ).all()
+        )
+        == 3
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,11 +23,12 @@ const DOCS_URL = "https://flashquest-docs.netlify.app/";
 function Shell() {
   const { user, signOut } = useAuth();
   const location = useLocation();
+  const roomsTarget = user ? "/rooms" : "/signup?next=%2Frooms";
   const navItems = [
     { to: "/study", icon: "⚡", label: "Play" },
     { to: "/arcade", icon: "🎮", label: "Arcade" },
     { to: "/library", icon: "📚", label: "Library" },
-    ...(user ? [{ to: "/rooms", icon: "👥", label: "Rooms" }] : []),
+    { to: roomsTarget, icon: "👥", label: "Quest Rooms" },
     { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
     ...(user ? [{ to: "/decks", icon: "🗂️", label: "My Decks" }] : []),
     { to: "/status", icon: "🗺️", label: "Deck Map" },
@@ -50,7 +51,7 @@ function Shell() {
           <div className="flex flex-wrap items-center gap-2">
             <nav className="flex flex-wrap gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
               {navItems.map((item) => (
-                <NavLink key={item.to} to={item.to} className={({ isActive }) => ["flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
+                <NavLink key={`${item.to}-${item.label}`} to={item.to} className={({ isActive }) => ["flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
                   <span aria-hidden="true">{item.icon}</span><span>{item.label}</span>
                 </NavLink>
               ))}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "../auth";
 
 export default function Landing() {
   const { user } = useAuth();
+  const roomsTarget = user ? "/rooms" : "/signup?next=%2Frooms";
 
   return (
     <div className="grid gap-14 pb-10 pt-4 sm:pt-10">
@@ -15,7 +16,7 @@ export default function Landing() {
             Learn it. Break it. <span className="ember-text">Fix it.</span> Remember it.
           </h1>
           <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-            FlashQuest’s turns study cards into a game loop. Start with 216 Platform Engineering challenges, then sign in and build decks for anything you want to learn.
+            FlashQuest turns study cards into a game loop. Learn solo, jump into Arcade, or bring a deck into a Quest Room for realtime chat and multiplayer study.
           </p>
           <div className="mt-7 flex flex-wrap gap-3">
             <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">
@@ -23,24 +24,22 @@ export default function Landing() {
             </Link>
             <Link
               className="game-button border border-[#faa307]/40 bg-[#6a040f]/45 px-5 py-3 text-sm font-black text-[#ffba08]"
+              to={roomsTarget}
+            >
+              👥 Explore Quest Rooms
+            </Link>
+            <Link
+              className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-slate-200"
               to={user ? "/decks" : "/signup"}
             >
               ✨ Make your own deck
             </Link>
-            <a
-              className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-slate-200"
-              href="https://flashquest-docs.netlify.app/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              📖 Read the docs
-            </a>
           </div>
           <div className="mt-8 flex flex-wrap gap-5 text-sm text-slate-400">
-            <span><b className="text-white">144</b> concepts</span>
-            <span><b className="text-white">72</b> break/fix labs</span>
-            <span><b className="text-white">12</b> domains</span>
-            <span><b className="text-white">12</b> mastery levels</span>
+            <span><b className="text-white">6</b> Official decks</span>
+            <span><b className="text-white">366</b> study cards</span>
+            <span><b className="text-white">3</b> Arcade games</span>
+            <span><b className="text-white">Realtime</b> Quest Rooms</span>
           </div>
         </div>
 
@@ -66,11 +65,12 @@ export default function Landing() {
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {[
           ["🧠", "Learn the idea", "Concept cards build the mental models behind Linux, networking, containers, Kubernetes, Terraform, databases, SRE, and more."],
           ["🛠️", "Practice the failure", "Lab cards drop you into realistic break/fix situations and make you explain what you would inspect, change, and verify."],
-          ["🗂️", "Build anything", "Create an account, verify your email, and make your own private decks for certifications, school, coding, languages, interviews, or whatever comes next."],
+          ["🎮", "Play it differently", "Use Blitz, Match Quest, and Sort the Stack in Arcade with Chill, Focus, and accessibility-friendly experience controls."],
+          ["👥", "Study together", "Quest Rooms combine persistent chat, presence, invites, moderation, and synchronized multiplayer Arcade around the same deck."],
         ].map(([icon, title, body]) => (
           <article key={title} className="game-panel p-6">
             <div className="text-3xl">{icon}</div>
@@ -81,17 +81,22 @@ export default function Landing() {
       </section>
 
       <section className="game-panel p-6 sm:p-8">
-        <div className="max-w-2xl">
-          <p className="metric-label">Make your own deck</p>
-          <h2 className="mt-2 text-3xl font-black text-white">Same game engine. Your topic.</h2>
-          <p className="mt-3 text-slate-400">Sign up, verify your email, create a deck, add questions or labs, then study with XP, streaks, mastery, and spaced repetition.</p>
+        <div className="grid gap-7 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div className="max-w-2xl">
+            <p className="metric-label">Your topic. Your crew.</p>
+            <h2 className="mt-2 text-3xl font-black text-white">Same learning engine, solo or together.</h2>
+            <p className="mt-3 text-slate-400">Create a deck, study with XP and spaced repetition, then bring that deck into a Quest Room when you want realtime chat, presence, and multiplayer rounds.</p>
+          </div>
+          <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to={roomsTarget}>
+            👥 Open Quest Rooms
+          </Link>
         </div>
         <div className="mt-7 grid gap-3 sm:grid-cols-4">
           {[
-            ["1", "Sign up"],
-            ["2", "Verify email"],
-            ["3", "Build a deck"],
-            ["4", "Play + remember"],
+            ["1", "Pick a deck"],
+            ["2", "Study solo"],
+            ["3", "Open a room"],
+            ["4", "Chat + play"],
           ].map(([step, label]) => (
             <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
               <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 
+const DEMO_EMAIL = "demo@flashquest.app";
+const DEMO_PASSWORD = "QuestRoomDemo!";
+
 export default function Login() {
   const { signIn } = useAuth();
   const navigate = useNavigate();
@@ -11,14 +14,17 @@ export default function Login() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  async function onSubmit(event: React.FormEvent) {
-    event.preventDefault();
+  const stateNext = (location.state as { from?: string } | null)?.from;
+  const queryNext = new URLSearchParams(location.search).get("next");
+  const safeQueryNext = queryNext?.startsWith("/") ? queryNext : null;
+  const next = stateNext ?? safeQueryNext ?? "/decks";
+
+  async function loginWith(credentials: { email: string; password: string }, destination = next) {
     setLoading(true);
     setError(null);
     try {
-      await signIn({ email, password });
-      const next = (location.state as { from?: string } | null)?.from ?? "/decks";
-      navigate(next, { replace: true });
+      await signIn(credentials);
+      navigate(destination, { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not sign in");
     } finally {
@@ -26,12 +32,37 @@ export default function Login() {
     }
   }
 
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    await loginWith({ email, password });
+  }
+
   return (
-    <div className="mx-auto max-w-xl py-6 sm:py-10">
+    <div className="mx-auto grid max-w-xl gap-5 py-6 sm:py-10">
+      <section className="game-panel border-[#faa307]/30 p-5 sm:p-6">
+        <p className="metric-label">👥 Quest Rooms demo</p>
+        <h2 className="mt-2 text-2xl font-black text-white">Want to see the chat rooms right now?</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-400">
+          Use the sandbox account below. It opens a private demo room with realtime chat and multiplayer Arcade, but it cannot create decks or new rooms.
+        </p>
+        <div className="mt-4 grid gap-2 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm sm:grid-cols-2">
+          <div><span className="text-slate-500">Demo email</span><p className="mt-1 font-black text-white">{DEMO_EMAIL}</p></div>
+          <div><span className="text-slate-500">Password</span><p className="mt-1 font-black text-white">{DEMO_PASSWORD}</p></div>
+        </div>
+        <button
+          type="button"
+          className="game-button mt-4 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+          disabled={loading}
+          onClick={() => void loginWith({ email: DEMO_EMAIL, password: DEMO_PASSWORD }, "/rooms")}
+        >
+          {loading ? "Entering demo…" : "👥 Enter the Demo Room"}
+        </button>
+      </section>
+
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
         <p className="metric-label">Welcome back</p>
-        <h1 className="mt-2 text-3xl font-black text-white">Sign in to your decks</h1>
-        <p className="mt-2 text-sm text-slate-400">Your custom decks and progress stay tied to your verified account.</p>
+        <h1 className="mt-2 text-3xl font-black text-white">Sign in to FlashQuest</h1>
+        <p className="mt-2 text-sm text-slate-400">Your decks, progress, and Quest Room memberships stay tied to your verified account.</p>
         <div className="mt-6 grid gap-4">
           <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
             <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />
@@ -42,7 +73,7 @@ export default function Login() {
         </div>
         {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
         <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Signing in…" : "Sign in →"}</button>
-        <p className="mt-5 text-center text-sm text-slate-500">Need an account? <Link className="font-bold text-[#faa307]" to="/signup">Create one</Link></p>
+        <p className="mt-5 text-center text-sm text-slate-500">Need an account? <Link className="font-bold text-[#faa307]" to={`/signup${safeQueryNext ? `?next=${encodeURIComponent(safeQueryNext)}` : ""}`}>Create one</Link></p>
       </form>
     </div>
   );

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -15,6 +15,8 @@ import {
 } from "../roomApi";
 import type { DeckRead } from "../types";
 
+const DEMO_EMAIL = "demo@flashquest.app";
+
 function uniqueDecks(rows: DeckRead[]): DeckRead[] {
   const seen = new Set<number>();
   return rows.filter((deck) => {
@@ -44,6 +46,7 @@ export default function Rooms() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isDemo = user?.email.toLowerCase() === DEMO_EMAIL;
   const selectedDeck = useMemo(
     () => decks.find((deck) => deck.id === deckId) ?? null,
     [deckId, decks]
@@ -93,23 +96,31 @@ export default function Rooms() {
     return (
       <section className="game-panel mx-auto max-w-2xl p-8 text-center">
         <div className="text-5xl" aria-hidden="true">👥</div>
-        <h1 className="mt-4 text-3xl font-black text-white">Quest Rooms need an account</h1>
+        <h1 className="mt-4 text-3xl font-black text-white">Join Quest Rooms</h1>
         <p className="mt-3 text-slate-400">
-          Rooms keep persistent membership and author identity, so realtime participation starts with signed-in learners.
+          Create a verified account to join persistent study chat, presence, invites, and multiplayer Arcade around a shared deck.
         </p>
-        <Link
-          to="/login"
-          className="game-button mt-6 inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]"
-        >
-          Sign in to Rooms
-        </Link>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <Link
+            to="/signup?next=%2Frooms"
+            className="game-button inline-flex bg-[#faa307] px-5 py-3 font-black text-[#370617]"
+          >
+            Create account for Rooms
+          </Link>
+          <Link
+            to="/login?next=%2Frooms"
+            className="game-button inline-flex border border-white/10 bg-white/[0.04] px-5 py-3 font-black text-white"
+          >
+            Sign in
+          </Link>
+        </div>
       </section>
     );
   }
 
   async function submitCreate(event: FormEvent) {
     event.preventDefault();
-    if (!deckId || !name.trim()) return;
+    if (!deckId || !name.trim() || isDemo) return;
     setLoading(true);
     setError(null);
     try {
@@ -130,6 +141,7 @@ export default function Rooms() {
 
   async function submitJoin(event: FormEvent) {
     event.preventDefault();
+    if (isDemo) return;
     const roomId = Number(joinId);
     if (!Number.isInteger(roomId) || roomId <= 0) {
       setError("Enter a valid room number");
@@ -158,9 +170,24 @@ export default function Rooms() {
           Study together. <span className="ember-text">Same deck, same room.</span>
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
-          Rooms are deck-linked spaces for live chat, presence, and multiplayer Arcade. Public rooms use a shared room link/number; invite-only rooms use expiring secret links; private rooms admit specific accounts.
+          Rooms are deck-linked spaces for realtime chat, presence, persistent history, invites, moderation, and multiplayer Arcade. Learn solo when you want; bring in a crew when you don’t.
         </p>
       </section>
+
+      {isDemo && (
+        <section className="game-panel border-[#faa307]/35 bg-[#faa307]/[0.05] p-5 sm:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="max-w-2xl">
+              <p className="metric-label">🧪 Demo Explorer sandbox</p>
+              <h2 className="mt-2 text-2xl font-black text-white">You’re inside the safe public demo account.</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-400">
+                Open <b className="text-white">FlashQuest Demo Room</b> below to try persistent chat, presence, and multiplayer Arcade. This shared account cannot create decks or rooms, so the demo stays safe for everybody.
+              </p>
+            </div>
+            <span className="game-chip px-3 py-2 text-xs font-black text-[#ffba08]">Sandboxed</span>
+          </div>
+        </section>
+      )}
 
       {error && (
         <section className="game-panel border-[#d00000]/50 p-4 text-sm text-rose-200">
@@ -168,102 +195,104 @@ export default function Rooms() {
         </section>
       )}
 
-      <section className="grid gap-5 lg:grid-cols-2">
-        <form className="game-panel p-5 sm:p-6" onSubmit={submitCreate}>
-          <p className="metric-label">Create a room</p>
-          <h2 className="mt-2 text-2xl font-black text-white">Start a study crew</h2>
+      {!isDemo && (
+        <section className="grid gap-5 lg:grid-cols-2">
+          <form className="game-panel p-5 sm:p-6" onSubmit={submitCreate}>
+            <p className="metric-label">Create a room</p>
+            <h2 className="mt-2 text-2xl font-black text-white">Start a study crew</h2>
 
-          <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="room-name">
-            Room name
-          </label>
-          <input
-            id="room-name"
-            className="game-input mt-2"
-            value={name}
-            maxLength={80}
-            onChange={(event) => setName(event.target.value)}
-          />
+            <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="room-name">
+              Room name
+            </label>
+            <input
+              id="room-name"
+              className="game-input mt-2"
+              value={name}
+              maxLength={80}
+              onChange={(event) => setName(event.target.value)}
+            />
 
-          <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-deck">
-            Deck
-          </label>
-          <select
-            id="room-deck"
-            className="game-input mt-2"
-            value={deckId ?? ""}
-            onChange={(event) => setDeckId(Number(event.target.value))}
-          >
-            {decks.map((deck) => (
-              <option key={deck.id} value={deck.id}>
-                {deck.is_official ? "⭐ " : deck.visibility === "private" ? "🔒 " : "🧑‍🚀 "}
-                {deck.title} · {deck.card_count} cards
+            <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-deck">
+              Deck
+            </label>
+            <select
+              id="room-deck"
+              className="game-input mt-2"
+              value={deckId ?? ""}
+              onChange={(event) => setDeckId(Number(event.target.value))}
+            >
+              {decks.map((deck) => (
+                <option key={deck.id} value={deck.id}>
+                  {deck.is_official ? "⭐ " : deck.visibility === "private" ? "🔒 " : "🧑‍🚀 "}
+                  {deck.title} · {deck.card_count} cards
+                </option>
+              ))}
+            </select>
+
+            <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-visibility">
+              Room access
+            </label>
+            <select
+              id="room-visibility"
+              className="game-input mt-2"
+              value={visibility}
+              onChange={(event) => setVisibility(event.target.value as RoomVisibility)}
+            >
+              <option value="private">Private · host adds specific accounts</option>
+              <option value="invite_only">Invite only · share an expiring secret link</option>
+              <option value="public" disabled={!canPublic}>
+                Public by link/ID · signed-in learners can join
               </option>
-            ))}
-          </select>
-
-          <label className="mt-4 block text-sm font-black text-slate-200" htmlFor="room-visibility">
-            Room access
-          </label>
-          <select
-            id="room-visibility"
-            className="game-input mt-2"
-            value={visibility}
-            onChange={(event) => setVisibility(event.target.value as RoomVisibility)}
-          >
-            <option value="private">Private · host adds specific accounts</option>
-            <option value="invite_only">Invite only · share an expiring secret link</option>
-            <option value="public" disabled={!canPublic}>
-              Public by link/ID · signed-in learners can join
-            </option>
-          </select>
-          <p className="mt-2 text-xs leading-5 text-slate-500">
-            {visibility === "private"
-              ? "After creation, add verified FlashQuest accounts by email from the room's access controls."
-              : visibility === "invite_only"
-                ? "After creation, generate a 24-hour, 3-day, or 7-day invite link. You can revoke it whenever you want."
-                : "Public rooms remain link/ID based until broad room discovery ships with moderation controls."}
-          </p>
-          {!canPublic && selectedDeck && (
+            </select>
             <p className="mt-2 text-xs leading-5 text-slate-500">
-              This deck is {selectedDeck.visibility}; FlashQuest will not widen it through a public room.
+              {visibility === "private"
+                ? "After creation, add verified FlashQuest accounts by email from the room's access controls."
+                : visibility === "invite_only"
+                  ? "After creation, generate a 24-hour, 3-day, or 7-day invite link. You can revoke it whenever you want."
+                  : "Public rooms remain link/ID based until broad room discovery ships with moderation controls."}
             </p>
-          )}
+            {!canPublic && selectedDeck && (
+              <p className="mt-2 text-xs leading-5 text-slate-500">
+                This deck is {selectedDeck.visibility}; FlashQuest will not widen it through a public room.
+              </p>
+            )}
 
-          <button
-            type="submit"
-            disabled={loading || !deckId || !name.trim()}
-            className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
-          >
-            {loading ? "Opening room…" : "👥 Create Quest Room"}
-          </button>
-        </form>
+            <button
+              type="submit"
+              disabled={loading || !deckId || !name.trim()}
+              className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
+            >
+              {loading ? "Opening room…" : "👥 Create Quest Room"}
+            </button>
+          </form>
 
-        <form className="game-panel p-5 sm:p-6" onSubmit={submitJoin}>
-          <p className="metric-label">Join a public room</p>
-          <h2 className="mt-2 text-2xl font-black text-white">Got a room number?</h2>
-          <p className="mt-3 text-sm leading-6 text-slate-400">
-            This box is only for public rooms. Invite-only links go through their secret invite URL, and private rooms require the host to add your account first.
-          </p>
-          <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="join-room-id">
-            Public room number
-          </label>
-          <input
-            id="join-room-id"
-            className="game-input mt-2"
-            inputMode="numeric"
-            placeholder="42"
-            value={joinId}
-            onChange={(event) => setJoinId(event.target.value.replace(/[^0-9]/g, ""))}
-          />
-          <button
-            type="submit"
-            disabled={loading || !joinId}
-            className="game-button mt-5 border border-[#faa307]/30 bg-[#370617]/70 px-5 py-3 font-black text-[#ffba08]"
-          >
-            🔗 Open public room
-          </button>
-        </form>
-      </section>
+          <form className="game-panel p-5 sm:p-6" onSubmit={submitJoin}>
+            <p className="metric-label">Join a public room</p>
+            <h2 className="mt-2 text-2xl font-black text-white">Got a room number?</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-400">
+              This box is only for public rooms. Invite-only links go through their secret invite URL, and private rooms require the host to add your account first.
+            </p>
+            <label className="mt-5 block text-sm font-black text-slate-200" htmlFor="join-room-id">
+              Public room number
+            </label>
+            <input
+              id="join-room-id"
+              className="game-input mt-2"
+              inputMode="numeric"
+              placeholder="42"
+              value={joinId}
+              onChange={(event) => setJoinId(event.target.value.replace(/[^0-9]/g, ""))}
+            />
+            <button
+              type="submit"
+              disabled={loading || !joinId}
+              className="game-button mt-5 border border-[#faa307]/30 bg-[#370617]/70 px-5 py-3 font-black text-[#ffba08]"
+            >
+              🔗 Open public room
+            </button>
+          </form>
+        </section>
+      )}
 
       <section>
         <div className="flex flex-wrap items-end justify-between gap-3">
@@ -278,7 +307,9 @@ export default function Rooms() {
 
         {rooms.length === 0 ? (
           <div className="game-panel mt-4 p-7 text-center text-slate-400">
-            No rooms yet. Create one above, join a public room, or open an invite link somebody shared with you.
+            {isDemo
+              ? "The demo room is still being prepared. Refresh after the latest backend deploy finishes."
+              : "No rooms yet. Create one above, join a public room, or open an invite link somebody shared with you."}
           </div>
         ) : (
           <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { resendVerification, signup } from "../api";
 
 export default function Signup() {
+  const location = useLocation();
   const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -10,6 +11,11 @@ export default function Signup() {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const requestedNext = new URLSearchParams(location.search).get("next");
+  const safeNext = requestedNext?.startsWith("/") ? requestedNext : null;
+  const joiningRooms = safeNext === "/rooms";
+  const loginTarget = safeNext ? `/login?next=${encodeURIComponent(safeNext)}` : "/login";
 
   async function onSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -47,12 +53,16 @@ export default function Signup() {
           <p className="metric-label mt-5">Almost there</p>
           <h1 className="mt-2 text-3xl font-black text-white">Check your inbox!</h1>
           <p className="mt-3 text-slate-300">We sent a verification link to <b className="text-[#ffba08]">{sentTo}</b>.</p>
-          <p className="mt-2 text-sm text-slate-500">Click it to unlock Make Your Own Deck.</p>
+          <p className="mt-2 text-sm text-slate-500">
+            {joiningRooms
+              ? "Verify your email, then sign in and FlashQuest will send you to Quest Rooms."
+              : "Verify your email to unlock private decks, durable progress, and Quest Rooms."}
+          </p>
           {message && <p className="mt-5 rounded-xl border border-[#faa307]/20 bg-[#faa307]/10 p-3 text-sm text-[#ffba08]">{message}</p>}
           {error && <p className="mt-5 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
           <div className="mt-6 flex flex-wrap justify-center gap-3">
             <button className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]" onClick={() => void resend()} disabled={loading}>Resend email</button>
-            <Link className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-black text-white" to="/login">Go to sign in</Link>
+            <Link className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-black text-white" to={loginTarget}>Go to sign in</Link>
           </div>
         </div>
       </div>
@@ -62,9 +72,19 @@ export default function Signup() {
   return (
     <div className="mx-auto max-w-xl py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
-        <p className="metric-label">Make your own deck</p>
+        <p className="metric-label">{joiningRooms ? "👥 Join Quest Rooms" : "Make your own deck"}</p>
         <h1 className="mt-2 text-3xl font-black text-white">Create your FlashQuest account</h1>
-        <p className="mt-2 text-sm leading-6 text-slate-400">The Platform Engineering demo is free to try. An account lets you save private decks and progress.</p>
+        <p className="mt-2 text-sm leading-6 text-slate-400">
+          {joiningRooms
+            ? "Create and verify an account to join persistent study chat, presence, and multiplayer Arcade with other learners."
+            : "The public study demo is free to try. An account adds private decks, durable progress, publishing, and Quest Rooms."}
+        </p>
+
+        {joiningRooms && (
+          <div className="mt-5 rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-4 text-sm leading-6 text-slate-300">
+            <b className="text-[#ffba08]">Why an account?</b> Quest Rooms keep membership, chat authorship, invites, moderation, and multiplayer state tied to real signed-in learners.
+          </div>
+        )}
 
         <div className="mt-6 grid gap-4">
           <label className="grid gap-1.5 text-sm font-bold text-slate-200">Name
@@ -80,8 +100,8 @@ export default function Signup() {
         </div>
 
         {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
-        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : "Create account →"}</button>
-        <p className="mt-5 text-center text-sm text-slate-500">Already verified? <Link className="font-bold text-[#faa307]" to="/login">Sign in</Link></p>
+        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : joiningRooms ? "Create account for Quest Rooms →" : "Create account →"}</button>
+        <p className="mt-5 text-center text-sm text-slate-500">Already verified? <Link className="font-bold text-[#faa307]" to={loginTarget}>Sign in</Link></p>
       </form>
     </div>
   );


### PR DESCRIPTION
## What changed
- Always shows **Quest Rooms** in the global nav.
- Signed-out Quest Rooms clicks go to registration with `/rooms` preserved as the return destination.
- Adds a visible demo login on the sign-in page:
  - `demo@flashquest.app`
  - `QuestRoomDemo!`
- Seeds a verified **Demo Explorer** account, a non-loginable **FlashQuest Guide** host, one private **FlashQuest Demo Room**, durable memberships, and three starter messages.
- Keeps the public demo account sandboxed by rejecting verified-creator endpoints (decks/cards/room creation) while still allowing normal signed-in room participation.
- Hides creator/join controls for Demo Explorer and surfaces a clear sandbox banner.
- Promotes Quest Rooms on the landing page.
- Adds regression coverage for demo login, idempotent seeding, room membership/history, and creator restrictions.

## Production behavior
Fly already runs `alembic upgrade head && python -m app.seed` as its release command, so the demo account/room are created idempotently after migrations on deploy.

## Why
The social features were effectively hidden from signed-out visitors, and there was no safe account for product/demo inspection. This makes Quest Rooms discoverable and gives a real, bounded way to explore the chat UI without creating a personal test account.