### PR TITLE
Add signed-in plan tiers and two-minute demo expiry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Library from "./pages/Library";
 import LibraryDeck from "./pages/LibraryDeck";
 import Login from "./pages/Login";
 import MyDecks from "./pages/MyDecks";
+import Plans from "./pages/Plans";
 import Preferences from "./pages/Preferences";
 import Room from "./pages/Room";
 import RoomInvite from "./pages/RoomInvite";
@@ -116,6 +117,7 @@ function Shell() {
           <Route path="/decks" element={<RequireAccount><MyDecks /></RequireAccount>} />
           <Route path="/status" element={<RequireAccount><Status /></RequireAccount>} />
           <Route path="/preferences" element={<RequireAccount><Preferences /></RequireAccount>} />
+          <Route path="/plans" element={<RequireAccount><Plans /></RequireAccount>} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/verify-email" element={<VerifyEmail />} />

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -10,6 +10,10 @@ import {
 import { getAccessToken, getMe, login as apiLogin, logout as apiLogout } from "./api";
 import type { LoginPayload, UserRead } from "./types";
 
+export const DEMO_ACCOUNT_EMAIL = "demo@flashquest.app";
+const DEMO_SESSION_STARTED_KEY = "flashquest-demo-auth-started-at";
+const DEMO_SESSION_MS = 2 * 60 * 1000;
+
 type AuthValue = {
   user: UserRead | null;
   loading: boolean;
@@ -19,6 +23,20 @@ type AuthValue = {
 };
 
 const AuthContext = createContext<AuthValue | null>(null);
+
+function clearDemoSessionState(userId?: number) {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.removeItem(DEMO_SESSION_STARTED_KEY);
+  if (userId != null) {
+    window.localStorage.removeItem(`flashquest-welcome-seen:${userId}`);
+  }
+
+  for (let index = window.sessionStorage.length - 1; index >= 0; index -= 1) {
+    const key = window.sessionStorage.key(index);
+    if (key?.startsWith("flashquest-")) window.sessionStorage.removeItem(key);
+  }
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<UserRead | null>(null);
@@ -45,14 +63,54 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signIn = useCallback(async (payload: LoginPayload): Promise<UserRead> => {
     const response = await apiLogin(payload);
+    if (response.user.email.toLowerCase() === DEMO_ACCOUNT_EMAIL) {
+      window.localStorage.setItem(DEMO_SESSION_STARTED_KEY, String(Date.now()));
+    }
     setUser(response.user);
     return response.user;
   }, []);
 
   const signOut = useCallback(async () => {
-    await apiLogout();
-    setUser(null);
-  }, []);
+    const signedOutUser = user;
+    try {
+      await apiLogout();
+    } catch {
+      // apiLogout clears the local token in its finally block; local sign-out still completes.
+    } finally {
+      if (signedOutUser?.email.toLowerCase() === DEMO_ACCOUNT_EMAIL) {
+        clearDemoSessionState(signedOutUser.id);
+      }
+      setUser(null);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!user || user.email.toLowerCase() !== DEMO_ACCOUNT_EMAIL) return;
+
+    const rawStartedAt = window.localStorage.getItem(DEMO_SESSION_STARTED_KEY);
+    const parsedStartedAt = rawStartedAt ? Number(rawStartedAt) : Number.NaN;
+    const startedAt = Number.isFinite(parsedStartedAt) ? parsedStartedAt : Date.now();
+    if (!Number.isFinite(parsedStartedAt)) {
+      window.localStorage.setItem(DEMO_SESSION_STARTED_KEY, String(startedAt));
+    }
+
+    const remainingMs = Math.max(0, DEMO_SESSION_MS - (Date.now() - startedAt));
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          await apiLogout();
+        } catch {
+          // The API helper still clears the browser token on failure.
+        } finally {
+          clearDemoSessionState(user.id);
+          setUser(null);
+          window.location.replace("/");
+        }
+      })();
+    }, remainingMs);
+
+    return () => window.clearTimeout(timer);
+  }, [user]);
 
   const value = useMemo(
     () => ({ user, loading, signIn, signOut, refresh }),

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,22 +1,45 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 
+const demoCards = [
+  {
+    question: "What is 1 + 1?",
+    hint: "Start with one thing, then add one more.",
+    answer: "2",
+    detail: "One plus one equals two. The point here is the FlashQuest loop, not a difficult question.",
+  },
+  {
+    question: "What kind of snack is commonly dunked in milk?",
+    hint: "Think round, sweet, and often found in a cookie jar.",
+    answer: "A cookie",
+    detail: "Cookies are commonly dunked in milk. FlashQuest can use the same simple recall loop for any subject you choose later.",
+  },
+] as const;
+
 export default function Demo() {
+  const [cardIndex, setCardIndex] = useState(0);
   const [showHint, setShowHint] = useState(false);
   const [revealed, setRevealed] = useState(false);
+  const card = demoCards[cardIndex];
+
+  function nextCard() {
+    setCardIndex((current) => (current + 1) % demoCards.length);
+    setShowHint(false);
+    setRevealed(false);
+  }
 
   return (
     <div className="mx-auto max-w-2xl py-6 sm:py-10">
       <section className="quest-card p-6 sm:p-8">
         <div className="relative z-10">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">⚡ 60-second demo</span>
+            <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">⚡ Tiny demo</span>
             <span className="text-xs font-bold text-slate-500">No account needed</span>
           </div>
 
           <p className="mt-8 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Your question</p>
           <h1 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">
-            A Linux process is listening on a port, but another machine cannot reach it. What would you check first?
+            {card.question}
           </h1>
 
           {!revealed && (
@@ -40,26 +63,31 @@ export default function Demo() {
 
           {showHint && !revealed && (
             <div className="mt-5 rounded-2xl border border-violet-400/25 bg-violet-400/[0.08] p-4 text-sm leading-6 text-violet-100">
-              <b>Hint:</b> Separate “is the app listening?” from “can traffic reach it?” Think bind address, host firewall, and the network path.
+              <b>Hint:</b> {card.hint}
             </div>
           )}
 
           {revealed && (
             <div className="mt-7 grid gap-4">
               <div className="rounded-2xl border border-cyan-400/25 bg-cyan-400/[0.08] p-4">
-                <p className="text-xs font-black uppercase tracking-[0.15em] text-cyan-300">TL;DR</p>
-                <p className="mt-2 text-sm leading-6 text-cyan-50">Check the bind address, host firewall, and whether the port is reachable from the remote network.</p>
+                <p className="text-xs font-black uppercase tracking-[0.15em] text-cyan-300">Answer</p>
+                <p className="mt-2 text-xl font-black text-cyan-50">{card.answer}</p>
               </div>
               <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm leading-6 text-slate-300">
-                Confirm the process is listening on the expected interface (not only localhost), inspect firewall rules, then test the path with tools such as <code>ss</code>, <code>curl</code>, or <code>nc</code>. FlashQuest turns that recall loop into repeatable study, games, and collaborative practice after you create an account.
+                {card.detail}
               </div>
               <div className="rounded-2xl border border-[#ffba08]/25 bg-[#ffba08]/[0.08] p-5 text-center">
                 <div className="text-3xl">✨ +10 XP</div>
-                <h2 className="mt-2 text-xl font-black text-white">That’s the loop.</h2>
-                <p className="mt-2 text-sm text-slate-400">Create an account to save progress and unlock the full FlashQuest experience.</p>
-                <Link className="game-button mt-5 inline-flex bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/signup">
-                  Create free account →
-                </Link>
+                <h2 className="mt-2 text-xl font-black text-white">That’s the idea.</h2>
+                <p className="mt-2 text-sm text-slate-400">Question. Hint if you want it. Reveal. Remember. Your account adds the bigger FlashQuest experience afterward.</p>
+                <div className="mt-5 flex flex-wrap justify-center gap-3">
+                  <button type="button" className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white" onClick={nextCard}>
+                    Try another easy one
+                  </button>
+                  <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/signup">
+                    Create free account →
+                  </Link>
+                </div>
               </div>
             </div>
           )}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { DEMO_ACCOUNT_EMAIL, useAuth } from "../auth";
-
-const DEMO_PASSWORD = "QuestRoomDemo!";
+import { useAuth } from "../auth";
 
 function welcomeKey(userId: number) {
   return `flashquest-welcome-seen:${userId}`;
@@ -22,13 +20,13 @@ export default function Login() {
   const safeQueryNext = queryNext?.startsWith("/") ? queryNext : null;
   const explicitNext = stateNext ?? safeQueryNext;
 
-  async function loginWith(credentials: { email: string; password: string }, forcedDestination?: string) {
+  async function loginWith(credentials: { email: string; password: string }) {
     setLoading(true);
     setError(null);
     try {
       const signedInUser = await signIn(credentials);
       const hasSeenWelcome = window.localStorage.getItem(welcomeKey(signedInUser.id)) === "1";
-      const destination = forcedDestination ?? explicitNext ?? (hasSeenWelcome ? "/study" : "/welcome");
+      const destination = explicitNext ?? (hasSeenWelcome ? "/study" : "/welcome");
       navigate(destination, { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not sign in");
@@ -43,34 +41,11 @@ export default function Login() {
   }
 
   return (
-    <div className="mx-auto grid max-w-xl gap-5 py-6 sm:py-10">
-      <section className="game-panel border-[#faa307]/30 p-5 sm:p-6">
-        <p className="metric-label">👥 Quest Rooms demo</p>
-        <h2 className="mt-2 text-2xl font-black text-white">Want to see the chat rooms right now?</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-400">
-          Use the sandbox account below. It opens a private demo room with realtime chat and multiplayer Arcade, but it cannot create decks or new rooms.
-        </p>
-        <p className="mt-3 rounded-xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-3 text-xs font-bold leading-5 text-[#ffba08]">
-          Demo sessions automatically sign out and reset after 2 minutes.
-        </p>
-        <div className="mt-4 grid gap-2 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm sm:grid-cols-2">
-          <div><span className="text-slate-500">Demo email</span><p className="mt-1 font-black text-white">{DEMO_ACCOUNT_EMAIL}</p></div>
-          <div><span className="text-slate-500">Password</span><p className="mt-1 font-black text-white">{DEMO_PASSWORD}</p></div>
-        </div>
-        <button
-          type="button"
-          className="game-button mt-4 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
-          disabled={loading}
-          onClick={() => void loginWith({ email: DEMO_ACCOUNT_EMAIL, password: DEMO_PASSWORD }, "/rooms")}
-        >
-          {loading ? "Entering demo…" : "👥 Enter the Demo Room"}
-        </button>
-      </section>
-
+    <div className="mx-auto max-w-xl py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
         <p className="metric-label">Welcome back</p>
         <h1 className="mt-2 text-3xl font-black text-white">Sign in to FlashQuest</h1>
-        <p className="mt-2 text-sm text-slate-400">Your decks, progress, and Quest Room memberships stay tied to your verified account.</p>
+        <p className="mt-2 text-sm text-slate-400">Pick up your decks, progress, and Quest Rooms where you left off.</p>
         <div className="mt-6 grid gap-4">
           <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
             <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { useAuth } from "../auth";
+import { DEMO_ACCOUNT_EMAIL, useAuth } from "../auth";
 
-const DEMO_EMAIL = "demo@flashquest.app";
 const DEMO_PASSWORD = "QuestRoomDemo!";
 
 function welcomeKey(userId: number) {
@@ -51,15 +50,18 @@ export default function Login() {
         <p className="mt-2 text-sm leading-6 text-slate-400">
           Use the sandbox account below. It opens a private demo room with realtime chat and multiplayer Arcade, but it cannot create decks or new rooms.
         </p>
+        <p className="mt-3 rounded-xl border border-[#faa307]/20 bg-[#faa307]/[0.07] p-3 text-xs font-bold leading-5 text-[#ffba08]">
+          Demo sessions automatically sign out and reset after 2 minutes.
+        </p>
         <div className="mt-4 grid gap-2 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm sm:grid-cols-2">
-          <div><span className="text-slate-500">Demo email</span><p className="mt-1 font-black text-white">{DEMO_EMAIL}</p></div>
+          <div><span className="text-slate-500">Demo email</span><p className="mt-1 font-black text-white">{DEMO_ACCOUNT_EMAIL}</p></div>
           <div><span className="text-slate-500">Password</span><p className="mt-1 font-black text-white">{DEMO_PASSWORD}</p></div>
         </div>
         <button
           type="button"
           className="game-button mt-4 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
           disabled={loading}
-          onClick={() => void loginWith({ email: DEMO_EMAIL, password: DEMO_PASSWORD }, "/rooms")}
+          onClick={() => void loginWith({ email: DEMO_ACCOUNT_EMAIL, password: DEMO_PASSWORD }, "/rooms")}
         >
           {loading ? "Entering demo…" : "👥 Enter the Demo Room"}
         </button>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -1,0 +1,108 @@
+const plans = [
+  {
+    name: "Free",
+    price: "$0",
+    cadence: "forever",
+    badge: "Core learning",
+    summary: "Everything needed to learn, build a deck, and study with the community.",
+    features: [
+      "Official decks and durable study progress",
+      "Library browsing and community decks",
+      "Solo Arcade games",
+      "Create, remix, and publish decks",
+      "Public Quest Rooms",
+    ],
+  },
+  {
+    name: "Pro",
+    price: "$7.99",
+    cadence: "/ month",
+    badge: "Planned",
+    summary: "Power features for learners who want deeper progress insight and more private control.",
+    features: [
+      "Everything in Free",
+      "Advanced progress and mastery analytics",
+      "More private and invite-only room capacity",
+      "Larger Quest Rooms",
+      "Priority access to future power workflows",
+    ],
+    featured: true,
+  },
+  {
+    name: "Educator",
+    price: "$19.99",
+    cadence: "/ month",
+    badge: "Planned",
+    summary: "Teaching and cohort tools for instructors, tutors, and study-group leaders.",
+    features: [
+      "Everything in Pro",
+      "Multiple learner groups and cohorts",
+      "Educator-facing progress views",
+      "Expanded room and deck organization",
+      "Future assignment and classroom workflows",
+    ],
+  },
+] as const;
+
+export default function Plans() {
+  return (
+    <div className="mx-auto grid max-w-6xl gap-7">
+      <section>
+        <p className="metric-label">💳 Plans</p>
+        <h1 className="mt-2 text-4xl font-black tracking-tight text-white sm:text-5xl">
+          Start free. <span className="ember-text">Upgrade when it earns it.</span>
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
+          Core learning stays free. Paid tiers are reserved for power features, larger private collaboration, and educator workflows.
+        </p>
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {plans.map((plan) => (
+          <article
+            key={plan.name}
+            className={`game-panel flex h-full flex-col p-6 ${plan.featured ? "border-[#faa307]/45 bg-[#faa307]/[0.055]" : ""}`}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.14em] text-[#ffba08]">{plan.badge}</p>
+                <h2 className="mt-2 text-2xl font-black text-white">{plan.name}</h2>
+              </div>
+              {plan.name === "Free" && <span className="game-chip px-3 py-1 text-xs font-black text-slate-300">Current</span>}
+            </div>
+
+            <div className="mt-5 flex items-end gap-2">
+              <span className="text-4xl font-black text-white">{plan.price}</span>
+              <span className="pb-1 text-sm font-bold text-slate-500">{plan.cadence}</span>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-slate-400">{plan.summary}</p>
+
+            <ul className="mt-5 grid flex-1 gap-3 text-sm text-slate-300">
+              {plan.features.map((feature) => (
+                <li key={feature} className="flex gap-2">
+                  <span className="text-[#faa307]" aria-hidden="true">✓</span>
+                  <span>{feature}</span>
+                </li>
+              ))}
+            </ul>
+
+            <button
+              type="button"
+              disabled
+              className="game-button mt-6 w-full border border-white/10 bg-white/[0.04] px-4 py-3 text-sm font-black text-slate-400 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {plan.name === "Free" ? "Free plan active" : "Checkout coming soon"}
+            </button>
+          </article>
+        ))}
+      </div>
+
+      <section className="game-panel p-5 sm:p-6">
+        <p className="font-black text-white">Billing is not enabled yet.</p>
+        <p className="mt-2 text-sm leading-6 text-slate-400">
+          These are planned launch prices, not an active subscription offer. FlashQuest will only enable checkout after plan entitlements and billing are wired and tested end to end.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -12,6 +12,7 @@ const plans = [
       "Create, remix, and publish decks",
       "Public Quest Rooms",
     ],
+    featured: false,
   },
   {
     name: "Pro",
@@ -41,6 +42,7 @@ const plans = [
       "Expanded room and deck organization",
       "Future assignment and classroom workflows",
     ],
+    featured: false,
   },
 ] as const;
 

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useExperience } from "../experienceContext";
 import { useGameFeel } from "../gameFeelContext";
 import type { LearningMode } from "../experienceContext";
@@ -55,13 +56,24 @@ export default function Preferences() {
   return (
     <div className="mx-auto grid max-w-5xl gap-6">
       <section>
-        <p className="metric-label">🎚️ Experience settings</p>
+        <p className="metric-label">⚙️ Settings</p>
         <h1 className="mt-2 text-4xl font-black tracking-tight text-white sm:text-5xl">
           Learn your way <span className="ember-text">right now.</span>
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400 sm:text-base">
           These are presentation preferences, not permanent learner labels. Switch whenever the subject, environment, or your mood changes — your decks and mastery stay the same.
         </p>
+      </section>
+
+      <section className="game-panel grid gap-4 p-5 sm:p-6 lg:grid-cols-[1fr_auto] lg:items-center">
+        <div>
+          <p className="metric-label">Plans & billing</p>
+          <h2 className="mt-1 text-xl font-black text-white">Free now. Power tiers when you need more.</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-400">See the planned Free, Pro, and Educator tiers. Checkout is not enabled yet.</p>
+        </div>
+        <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/plans">
+          View plans →
+        </Link>
       </section>
 
       <section className="game-panel p-5 sm:p-6">

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { resendVerification, signup } from "../api";
+import { DEMO_ACCOUNT_EMAIL, useAuth } from "../auth";
+
+const DEMO_PASSWORD = "QuestRoomDemo!";
 
 export default function Signup() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { signIn } = useAuth();
   const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -11,6 +16,8 @@ export default function Signup() {
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [demoLoading, setDemoLoading] = useState(false);
+  const [demoError, setDemoError] = useState<string | null>(null);
 
   const requestedNext = new URLSearchParams(location.search).get("next");
   const safeNext = requestedNext?.startsWith("/") ? requestedNext : null;
@@ -29,6 +36,19 @@ export default function Signup() {
       setError(e instanceof Error ? e.message : "Could not create account");
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function enterDemoRoom() {
+    setDemoLoading(true);
+    setDemoError(null);
+    try {
+      await signIn({ email: DEMO_ACCOUNT_EMAIL, password: DEMO_PASSWORD });
+      navigate("/rooms", { replace: true });
+    } catch (e) {
+      setDemoError(e instanceof Error ? e.message : "Could not enter the demo room");
+    } finally {
+      setDemoLoading(false);
     }
   }
 
@@ -70,7 +90,7 @@ export default function Signup() {
   }
 
   return (
-    <div className="mx-auto max-w-xl py-6 sm:py-10">
+    <div className="mx-auto grid max-w-xl gap-5 py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
         <p className="metric-label">{joiningRooms ? "👥 Join Quest Rooms" : "Continue your quest"}</p>
         <h1 className="mt-2 text-3xl font-black text-white">Create your FlashQuest account</h1>
@@ -103,6 +123,23 @@ export default function Signup() {
         <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : joiningRooms ? "Create account for Quest Rooms →" : "Create account →"}</button>
         <p className="mt-5 text-center text-sm text-slate-500">Already verified? <Link className="font-bold text-[#faa307]" to={loginTarget}>Sign in</Link></p>
       </form>
+
+      <section className="game-panel border-[#faa307]/25 p-5 sm:p-6">
+        <p className="metric-label">👀 Want to look around first?</p>
+        <h2 className="mt-2 text-xl font-black text-white">Enter the Demo Room</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-400">
+          See realtime chat and the signed-in room experience without creating an account yet. Demo sessions reset automatically after 2 minutes.
+        </p>
+        {demoError && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{demoError}</p>}
+        <button
+          type="button"
+          className="game-button mt-4 w-full border border-[#faa307]/35 bg-[#faa307]/10 px-5 py-3 font-black text-[#ffba08]"
+          disabled={demoLoading}
+          onClick={() => void enterDemoRoom()}
+        >
+          {demoLoading ? "Entering demo…" : "👥 Enter Demo Room"}
+        </button>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## What changed

Adds a signed-in monetization surface, hardens the shared demo-account lifecycle, and makes the visitor demo easier to understand.

### Plans
- Adds `/plans` behind authentication.
- Adds planned launch tiers: Free ($0), Pro ($7.99/month), Educator ($19.99/month).
- Keeps checkout disabled and labels paid pricing as planned until billing/entitlements are wired end to end.
- Keeps core learning on Free.
- Adds a Plans & billing entry point inside `⚙️ Settings`, not the public marketing navigation.

### Public demo clarity
- Replaces the engineering-specific Linux example with intentionally easy, universal demo cards such as `1 + 1` and a cookie/milk question.
- Keeps the demo focused on teaching the FlashQuest interaction loop rather than testing subject knowledge.
- Lets visitors try another easy example after Reveal.

### Demo Room placement
- Removes the Demo Room shortcut from the returning-user Sign In page.
- Adds `Enter Demo Room` to Create Account as a `Want to look around first?` option.
- Keeps the Demo Room one-click and routes directly to Quest Rooms.

### Demo account lifecycle
- `demo@flashquest.app` receives a 2-minute authenticated session window.
- The timer persists across refreshes so reloads do not extend the demo session.
- On expiry FlashQuest calls the existing server logout endpoint, clears the local auth token through the existing API helper, clears demo-specific/transient FlashQuest browser session state, and reloads to the public landing page.
- Manual demo sign-out also clears the demo session timestamp/transient state.
- Create Account warns that Demo Room sessions automatically sign out and reset after 2 minutes.

### Scope
Frontend only. No payment processor, billing tables, backend entitlement enforcement, Study engine, Arcade runtime, or Quest Room protocol changes.

Part of #20.