### PR TITLE
Redesign Quest Rooms as a focused channel workspace

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,9 +44,7 @@ function Shell() {
         { to: "/arcade", icon: "🎮", label: "Arcade" },
         { to: "/library", icon: "📚", label: "Library" },
         { to: "/rooms", icon: "👥", label: "Quest Rooms" },
-        { to: "/deck-lab", icon: "🧪", label: "Deck Lab" },
         { to: "/decks", icon: "🗂️", label: "My Decks" },
-        { to: "/status", icon: "🗺️", label: "Deck Map" },
       ]
     : [{ to: "/demo", icon: "⚡", label: "Try demo" }];
 
@@ -55,19 +53,22 @@ function Shell() {
       <div className="game-grid" aria-hidden="true" />
 
       <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 lg:flex-row lg:items-center lg:justify-between sm:px-6">
-          <NavLink to={user ? "/study" : "/"} className="group flex items-center gap-3">
-            <div className="grid h-11 w-11 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">🧠</div>
-            <div>
-              <div className="flex items-center gap-2"><span className="text-lg font-black tracking-tight text-white">FlashQuest</span><span className="rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.16em] text-[#ffba08]">Quest Mode</span></div>
+        <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+          <NavLink to={user ? "/study" : "/"} className="group flex min-w-0 items-center gap-3">
+            <div className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">🧠</div>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-lg font-black tracking-tight text-white">FlashQuest</span>
+                <span className="whitespace-nowrap rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.12em] leading-none text-[#ffba08]">Quest Mode</span>
+              </div>
               <p className="text-xs font-medium text-slate-400">Any topic. One memory engine.</p>
             </div>
           </NavLink>
 
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center justify-start gap-2 lg:justify-end">
             <nav className="flex flex-wrap gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
               {navItems.map((item) => (
-                <NavLink key={`${item.to}-${item.label}`} to={item.to} className={({ isActive }) => ["flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
+                <NavLink key={`${item.to}-${item.label}`} to={item.to} className={({ isActive }) => ["flex items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
                   <span aria-hidden="true">{item.icon}</span><span>{item.label}</span>
                 </NavLink>
               ))}
@@ -75,6 +76,18 @@ function Shell() {
 
             {user ? (
               <>
+                <NavLink
+                  to="/deck-lab"
+                  className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
+                >
+                  <span aria-hidden="true">🧪</span><span>Deck Lab</span>
+                </NavLink>
+                <NavLink
+                  to="/status"
+                  className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black 2xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
+                >
+                  <span aria-hidden="true">🗺️</span><span>Deck Map</span>
+                </NavLink>
                 <SoundToggle />
                 <NavLink
                   to="/preferences"
@@ -82,11 +95,11 @@ function Shell() {
                   title="Settings"
                   className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
                 >
-                  <span aria-hidden="true">⚙️</span><span className="hidden xl:inline">Settings</span>
+                  <span aria-hidden="true">⚙️</span><span className="hidden 2xl:inline">Settings</span>
                 </NavLink>
-                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button hidden items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] xl:flex">📖 Docs</a>
+                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button hidden items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] 2xl:flex">📖 Docs</a>
                 <div className="flex items-center gap-2">
-                  <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 sm:inline">👋 {user.display_name}</span>
+                  <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 2xl:inline">👋 {user.display_name}</span>
                   <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
                 </div>
               </>
@@ -100,7 +113,7 @@ function Shell() {
         </div>
       </header>
 
-      <main key={location.pathname} className="game-page-enter relative z-10 mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+      <main key={location.pathname} className="game-page-enter relative z-10 mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 sm:py-10">
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/demo" element={<Demo />} />
@@ -125,7 +138,7 @@ function Shell() {
         </Routes>
       </main>
 
-      <footer className="relative z-10 mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
+      <footer className="relative z-10 mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
         <span>{user ? "Learn · play · create · study together" : "Try the memory loop. Create an account when you want the full experience."}</span>
         {user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">Docs ↗</a>}
       </footer>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -167,6 +167,79 @@ select.game-input option { background: var(--ink-black); color: white; }
   text-transform: uppercase;
 }
 
+/* Quest Room workspace: intentionally lighter than the rest of the app so chat feels calm and readable. */
+.quest-room-workspace {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #d8dee8;
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(148, 163, 184, .11), transparent 20rem),
+    radial-gradient(circle at 86% 82%, rgba(203, 213, 225, .22), transparent 21rem),
+    #f8fafc;
+  color: #172033;
+  box-shadow: 0 28px 80px rgba(3, 7, 30, .32);
+}
+
+.quest-room-workspace::before,
+.quest-room-workspace::after {
+  position: absolute;
+  z-index: 0;
+  color: rgba(100, 116, 139, .11);
+  font-size: 8rem;
+  line-height: 1;
+  pointer-events: none;
+}
+.quest-room-workspace::before { content: "📚"; left: 8%; top: 24%; transform: rotate(-10deg); filter: grayscale(1); }
+.quest-room-workspace::after { content: "📖"; right: 8%; bottom: 8%; transform: rotate(8deg); filter: grayscale(1); }
+
+.quest-room-workspace > * { position: relative; z-index: 1; }
+
+.quest-room-sidebar {
+  border-right: 1px solid #d8dee8;
+  background: rgba(241, 245, 249, .94);
+}
+
+.quest-room-channel {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  width: 100%;
+  border-radius: .7rem;
+  padding: .55rem .7rem;
+  color: #526076;
+  font-size: .82rem;
+  font-weight: 800;
+  text-align: left;
+  transition: background var(--motion-fast) ease, color var(--motion-fast) ease;
+}
+.quest-room-channel:hover { background: #e8edf4; color: #182033; }
+.quest-room-channel.is-active { background: #ffffff; color: #111827; box-shadow: 0 1px 2px rgba(15, 23, 42, .07); }
+
+.quest-room-chat-surface {
+  background: rgba(255, 255, 255, .95);
+  color: #1e293b;
+}
+
+.quest-room-chat-message {
+  border-bottom: 1px solid #eef2f7;
+  padding: .85rem 1rem;
+}
+.quest-room-chat-message:hover { background: #f8fafc; }
+.quest-room-chat-message strong { color: #111827; }
+.quest-room-chat-message small { color: #94a3b8; }
+.quest-room-chat-message p { color: #334155; }
+
+.quest-room-composer {
+  border: 1px solid #cbd5e1;
+  border-radius: .9rem;
+  background: #fff;
+  color: #111827;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, .04);
+}
+.quest-room-composer::placeholder { color: #94a3b8; }
+.quest-room-composer:focus { border-color: #94a3b8; box-shadow: 0 0 0 3px rgba(148, 163, 184, .16); outline: none; }
+
 .answer-pop { animation: answer-pop .36s cubic-bezier(.2, .9, .3, 1); }
 .wrong-shake { animation: wrong-shake .35s ease; }
 .floaty { animation: floaty 4s ease-in-out infinite; }

--- a/frontend/src/pages/Room.tsx
+++ b/frontend/src/pages/Room.tsx
@@ -22,6 +22,14 @@ import {
 } from "../roomApi";
 
 type ConnectionState = "idle" | "connecting" | "live" | "offline";
+type ChannelKey = "general" | "questions" | "wins" | "resources";
+
+const CHANNELS: Array<{ key: ChannelKey; label: string; icon: string; description: string }> = [
+  { key: "general", label: "general", icon: "#", description: "Main room conversation" },
+  { key: "questions", label: "questions", icon: "?", description: "Ask for help without losing the thread" },
+  { key: "wins", label: "wins", icon: "★", description: "Drop study wins and streak moments" },
+  { key: "resources", label: "resources", icon: "↗", description: "Keep useful links and references together" },
+];
 
 function messageTime(value: string): string {
   const date = new Date(value);
@@ -60,6 +68,20 @@ function roomActivityFrom(value: unknown): RoomActivitySnapshot | null {
   return candidate;
 }
 
+function channelPrefix(channel: ChannelKey): string {
+  if (channel === "general") return "";
+  return `[${channel}] `;
+}
+
+function displayMessageBody(body: string): { channel: ChannelKey; text: string } {
+  for (const channel of CHANNELS) {
+    if (channel.key === "general") continue;
+    const prefix = `[${channel.key}] `;
+    if (body.startsWith(prefix)) return { channel: channel.key, text: body.slice(prefix.length) };
+  }
+  return { channel: "general", text: body };
+}
+
 export default function Room() {
   const { roomId: roomIdParam } = useParams();
   const roomId = Number(roomIdParam || 0);
@@ -74,6 +96,7 @@ export default function Room() {
   const [activity, setActivity] = useState<RoomActivitySnapshot | null>(null);
   const [connection, setConnection] = useState<ConnectionState>("idle");
   const [draft, setDraft] = useState("");
+  const [activeChannel, setActiveChannel] = useState<ChannelKey>("general");
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -99,9 +122,7 @@ export default function Room() {
     (event: RoomRealtimeEvent) => {
       if (event.type === "room.snapshot") {
         const nextMessages = event.payload.messages;
-        if (Array.isArray(nextMessages)) {
-          setMessages(nextMessages.filter(isMessage));
-        }
+        if (Array.isArray(nextMessages)) setMessages(nextMessages.filter(isMessage));
         setPresence(presenceFrom(event.payload.presence));
         setActivity(roomActivityFrom(event.payload.activity));
         return;
@@ -197,17 +218,13 @@ export default function Room() {
         }
       };
       socket.onerror = () => {
-        if (socketRef.current === socket) {
-          setError("Realtime connection hit a network error");
-        }
+        if (socketRef.current === socket) setError("Realtime connection hit a network error");
       };
       socket.onclose = (closeEvent) => {
         if (socketRef.current === socket) {
           socketRef.current = null;
           setConnection("offline");
-          if (closeEvent.code === 4403) {
-            navigate("/rooms", { replace: true });
-          }
+          if (closeEvent.code === 4403) navigate("/rooms", { replace: true });
         }
       };
     } catch (cause) {
@@ -217,9 +234,7 @@ export default function Room() {
   }, [handleRealtimeEvent, navigate, room, roomId, user]);
 
   useEffect(() => {
-    if (room?.current_user_role && room.status === "open") {
-      void connectRealtime();
-    }
+    if (room?.current_user_role && room.status === "open") void connectRealtime();
     return () => {
       socketRef.current?.close();
       socketRef.current = null;
@@ -308,13 +323,11 @@ export default function Room() {
     event.preventDefault();
     const body = draft.trim();
     if (!body) return;
-    sendRoomEvent("chat.send", { body });
+    sendRoomEvent("chat.send", { body: `${channelPrefix(activeChannel)}${body}` });
     setDraft("");
   }
 
-  if (!room && busy) {
-    return <div className="game-panel p-8 text-center text-slate-300">Opening Quest Room…</div>;
-  }
+  if (!room && busy) return <div className="game-panel p-8 text-center text-slate-300">Opening Quest Room…</div>;
 
   if (!room) {
     return (
@@ -331,12 +344,9 @@ export default function Room() {
 
   const isMember = Boolean(room.current_user_role);
   const isHost = room.current_user_role === "host";
-  const connectionLabel =
-    connection === "live"
-      ? "🟢 Live"
-      : connection === "connecting"
-        ? "🟡 Connecting"
-        : "⚪ Offline";
+  const connectionLabel = connection === "live" ? "Live" : connection === "connecting" ? "Connecting" : "Offline";
+  const activeChannelMeta = CHANNELS.find((channel) => channel.key === activeChannel) ?? CHANNELS[0];
+  const visibleMessages = messages.filter((message) => displayMessageBody(message.body).channel === activeChannel);
 
   return (
     <div className="grid gap-5">
@@ -349,47 +359,28 @@ export default function Room() {
               <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{room.status}</span>
             </div>
             <h1 className="mt-3 text-3xl font-black text-white sm:text-4xl">{room.name}</h1>
-            <p className="mt-2 text-sm text-slate-400">
-              Deck #{room.deck_id} · {room.member_count} member{room.member_count === 1 ? "" : "s"}
-            </p>
+            <p className="mt-2 text-sm text-slate-400">Deck #{room.deck_id} · {room.member_count} member{room.member_count === 1 ? "" : "s"}</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {room.visibility === "public" && (
               <button type="button" onClick={() => void copyRoomLink()} className="game-button game-chip px-3 py-2 text-xs font-black text-slate-200">
-                {copied ? "✅ Copied" : "🔗 Copy public room link"}
+                {copied ? "✅ Copied" : "🔗 Copy room link"}
               </button>
             )}
-            <Link to={`/study?deck=${room.deck_id}`} className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white">
-              ⚡ Study deck
-            </Link>
-            <Link to={`/arcade?deck=${room.deck_id}`} className="game-button border border-[#faa307]/25 bg-[#370617]/60 px-3 py-2 text-xs font-black text-[#ffba08]">
-              🎮 Solo Arcade
-            </Link>
+            <Link to={`/study?deck=${room.deck_id}`} className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white">⚡ Study deck</Link>
+            <Link to={`/arcade?deck=${room.deck_id}`} className="game-button border border-[#faa307]/25 bg-[#370617]/60 px-3 py-2 text-xs font-black text-[#ffba08]">🎮 Solo Arcade</Link>
           </div>
         </div>
       </section>
 
-      {error && (
-        <section className="game-panel border-[#d00000]/50 p-4 text-sm text-rose-200">
-          🛡️ {error}
-        </section>
-      )}
+      {error && <section className="game-panel border-[#d00000]/50 p-4 text-sm text-rose-200">🛡️ {error}</section>}
 
       {!isMember && room.status === "open" && room.visibility === "public" && (
         <section className="game-panel p-7 text-center">
           <div className="text-4xl">🚪</div>
           <h2 className="mt-3 text-2xl font-black text-white">You found a public Quest Room</h2>
-          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-400">
-            Join to receive live presence, chat, and room Arcade. Membership is persistent; disconnecting your browser does not create or remove membership rows.
-          </p>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void handleJoin()}
-            className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]"
-          >
-            👋 Join room
-          </button>
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-400">Join to receive live presence, chat, and room Arcade.</p>
+          <button type="button" disabled={busy} onClick={() => void handleJoin()} className="game-button mt-5 bg-[#ffba08] px-5 py-3 font-black text-[#370617]">👋 Join room</button>
         </section>
       )}
 
@@ -404,80 +395,125 @@ export default function Room() {
             onSend={sendRoomEvent}
           />
 
-          <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-            <div className="game-panel flex min-h-[520px] flex-col overflow-hidden">
-              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
+          <section className="quest-room-workspace grid min-h-[650px] lg:grid-cols-[230px_minmax(0,1fr)_300px]">
+            <aside className="quest-room-sidebar p-4 sm:p-5">
+              <div className="border-b border-slate-200 pb-4">
+                <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-400">Study session</p>
+                <h2 className="mt-1 truncate text-lg font-black text-slate-900">{room.name}</h2>
+                <p className="mt-1 text-xs font-semibold text-slate-500">Deck #{room.deck_id}</p>
+              </div>
+
+              <div className="mt-4">
+                <div className="mb-2 flex items-center justify-between px-2">
+                  <span className="text-[11px] font-black uppercase tracking-[0.12em] text-slate-400">Channels</span>
+                  <span className="text-xs font-black text-slate-400">+</span>
+                </div>
+                <div className="space-y-1">
+                  {CHANNELS.map((channel) => (
+                    <button
+                      key={channel.key}
+                      type="button"
+                      className={`quest-room-channel ${activeChannel === channel.key ? "is-active" : ""}`}
+                      onClick={() => setActiveChannel(channel.key)}
+                    >
+                      <span className="w-4 text-center text-slate-400">{channel.icon}</span>
+                      <span className="truncate">{channel.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-6 rounded-xl border border-slate-200 bg-white/75 p-3">
+                <p className="text-[11px] font-black uppercase tracking-[0.12em] text-slate-400">Session tools</p>
+                <Link to={`/study?deck=${room.deck_id}`} className="mt-3 block text-sm font-black text-slate-700 hover:text-slate-950">⚡ Focus study</Link>
+                <Link to={`/arcade?deck=${room.deck_id}`} className="mt-2 block text-sm font-black text-slate-700 hover:text-slate-950">🎮 Start Arcade</Link>
+                <button type="button" onClick={() => void copyRoomLink()} className="mt-2 block text-left text-sm font-black text-slate-700 hover:text-slate-950">🔗 Invite people</button>
+              </div>
+            </aside>
+
+            <div className="quest-room-chat-surface flex min-h-[650px] flex-col">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-5 py-4">
                 <div>
-                  <p className="text-sm font-black text-white">💬 Room chat</p>
-                  <p className="mt-0.5 text-xs text-slate-500">Chat stays live while the room plays.</p>
+                  <div className="flex items-center gap-2">
+                    <span className="text-lg font-black text-slate-400">{activeChannelMeta.icon}</span>
+                    <h3 className="text-lg font-black text-slate-900">{activeChannelMeta.label}</h3>
+                  </div>
+                  <p className="mt-0.5 text-xs font-medium text-slate-500">{activeChannelMeta.description}</p>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="game-chip px-2.5 py-1 text-xs font-black text-slate-300">{connectionLabel}</span>
+                  <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-black text-slate-600">{connectionLabel}</span>
                   {room.status === "open" && connection === "offline" && (
-                    <button type="button" className="game-button px-2.5 py-1 text-xs font-black text-[#ffba08]" onClick={() => void connectRealtime()}>
-                      Reconnect
-                    </button>
+                    <button type="button" className="text-xs font-black text-slate-700 underline" onClick={() => void connectRealtime()}>Reconnect</button>
                   )}
                 </div>
               </div>
 
-              <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-5" aria-live="polite">
-                {messages.length === 0 ? (
-                  <div className="grid min-h-60 place-items-center text-center text-sm text-slate-500">
-                    <div><div className="text-4xl">🌱</div><p className="mt-3">No messages yet. Somebody gets to be first.</p></div>
+              <div className="flex-1 overflow-y-auto py-2" aria-live="polite">
+                {visibleMessages.length === 0 ? (
+                  <div className="grid min-h-[360px] place-items-center px-6 text-center">
+                    <div>
+                      <div className="text-5xl grayscale opacity-35">📚</div>
+                      <h4 className="mt-4 text-lg font-black text-slate-700">Start the #{activeChannelMeta.label} thread</h4>
+                      <p className="mt-1 max-w-sm text-sm leading-6 text-slate-400">Keep this channel focused so everyone can find the conversation later.</p>
+                    </div>
                   </div>
                 ) : (
-                  messages.map((message) => {
+                  visibleMessages.map((message) => {
                     const mine = message.user_id === user.id;
+                    const parsed = displayMessageBody(message.body);
                     return (
-                      <article key={message.id} className={`max-w-[88%] rounded-2xl border p-3 ${mine ? "ml-auto border-[#faa307]/25 bg-[#faa307]/10" : "border-white/10 bg-black/20"}`}>
-                        <div className="flex flex-wrap items-center gap-2 text-xs">
-                          <strong className={mine ? "text-[#ffba08]" : "text-slate-200"}>{mine ? "You" : message.author_display_name}</strong>
-                          <span className="text-slate-600">{messageTime(message.created_at)}</span>
+                      <article key={message.id} className="quest-room-chat-message">
+                        <div className="flex items-center gap-2 text-xs">
+                          <div className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-xs font-black ${mine ? "bg-amber-100 text-amber-800" : "bg-slate-200 text-slate-700"}`}>
+                            {(mine ? "Y" : message.author_display_name.slice(0, 1)).toUpperCase()}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-baseline gap-2">
+                              <strong className="text-sm">{mine ? "You" : message.author_display_name}</strong>
+                              <small>{messageTime(message.created_at)}</small>
+                            </div>
+                            <p className="mt-1 whitespace-pre-wrap break-words text-sm leading-6">{parsed.text}</p>
+                          </div>
                         </div>
-                        <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">{message.body}</p>
                       </article>
                     );
                   })
                 )}
               </div>
 
-              <form className="border-t border-white/10 p-3 sm:p-4" onSubmit={sendChat}>
+              <form className="border-t border-slate-200 bg-white/95 p-4" onSubmit={sendChat}>
                 <div className="flex gap-2">
                   <label htmlFor="room-chat" className="sr-only">Message room</label>
                   <input
                     id="room-chat"
-                    className="game-input"
+                    className="quest-room-composer w-full px-4 py-3 text-sm"
                     maxLength={1000}
                     value={draft}
                     disabled={connection !== "live" || room.status !== "open"}
-                    placeholder={connection === "live" ? "Message the room…" : "Reconnect to chat…"}
+                    placeholder={connection === "live" ? `Message #${activeChannelMeta.label}` : "Reconnect to chat…"}
                     onChange={(event) => setDraft(event.target.value)}
                   />
-                  <button
-                    type="submit"
-                    disabled={!draft.trim() || connection !== "live" || room.status !== "open"}
-                    className="game-button bg-[#faa307] px-4 font-black text-[#370617]"
-                  >
-                    Send
-                  </button>
+                  <button type="submit" disabled={!draft.trim() || connection !== "live" || room.status !== "open"} className="game-button bg-[#faa307] px-4 font-black text-[#370617]">Send</button>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-3 text-[11px] font-semibold text-slate-400">
+                  <span>Enter to send</span><span>Session history stays with the room</span><span>Close session when the study block is over</span>
                 </div>
               </form>
             </div>
 
-            <aside className="grid content-start gap-4">
-              <section className="game-panel p-4">
+            <aside className="grid content-start gap-4 border-l border-slate-200 bg-slate-50/90 p-4 sm:p-5">
+              <section>
                 <div className="flex items-center justify-between gap-2">
-                  <p className="metric-label">Online now</p>
-                  <span className="game-chip px-2 py-0.5 text-xs font-black text-slate-300">{presence.length}</span>
+                  <p className="text-xs font-black uppercase tracking-[0.12em] text-slate-400">Online now</p>
+                  <span className="rounded-full bg-white px-2 py-0.5 text-xs font-black text-slate-600 shadow-sm">{presence.length}</span>
                 </div>
                 <div className="mt-3 space-y-2">
                   {presence.length === 0 ? (
-                    <p className="text-sm text-slate-500">Presence is offline.</p>
+                    <p className="text-sm text-slate-400">Presence is offline.</p>
                   ) : (
                     presence.map((person) => (
-                      <div key={person.user_id} className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm font-bold text-slate-200">
-                        <span aria-hidden="true">🟢</span>
+                      <div key={person.user_id} className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-700">
+                        <span aria-hidden="true" className="text-emerald-500">●</span>
                         <span className="truncate">{person.user_id === user.id ? "You" : person.display_name}</span>
                       </div>
                     ))
@@ -485,48 +521,39 @@ export default function Room() {
                 </div>
               </section>
 
-              <RoomAccessPanel
-                room={room}
-                currentUserId={user.id}
-                onMembershipChanged={() => void loadRoom()}
-              />
+              <RoomAccessPanel room={room} currentUserId={user.id} onMembershipChanged={() => void loadRoom()} />
 
-              <section className="game-panel p-4">
-                <p className="metric-label">Room controls</p>
-                <p className="mt-2 text-sm text-slate-400">Role: <strong className="text-slate-200">{room.current_user_role}</strong></p>
+              <section className="rounded-xl border border-slate-200 bg-white p-4">
+                <p className="text-xs font-black uppercase tracking-[0.12em] text-slate-400">Session controls</p>
+                <p className="mt-2 text-sm text-slate-500">Role: <strong className="text-slate-800">{room.current_user_role}</strong></p>
                 {isHost ? (
                   <button
                     type="button"
                     disabled={busy || room.status === "closed"}
                     onClick={() => void handleClose()}
-                    className="game-button mt-4 w-full border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm font-black text-rose-200"
+                    className="game-button mt-4 w-full border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-black text-rose-700"
                   >
-                    🔒 Close room
+                    End study session
                   </button>
                 ) : (
                   <button
                     type="button"
                     disabled={busy}
                     onClick={() => void handleLeave()}
-                    className="game-button mt-4 w-full border border-white/10 bg-white/[0.04] px-3 py-2 text-sm font-black text-slate-200"
+                    className="game-button mt-4 w-full border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-black text-slate-700"
                   >
-                    Leave room
+                    Leave session
                   </button>
                 )}
+                <p className="mt-3 text-xs leading-5 text-slate-400">Ending a session locks new chat and Arcade activity but keeps the room history available as a study record.</p>
               </section>
-
-              <p className="px-2 text-xs leading-5 text-slate-600">
-                Presence and active Arcade runtime are realtime process state; room membership, invites, and messages stay durable in PostgreSQL.
-              </p>
             </aside>
           </section>
         </>
       )}
 
       {room.status === "closed" && (
-        <section className="game-panel p-5 text-center text-slate-300">
-          🔒 This room is closed. Its membership and chat history remain durable, but realtime posting is off.
-        </section>
+        <section className="game-panel p-5 text-center text-slate-300">🔒 This study session has ended. The room history remains available, but realtime posting is off.</section>
       )}
     </div>
   );


### PR DESCRIPTION
## What changed
- redesigns the in-room chat experience into a multi-channel workspace inspired by Slack without copying it
- adds lightweight channels for general, questions, wins, and resources using the existing durable room message stream
- gives hosts a clear **End study session** control while preserving room history
- gives members a **Leave session** action
- changes the chat workspace to a light white/gray surface with subtle grayscale book motifs for calmer reading
- keeps realtime presence, Arcade activity, invites, access controls, and persistent chat intact
- declutters the global navbar by keeping the main study destinations primary and moving lower-frequency tools out of the always-visible row
- fixes the `Quest Mode` badge so the text stays on one line

## Product direction
Quest Rooms should feel like temporary collaborative study spaces: start a session, talk in focused channels, run Arcade, share resources, then end the session while keeping a useful study record.

## Note
The channel UI is implemented on top of the existing room message model by prefixing messages per channel, so this PR avoids a risky backend migration while proving the interaction model first.