### PR TITLE
Simplify public onboarding and reveal features after signup

### DIFF
--- a/docs/ONBOARDING_FLOW.md
+++ b/docs/ONBOARDING_FLOW.md
@@ -1,0 +1,21 @@
+# FlashQuest onboarding flow
+
+## Product rule
+Visitors should understand the core memory loop without seeing the full product surface.
+
+### Signed out
+- Marketing landing page: one value proposition, one tiny demo CTA, one account CTA.
+- `/demo`: a short Question → Hint → Reveal → XP taste.
+- Full product routes are account-gated.
+
+### First authenticated entry
+- Normal first login goes to `/welcome` unless the user arrived with an explicit `next` destination.
+- Welcome Quest introduces the major product destinations after signup.
+- Completing or skipping Welcome Quest is remembered locally for that account.
+
+### Returning authenticated users
+- Normal login goes to `/study` after Welcome Quest has been seen.
+- Full navigation is visible: Play, Arcade, Library, Quest Rooms, Deck Lab, My Decks, Deck Map, and Settings.
+
+### Settings
+Use the familiar gear affordance (`⚙️ Settings`) for experience, sound, and accessibility preferences rather than an ambiguous standalone sliders icon.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { ExperienceProvider } from "./experience";
 import { GameFeelProvider, SoundToggle } from "./gameFeel";
 import Admin from "./pages/Admin";
 import Arcade from "./pages/Arcade";
+import Demo from "./pages/Demo";
 import Landing from "./pages/Landing";
 import Library from "./pages/Library";
 import LibraryDeck from "./pages/LibraryDeck";
@@ -18,13 +19,15 @@ import Signup from "./pages/Signup";
 import Status from "./pages/Status";
 import Study from "./pages/Study";
 import VerifyEmail from "./pages/VerifyEmail";
+import Welcome from "./pages/Welcome";
 
 const DOCS_URL = "https://flashquest-docs.netlify.app/";
 
 function RequireAccount({ children }: { children: ReactNode }) {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const location = useLocation();
 
+  if (loading) return <div className="game-panel mx-auto max-w-lg p-8 text-center text-slate-400">Loading your quest…</div>;
   if (user) return children;
 
   const next = `${location.pathname}${location.search}`;
@@ -44,7 +47,7 @@ function Shell() {
         { to: "/decks", icon: "🗂️", label: "My Decks" },
         { to: "/status", icon: "🗺️", label: "Deck Map" },
       ]
-    : [{ to: "/study", icon: "⚡", label: "Try demo" }];
+    : [{ to: "/demo", icon: "⚡", label: "Try demo" }];
 
   return (
     <div className="game-shell min-h-screen text-slate-100">
@@ -52,7 +55,7 @@ function Shell() {
 
       <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
         <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 lg:flex-row lg:items-center lg:justify-between sm:px-6">
-          <NavLink to="/" className="group flex items-center gap-3">
+          <NavLink to={user ? "/study" : "/"} className="group flex items-center gap-3">
             <div className="grid h-11 w-11 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">🧠</div>
             <div>
               <div className="flex items-center gap-2"><span className="text-lg font-black tracking-tight text-white">FlashQuest</span><span className="rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-[#ffba08]">Quest Mode</span></div>
@@ -80,7 +83,7 @@ function Shell() {
                 >
                   <span aria-hidden="true">⚙️</span><span className="hidden xl:inline">Settings</span>
                 </NavLink>
-                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
+                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button hidden items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] xl:flex">📖 Docs</a>
                 <div className="flex items-center gap-2">
                   <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 sm:inline">👋 {user.display_name}</span>
                   <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
@@ -99,7 +102,9 @@ function Shell() {
       <main key={location.pathname} className="game-page-enter relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
         <Routes>
           <Route path="/" element={<Landing />} />
-          <Route path="/study" element={<Study />} />
+          <Route path="/demo" element={<Demo />} />
+          <Route path="/welcome" element={<RequireAccount><Welcome /></RequireAccount>} />
+          <Route path="/study" element={<RequireAccount><Study /></RequireAccount>} />
           <Route path="/arcade" element={<RequireAccount><Arcade /></RequireAccount>} />
           <Route path="/library" element={<RequireAccount><Library /></RequireAccount>} />
           <Route path="/library/:slug" element={<RequireAccount><LibraryDeck /></RequireAccount>} />
@@ -114,13 +119,13 @@ function Shell() {
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/verify-email" element={<VerifyEmail />} />
-          <Route path="*" element={<div className="game-panel mx-auto max-w-lg p-8 text-center"><div className="text-5xl">🌀</div><h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1><p className="mt-2 text-slate-400">That route slipped into another dimension.</p><NavLink to="/" className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">Back home</NavLink></div>} />
+          <Route path="*" element={<div className="game-panel mx-auto max-w-lg p-8 text-center"><div className="text-5xl">🌀</div><h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1><p className="mt-2 text-slate-400">That route slipped into another dimension.</p><NavLink to={user ? "/study" : "/"} className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">Back home</NavLink></div>} />
         </Routes>
       </main>
 
       <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-        <span>{user ? "Library · community decks · Arcade · Quest Rooms · adaptable learning modes" : "Learn more after you create an account."}</span>
-        {user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>}
+        <span>{user ? "Learn · play · create · study together" : "Try the memory loop. Create an account when you want the full experience."}</span>
+        {user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">Docs ↗</a>}
       </footer>
     </div>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { BrowserRouter, Navigate, NavLink, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "./auth";
 import { ExperienceProvider } from "./experience";
@@ -20,19 +21,30 @@ import VerifyEmail from "./pages/VerifyEmail";
 
 const DOCS_URL = "https://flashquest-docs.netlify.app/";
 
+function RequireAccount({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (user) return children;
+
+  const next = `${location.pathname}${location.search}`;
+  return <Navigate to={`/signup?next=${encodeURIComponent(next)}`} replace />;
+}
+
 function Shell() {
   const { user, signOut } = useAuth();
   const location = useLocation();
-  const roomsTarget = user ? "/rooms" : "/signup?next=%2Frooms";
-  const navItems = [
-    { to: "/study", icon: "⚡", label: "Play" },
-    { to: "/arcade", icon: "🎮", label: "Arcade" },
-    { to: "/library", icon: "📚", label: "Library" },
-    { to: roomsTarget, icon: "👥", label: "Quest Rooms" },
-    { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
-    ...(user ? [{ to: "/decks", icon: "🗂️", label: "My Decks" }] : []),
-    { to: "/status", icon: "🗺️", label: "Deck Map" },
-  ];
+  const navItems = user
+    ? [
+        { to: "/study", icon: "⚡", label: "Play" },
+        { to: "/arcade", icon: "🎮", label: "Arcade" },
+        { to: "/library", icon: "📚", label: "Library" },
+        { to: "/rooms", icon: "👥", label: "Quest Rooms" },
+        { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
+        { to: "/decks", icon: "🗂️", label: "My Decks" },
+        { to: "/status", icon: "🗺️", label: "Deck Map" },
+      ]
+    : [{ to: "/study", icon: "⚡", label: "Try demo" }];
 
   return (
     <div className="game-shell min-h-screen text-slate-100">
@@ -56,23 +68,29 @@ function Shell() {
                 </NavLink>
               ))}
             </nav>
-            <SoundToggle />
-            <NavLink
-              to="/preferences"
-              aria-label="Experience settings"
-              title="Experience settings"
-              className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
-            >
-              <span aria-hidden="true">🎚️</span><span className="hidden xl:inline">Experience</span>
-            </NavLink>
-            <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
+
             {user ? (
-              <div className="flex items-center gap-2">
-                <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 sm:inline">👋 {user.display_name}</span>
-                <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
-              </div>
+              <>
+                <SoundToggle />
+                <NavLink
+                  to="/preferences"
+                  aria-label="Settings"
+                  title="Settings"
+                  className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
+                >
+                  <span aria-hidden="true">⚙️</span><span className="hidden xl:inline">Settings</span>
+                </NavLink>
+                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button flex items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08]">📖 Docs</a>
+                <div className="flex items-center gap-2">
+                  <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 sm:inline">👋 {user.display_name}</span>
+                  <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
+                </div>
+              </>
             ) : (
-              <div className="flex gap-2"><NavLink className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" to="/login">Sign in</NavLink><NavLink className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]" to="/signup">Make a deck</NavLink></div>
+              <div className="flex gap-2">
+                <NavLink className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" to="/login">Sign in</NavLink>
+                <NavLink className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]" to="/signup">Create account</NavLink>
+              </div>
             )}
           </div>
         </div>
@@ -82,17 +100,17 @@ function Shell() {
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/study" element={<Study />} />
-          <Route path="/arcade" element={<Arcade />} />
-          <Route path="/library" element={<Library />} />
-          <Route path="/library/:slug" element={<LibraryDeck />} />
-          <Route path="/rooms" element={<Rooms />} />
-          <Route path="/rooms/invite" element={<RoomInvite />} />
-          <Route path="/rooms/:roomId" element={<Room />} />
-          <Route path="/deck-lab" element={<Admin />} />
+          <Route path="/arcade" element={<RequireAccount><Arcade /></RequireAccount>} />
+          <Route path="/library" element={<RequireAccount><Library /></RequireAccount>} />
+          <Route path="/library/:slug" element={<RequireAccount><LibraryDeck /></RequireAccount>} />
+          <Route path="/rooms" element={<RequireAccount><Rooms /></RequireAccount>} />
+          <Route path="/rooms/invite" element={<RequireAccount><RoomInvite /></RequireAccount>} />
+          <Route path="/rooms/:roomId" element={<RequireAccount><Room /></RequireAccount>} />
+          <Route path="/deck-lab" element={<RequireAccount><Admin /></RequireAccount>} />
           <Route path="/admin" element={<Navigate to="/deck-lab" replace />} />
-          <Route path="/decks" element={<MyDecks />} />
-          <Route path="/status" element={<Status />} />
-          <Route path="/preferences" element={<Preferences />} />
+          <Route path="/decks" element={<RequireAccount><MyDecks /></RequireAccount>} />
+          <Route path="/status" element={<RequireAccount><Status /></RequireAccount>} />
+          <Route path="/preferences" element={<RequireAccount><Preferences /></RequireAccount>} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/verify-email" element={<VerifyEmail />} />
@@ -101,8 +119,8 @@ function Shell() {
       </main>
 
       <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-        <span>Library · community decks · Arcade · Quest Rooms · adaptable learning modes</span>
-        <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>
+        <span>{user ? "Library · community decks · Arcade · Quest Rooms · adaptable learning modes" : "Learn more after you create an account."}</span>
+        {user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">FastAPI · React · PostgreSQL · Docker · Docs ↗</a>}
       </footer>
     </div>
   );

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+export default function Demo() {
+  const [showHint, setShowHint] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="mx-auto max-w-2xl py-6 sm:py-10">
+      <section className="quest-card p-6 sm:p-8">
+        <div className="relative z-10">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">⚡ 60-second demo</span>
+            <span className="text-xs font-bold text-slate-500">No account needed</span>
+          </div>
+
+          <p className="mt-8 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Your question</p>
+          <h1 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">
+            A Linux process is listening on a port, but another machine cannot reach it. What would you check first?
+          </h1>
+
+          {!revealed && (
+            <div className="mt-7 flex flex-wrap gap-3">
+              <button
+                type="button"
+                className="game-button border border-[#faa307]/30 bg-[#faa307]/10 px-4 py-2 text-sm font-black text-[#ffba08]"
+                onClick={() => setShowHint(true)}
+              >
+                💡 Hint
+              </button>
+              <button
+                type="button"
+                className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]"
+                onClick={() => setRevealed(true)}
+              >
+                Reveal answer
+              </button>
+            </div>
+          )}
+
+          {showHint && !revealed && (
+            <div className="mt-5 rounded-2xl border border-violet-400/25 bg-violet-400/[0.08] p-4 text-sm leading-6 text-violet-100">
+              <b>Hint:</b> Separate “is the app listening?” from “can traffic reach it?” Think bind address, host firewall, and the network path.
+            </div>
+          )}
+
+          {revealed && (
+            <div className="mt-7 grid gap-4">
+              <div className="rounded-2xl border border-cyan-400/25 bg-cyan-400/[0.08] p-4">
+                <p className="text-xs font-black uppercase tracking-[0.15em] text-cyan-300">TL;DR</p>
+                <p className="mt-2 text-sm leading-6 text-cyan-50">Check the bind address, host firewall, and whether the port is reachable from the remote network.</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm leading-6 text-slate-300">
+                Confirm the process is listening on the expected interface (not only localhost), inspect firewall rules, then test the path with tools such as <code>ss</code>, <code>curl</code>, or <code>nc</code>. FlashQuest turns that recall loop into repeatable study, games, and collaborative practice after you create an account.
+              </div>
+              <div className="rounded-2xl border border-[#ffba08]/25 bg-[#ffba08]/[0.08] p-5 text-center">
+                <div className="text-3xl">✨ +10 XP</div>
+                <h2 className="mt-2 text-xl font-black text-white">That’s the loop.</h2>
+                <p className="mt-2 text-sm text-slate-400">Create an account to save progress and unlock the full FlashQuest experience.</p>
+                <Link className="game-button mt-5 inline-flex bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/signup">
+                  Create free account →
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <p className="mt-5 text-center text-sm text-slate-500">
+        Already have an account? <Link className="font-bold text-[#faa307]" to="/login">Sign in</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -3,106 +3,52 @@ import { useAuth } from "../auth";
 
 export default function Landing() {
   const { user } = useAuth();
-  const roomsTarget = user ? "/rooms" : "/signup?next=%2Frooms";
 
   return (
-    <div className="grid gap-14 pb-10 pt-4 sm:pt-10">
+    <div className="grid gap-10 pb-10 pt-4 sm:pt-10">
       <section className="grid items-center gap-10 lg:grid-cols-[1.08fr_.92fr]">
         <div>
           <div className="game-chip inline-flex items-center gap-2 px-3 py-1.5 text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">
-            ⚡ Featured deck · Platform Engineering
+            ⚡ Learn by doing
           </div>
           <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[.98] tracking-[-0.045em] text-white sm:text-6xl lg:text-7xl">
-            Learn it. Break it. <span className="ember-text">Fix it.</span> Remember it.
+            Turn what you need to remember into a <span className="ember-text">quest.</span>
           </h1>
           <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-            FlashQuest turns study cards into a game loop. Learn solo, jump into Arcade, or bring a deck into a Quest Room for realtime chat and multiplayer study.
+            FlashQuest helps you remember ideas by making you try, hint, reveal, and come back to the things you miss.
           </p>
           <div className="mt-7 flex flex-wrap gap-3">
-            <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">
-              🎮 Try the Platform demo
-            </Link>
-            <Link
-              className="game-button border border-[#faa307]/40 bg-[#6a040f]/45 px-5 py-3 text-sm font-black text-[#ffba08]"
-              to={roomsTarget}
-            >
-              👥 Explore Quest Rooms
-            </Link>
-            <Link
-              className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-slate-200"
-              to={user ? "/decks" : "/signup"}
-            >
-              ✨ Make your own deck
-            </Link>
+            {user ? (
+              <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">⚡ Continue learning</Link>
+            ) : (
+              <>
+                <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/demo">Try the 60-second demo</Link>
+                <Link className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white" to="/signup">Create free account</Link>
+              </>
+            )}
           </div>
-          <div className="mt-8 flex flex-wrap gap-5 text-sm text-slate-400">
-            <span><b className="text-white">6</b> Official decks</span>
-            <span><b className="text-white">366</b> study cards</span>
-            <span><b className="text-white">3</b> Arcade games</span>
-            <span><b className="text-white">Realtime</b> Quest Rooms</span>
-          </div>
+          {!user && <p className="mt-4 text-sm text-slate-500">No account needed for the demo. The rest of FlashQuest unlocks after signup.</p>}
         </div>
 
         <div className="quest-card p-6 sm:p-8">
           <div className="relative z-10">
-            <div className="flex items-center justify-between gap-3">
-              <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">🔧 BREAK/FIX LAB</span>
-              <span className="text-xs font-bold text-slate-500">Kubernetes</span>
+            <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">ONE MEMORY LOOP</span>
+            <p className="mt-7 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Question</p>
+            <h2 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">What would you check first?</h2>
+            <div className="mt-6 grid gap-3 sm:grid-cols-3">
+              {[
+                ["1", "Try it"],
+                ["2", "Get a hint"],
+                ["3", "Reveal + remember"],
+              ].map(([step, label]) => (
+                <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
+                  <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
+                  <p className="mt-2 font-black text-white">{label}</p>
+                </div>
+              ))}
             </div>
-            <p className="mt-8 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Your challenge</p>
-            <h2 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">
-              A Service has no traffic even though the Pods are Running. What do you check first?
-            </h2>
-            <div className="mt-7 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-5">
-              <p className="text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">Think like the engineer</p>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
-                Check Service selectors against Pod labels, inspect EndpointSlices, verify targetPort, then confirm readiness and network policy.
-              </p>
-            </div>
-            <div className="mt-6 xp-track"><div className="xp-fill" style={{ width: "68%" }} /></div>
-            <div className="mt-2 flex justify-between text-xs font-bold text-slate-500"><span>Mastery path</span><span>Level 7 / 11</span></div>
+            <p className="mt-6 text-sm leading-6 text-slate-400">That’s all visitors need to understand. Once you create an account, FlashQuest shows you the rest as you explore.</p>
           </div>
-        </div>
-      </section>
-
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {[
-          ["🧠", "Learn the idea", "Concept cards build the mental models behind Linux, networking, containers, Kubernetes, Terraform, databases, SRE, and more."],
-          ["🛠️", "Practice the failure", "Lab cards drop you into realistic break/fix situations and make you explain what you would inspect, change, and verify."],
-          ["🎮", "Play it differently", "Use Blitz, Match Quest, and Sort the Stack in Arcade with Chill, Focus, and accessibility-friendly experience controls."],
-          ["👥", "Study together", "Quest Rooms combine persistent chat, presence, invites, moderation, and synchronized multiplayer Arcade around the same deck."],
-        ].map(([icon, title, body]) => (
-          <article key={title} className="game-panel p-6">
-            <div className="text-3xl">{icon}</div>
-            <h2 className="mt-4 text-xl font-black text-white">{title}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-400">{body}</p>
-          </article>
-        ))}
-      </section>
-
-      <section className="game-panel p-6 sm:p-8">
-        <div className="grid gap-7 lg:grid-cols-[1fr_auto] lg:items-end">
-          <div className="max-w-2xl">
-            <p className="metric-label">Your topic. Your crew.</p>
-            <h2 className="mt-2 text-3xl font-black text-white">Same learning engine, solo or together.</h2>
-            <p className="mt-3 text-slate-400">Create a deck, study with XP and spaced repetition, then bring that deck into a Quest Room when you want realtime chat, presence, and multiplayer rounds.</p>
-          </div>
-          <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to={roomsTarget}>
-            👥 Open Quest Rooms
-          </Link>
-        </div>
-        <div className="mt-7 grid gap-3 sm:grid-cols-4">
-          {[
-            ["1", "Pick a deck"],
-            ["2", "Study solo"],
-            ["3", "Open a room"],
-            ["4", "Chat + play"],
-          ].map(([step, label]) => (
-            <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-              <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
-              <p className="mt-2 font-black text-white">{label}</p>
-            </div>
-          ))}
         </div>
       </section>
     </div>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -5,6 +5,10 @@ import { useAuth } from "../auth";
 const DEMO_EMAIL = "demo@flashquest.app";
 const DEMO_PASSWORD = "QuestRoomDemo!";
 
+function welcomeKey(userId: number) {
+  return `flashquest-welcome-seen:${userId}`;
+}
+
 export default function Login() {
   const { signIn } = useAuth();
   const navigate = useNavigate();
@@ -17,13 +21,15 @@ export default function Login() {
   const stateNext = (location.state as { from?: string } | null)?.from;
   const queryNext = new URLSearchParams(location.search).get("next");
   const safeQueryNext = queryNext?.startsWith("/") ? queryNext : null;
-  const next = stateNext ?? safeQueryNext ?? "/decks";
+  const explicitNext = stateNext ?? safeQueryNext;
 
-  async function loginWith(credentials: { email: string; password: string }, destination = next) {
+  async function loginWith(credentials: { email: string; password: string }, forcedDestination?: string) {
     setLoading(true);
     setError(null);
     try {
-      await signIn(credentials);
+      const signedInUser = await signIn(credentials);
+      const hasSeenWelcome = window.localStorage.getItem(welcomeKey(signedInUser.id)) === "1";
+      const destination = forcedDestination ?? explicitNext ?? (hasSeenWelcome ? "/study" : "/welcome");
       navigate(destination, { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not sign in");

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -56,7 +56,7 @@ export default function Signup() {
           <p className="mt-2 text-sm text-slate-500">
             {joiningRooms
               ? "Verify your email, then sign in and FlashQuest will send you to Quest Rooms."
-              : "Verify your email to unlock private decks, durable progress, and Quest Rooms."}
+              : "Verify your email, then sign in to continue your quest."}
           </p>
           {message && <p className="mt-5 rounded-xl border border-[#faa307]/20 bg-[#faa307]/10 p-3 text-sm text-[#ffba08]">{message}</p>}
           {error && <p className="mt-5 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
@@ -72,17 +72,17 @@ export default function Signup() {
   return (
     <div className="mx-auto max-w-xl py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
-        <p className="metric-label">{joiningRooms ? "👥 Join Quest Rooms" : "Make your own deck"}</p>
+        <p className="metric-label">{joiningRooms ? "👥 Join Quest Rooms" : "Continue your quest"}</p>
         <h1 className="mt-2 text-3xl font-black text-white">Create your FlashQuest account</h1>
         <p className="mt-2 text-sm leading-6 text-slate-400">
           {joiningRooms
-            ? "Create and verify an account to join persistent study chat, presence, and multiplayer Arcade with other learners."
-            : "The public study demo is free to try. An account adds private decks, durable progress, publishing, and Quest Rooms."}
+            ? "Create and verify an account so FlashQuest can take you directly to the room experience you chose."
+            : "You’ve tried the public demo. Create an account to unlock the full FlashQuest experience."}
         </p>
 
         {joiningRooms && (
           <div className="mt-5 rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-4 text-sm leading-6 text-slate-300">
-            <b className="text-[#ffba08]">Why an account?</b> Quest Rooms keep membership, chat authorship, invites, moderation, and multiplayer state tied to real signed-in learners.
+            <b className="text-[#ffba08]">Why an account?</b> Quest Rooms need a signed-in identity for membership and realtime participation.
           </div>
         )}
 

--- a/frontend/src/pages/Welcome.tsx
+++ b/frontend/src/pages/Welcome.tsx
@@ -1,0 +1,70 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../auth";
+
+function welcomeKey(userId: number) {
+  return `flashquest-welcome-seen:${userId}`;
+}
+
+export default function Welcome() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  if (!user) return null;
+
+  function continueTo(path: string) {
+    window.localStorage.setItem(welcomeKey(user.id), "1");
+    navigate(path);
+  }
+
+  const choices = [
+    ["⚡", "Play", "Start with a deck and build durable study progress.", "/study"],
+    ["🎮", "Arcade", "Practice the same material through fast or untimed mini-games.", "/arcade"],
+    ["📚", "Library", "Choose an Official deck or discover community-made material.", "/library"],
+    ["👥", "Quest Rooms", "Study with other people through realtime chat and multiplayer rounds.", "/rooms"],
+    ["🧪", "Create", "Build your own deck or remix something that already exists.", "/deck-lab"],
+  ] as const;
+
+  return (
+    <div className="mx-auto max-w-4xl py-4 sm:py-8">
+      <section className="game-panel p-6 sm:p-9">
+        <p className="metric-label">🎉 Welcome Quest</p>
+        <h1 className="mt-2 text-3xl font-black text-white sm:text-4xl">You’re in, {user.display_name}.</h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400 sm:text-base">
+          The public demo only showed the core memory loop. Your account unlocks the rest of FlashQuest. Pick what you want to explore first — there is no required order.
+        </p>
+
+        <div className="mt-7 grid gap-3 sm:grid-cols-2">
+          {choices.map(([icon, title, body, path]) => (
+            <button
+              key={title}
+              type="button"
+              onClick={() => continueTo(path)}
+              className="game-button rounded-2xl border border-white/10 bg-white/[0.035] p-5 text-left hover:border-[#faa307]/35 hover:bg-[#faa307]/[0.06]"
+            >
+              <div className="text-3xl" aria-hidden="true">{icon}</div>
+              <h2 className="mt-3 text-lg font-black text-white">{title}</h2>
+              <p className="mt-1 text-sm leading-6 text-slate-400">{body}</p>
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-7 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-4">
+          <div>
+            <p className="font-black text-white">⚙️ Settings is where the experience controls live.</p>
+            <p className="mt-1 text-sm text-slate-400">Switch between Arcade, Chill, Focus, and Party, plus sound and accessibility preferences.</p>
+          </div>
+          <Link className="text-sm font-black text-[#ffba08] hover:text-white" to="/preferences" onClick={() => window.localStorage.setItem(welcomeKey(user.id), "1")}>Open Settings →</Link>
+        </div>
+
+        <div className="mt-7 flex flex-wrap gap-3">
+          <button type="button" className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" onClick={() => continueTo("/study")}>
+            Start studying →
+          </button>
+          <button type="button" className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white" onClick={() => continueTo("/library")}>
+            Skip intro
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Welcome.tsx
+++ b/frontend/src/pages/Welcome.tsx
@@ -10,9 +10,10 @@ export default function Welcome() {
   const navigate = useNavigate();
 
   if (!user) return null;
+  const signedInUser = user;
 
   function continueTo(path: string) {
-    window.localStorage.setItem(welcomeKey(user.id), "1");
+    window.localStorage.setItem(welcomeKey(signedInUser.id), "1");
     navigate(path);
   }
 
@@ -28,7 +29,7 @@ export default function Welcome() {
     <div className="mx-auto max-w-4xl py-4 sm:py-8">
       <section className="game-panel p-6 sm:p-9">
         <p className="metric-label">🎉 Welcome Quest</p>
-        <h1 className="mt-2 text-3xl font-black text-white sm:text-4xl">You’re in, {user.display_name}.</h1>
+        <h1 className="mt-2 text-3xl font-black text-white sm:text-4xl">You’re in, {signedInUser.display_name}.</h1>
         <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400 sm:text-base">
           The public demo only showed the core memory loop. Your account unlocks the rest of FlashQuest. Pick what you want to explore first — there is no required order.
         </p>
@@ -53,7 +54,7 @@ export default function Welcome() {
             <p className="font-black text-white">⚙️ Settings is where the experience controls live.</p>
             <p className="mt-1 text-sm text-slate-400">Switch between Arcade, Chill, Focus, and Party, plus sound and accessibility preferences.</p>
           </div>
-          <Link className="text-sm font-black text-[#ffba08] hover:text-white" to="/preferences" onClick={() => window.localStorage.setItem(welcomeKey(user.id), "1")}>Open Settings →</Link>
+          <Link className="text-sm font-black text-[#ffba08] hover:text-white" to="/preferences" onClick={() => window.localStorage.setItem(welcomeKey(signedInUser.id), "1")}>Open Settings →</Link>
         </div>
 
         <div className="mt-7 flex flex-wrap gap-3">


### PR DESCRIPTION
## What changed

Turns reviewer feedback into a focused onboarding/discoverability pass.

### Public experience
- Simplifies the marketing page to one value proposition, one tiny demo CTA, and one account CTA.
- Adds `/demo` as a short Question → Hint → Reveal → XP taste with no account required.
- Removes Library, Arcade, Quest Rooms, Deck Lab, Deck Map, Docs, and experience controls from signed-out navigation.
- Gates the full Study page and all major product surfaces behind authentication.
- Direct visits to gated routes preserve the intended destination through signup/login.

### Post-signup experience
- Adds `/welcome` as a first-login Welcome Quest that introduces Play, Arcade, Library, Quest Rooms, Create, and Settings only after authentication.
- Returning users skip Welcome Quest after it has been seen and land on Study.
- Explicit deep-link intent still wins, so a user who signs up for `/rooms` or `/library` lands where they intended.

### Navigation clarity
- Signed-out nav is only Try demo, Sign in, Create account.
- Signed-in nav expands to Play, Arcade, Library, Quest Rooms, Deck Lab, My Decks, and Deck Map.
- Replaces the ambiguous sliders affordance with `⚙️ Settings`.
- Keeps Docs out of the public marketing header.

### Signup copy
- Simplifies signup messaging so it stops re-listing the product before onboarding.

### Docs
- Adds `docs/ONBOARDING_FLOW.md` to capture the product boundary.

This is frontend/docs only; no backend, schema, Study engine, Arcade runtime, or Quest Room protocol changes.