### PR TITLE
Add branded Google/GitHub OAuth and full FlashQuest onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="frontend/public/flashquest-logo.svg" alt="FlashQuest logo" width="180" />
+</div>
+
 # FlashQuest’s 🎮🧠
 
 **Learn it. Break it. Fix it. Remember it.**
@@ -36,7 +40,7 @@ Try featured demo
       ↓
 Sign up
       ↓
-Verify email
+Verify email or use Google/GitHub
       ↓
 Sign in
       ↓
@@ -78,20 +82,21 @@ XP/streak presentation is session-local. Durable accounts, decks, cards, mastery
 
 ---
 
-## 🔐 Accounts and email verification
+## 🔐 Accounts and authentication
 
-Custom deck creation requires a verified account.
+FlashQuest supports **Google and GitHub OAuth** as the preferred sign-in paths. Provider-verified accounts skip FlashQuest email verification. Email/password remains available as a fallback and still uses the verification-email flow.
 
 Security boundaries include:
 
 - salted **PBKDF2-HMAC-SHA256** password hashes;
 - high-entropy opaque bearer sessions stored in PostgreSQL **only as SHA-256 hashes**;
+- OAuth `state` validation before provider callbacks are accepted;
 - one-time, expiring email-verification tokens stored only as hashes;
 - private deck/card APIs scoped to the signed-in owner;
 - built-in starter content read-only for normal users;
 - server-side `DEMO_DELETE_PASSWORD` protection for destructive demo maintenance.
 
-Local development uses `EMAIL_DELIVERY_MODE=console`, which prints verification URLs to API logs. Hosted delivery is designed for **Resend**.
+Local development uses `EMAIL_DELIVERY_MODE=console`, which prints verification URLs to API logs. Hosted email/password delivery is designed for **Resend**.
 
 See [Accounts & Email Verification](docs/AUTHENTICATION.md).
 
@@ -140,7 +145,9 @@ React / TypeScript
   ▼
 FastAPI
   │
-  ├── Resend (email verification)
+  ├── Google OAuth
+  ├── GitHub OAuth
+  └── Resend (email verification fallback)
   │
   ▼
 PostgreSQL 16
@@ -233,16 +240,16 @@ The Fly release command runs:
 alembic upgrade head && python -m app.seed
 ```
 
-Before public signup works in hosted `resend` mode, configure at least:
+OAuth production secrets:
 
-```bash
-fly secrets set \
-  RESEND_API_KEY='...' \
-  DEMO_DELETE_PASSWORD='...' \
-  -a flashcards-tobias
+```text
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_SECRET
 ```
 
-Configure `EMAIL_FROM` to a sender accepted by your Resend account.
+Email/password signup can additionally use `RESEND_API_KEY` and a verified `EMAIL_FROM` sender.
 
 **Netlify deploying the frontend does not migrate PostgreSQL.** The backend commit must also deploy to Fly so the account/deck migration and seed release command run.
 
@@ -286,7 +293,7 @@ Pull requests validate:
 backend/app/
 ├── data/              # featured curriculum JSON
 ├── routers/
-│   ├── auth.py        # signup / verify / login / logout
+│   ├── auth.py        # signup / OAuth / verify / login / logout
 │   ├── decks.py       # featured + owned decks
 │   ├── cards.py       # owner-scoped card CRUD
 │   └── study.py       # deck-aware spaced repetition
@@ -316,6 +323,7 @@ FlashQuest’s now demonstrates more than CRUD:
 
 - reusable product/data modeling;
 - account ownership boundaries;
+- Google/GitHub OAuth integration;
 - email-verification lifecycle;
 - password/token handling;
 - explicit migration + seed lifecycle;

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,25 +10,23 @@ class Settings(BaseSettings):
     APP_ENV: str = "development"
     APP_VERSION: str = "1.1.0"
     LOG_LEVEL: str = "INFO"
-    # Accept JSON-looking or comma-separated text; main.py normalizes it.
     ALLOWED_ORIGINS: str = ""
 
-    # Opaque bearer sessions are stored only as hashes in PostgreSQL.
     ACCESS_TOKEN_MINUTES: int = 60 * 24 * 7
 
-    # Email verification. `console` prints the verification URL locally/tests.
-    # Hosted environments should use `resend` with RESEND_API_KEY configured.
     EMAIL_DELIVERY_MODE: str = "console"
     RESEND_API_KEY: str = ""
     EMAIL_FROM: str = "FlashQuest <onboarding@resend.dev>"
     VERIFICATION_TOKEN_MINUTES: int = 60
     FRONTEND_URL: str = "http://localhost:5173"
+    API_PUBLIC_URL: str = "http://localhost:8080"
 
-    # Comma-separated account emails allowed to review moderation reports.
-    # This is a server-side privilege bootstrap, not a user-controlled role.
+    GOOGLE_CLIENT_ID: str = ""
+    GOOGLE_CLIENT_SECRET: str = ""
+    GITHUB_CLIENT_ID: str = ""
+    GITHUB_CLIENT_SECRET: str = ""
+
     MODERATOR_EMAILS: str = ""
-
-    # Server-side only. Built-in demo cards cannot be deleted/reset when blank.
     DEMO_DELETE_PASSWORD: str = ""
 
     model_config = SettingsConfigDict(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,44 +1,30 @@
-"""Account signup, email verification, login, and session endpoints."""
+"""Account signup, OAuth, email verification, login, and session endpoints."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import secrets
+from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
+from ..config import settings
 from ..db import get_session
 from ..email_service import create_verification_token, send_verification_email
-from ..models import (
-    AuthSession,
-    EmailVerificationToken,
-    LoginRequest,
-    SignupRequest,
-    User,
-    UserRead,
-)
-from ..security import (
-    bearer_scheme,
-    create_auth_session,
-    get_current_user,
-    hash_password,
-    hash_token,
-    verify_password,
-)
+from ..models import AuthSession, EmailVerificationToken, LoginRequest, SignupRequest, User, UserRead
+from ..security import bearer_scheme, create_auth_session, get_current_user, hash_password, hash_token, verify_password
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+OAUTH_COOKIE_MAX_AGE = 600
 
 
 def _user_read(user: User) -> UserRead:
-    return UserRead(
-        id=int(user.id or 0),
-        email=user.email,
-        display_name=user.display_name,
-        is_verified=user.is_verified,
-    )
+    return UserRead(id=int(user.id or 0), email=user.email, display_name=user.display_name, is_verified=user.is_verified)
 
 
 def _aware_utc(value: datetime) -> datetime:
@@ -47,52 +33,195 @@ def _aware_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _safe_next(value: str | None) -> str:
+    if value and value.startswith("/") and not value.startswith("//"):
+        return value
+    return "/welcome"
+
+
+def _require_oauth(client_id: str, client_secret: str, provider: str) -> None:
+    if not client_id or not client_secret:
+        raise HTTPException(status_code=503, detail=f"{provider} sign-in is not configured")
+
+
+def _oauth_start_response(url: str, state: str, next_path: str) -> RedirectResponse:
+    response = RedirectResponse(url, status_code=302)
+    secure = settings.APP_ENV.lower() == "production"
+    response.set_cookie("fq_oauth_state", state, max_age=OAUTH_COOKIE_MAX_AGE, httponly=True, secure=secure, samesite="lax", path="/auth")
+    response.set_cookie("fq_oauth_next", next_path, max_age=OAUTH_COOKIE_MAX_AGE, httponly=True, secure=secure, samesite="lax", path="/auth")
+    return response
+
+
+def _validate_oauth_state(request: Request, state: str | None) -> None:
+    expected = request.cookies.get("fq_oauth_state")
+    if not state or not expected or not secrets.compare_digest(state, expected):
+        raise HTTPException(status_code=400, detail="OAuth state validation failed")
+
+
+def _oauth_user(session: Session, email: str, display_name: str) -> User:
+    normalized = email.strip().lower()
+    user = session.exec(select(User).where(User.email == normalized)).first()
+    if user is None:
+        user = User(
+            email=normalized,
+            display_name=(display_name.strip() or normalized.split("@", 1)[0])[:120],
+            password_hash=hash_password(secrets.token_urlsafe(48)),
+            is_verified=True,
+        )
+        session.add(user)
+        try:
+            session.commit()
+            session.refresh(user)
+        except IntegrityError:
+            session.rollback()
+            user = session.exec(select(User).where(User.email == normalized)).first()
+            if user is None:
+                raise HTTPException(status_code=409, detail="Could not create OAuth account")
+    elif not user.is_verified:
+        user.is_verified = True
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+    return user
+
+
+def _oauth_finish(request: Request, session: Session, user: User) -> RedirectResponse:
+    access_token = create_auth_session(session, int(user.id or 0))
+    next_path = _safe_next(request.cookies.get("fq_oauth_next"))
+    fragment = urlencode({"token": access_token, "next": next_path})
+    response = RedirectResponse(f"{settings.FRONTEND_URL.rstrip('/')}/oauth/callback#{fragment}", status_code=302)
+    response.delete_cookie("fq_oauth_state", path="/auth")
+    response.delete_cookie("fq_oauth_next", path="/auth")
+    return response
+
+
+@router.get("/google/start")
+def google_start(next: str | None = None) -> RedirectResponse:
+    _require_oauth(settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google")
+    state = secrets.token_urlsafe(32)
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/google/callback"
+    params = urlencode({
+        "client_id": settings.GOOGLE_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "openid email profile",
+        "state": state,
+        "prompt": "select_account",
+    })
+    return _oauth_start_response(f"https://accounts.google.com/o/oauth2/v2/auth?{params}", state, _safe_next(next))
+
+
+@router.get("/google/callback")
+def google_callback(request: Request, code: str | None = None, state: str | None = None, session: Session = Depends(get_session)) -> RedirectResponse:
+    _require_oauth(settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google")
+    _validate_oauth_state(request, state)
+    if not code:
+        raise HTTPException(status_code=400, detail="Google did not return an authorization code")
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/google/callback"
+    try:
+        token_response = httpx.post("https://oauth2.googleapis.com/token", data={
+            "code": code,
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code",
+        }, timeout=10.0)
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=502, detail="Google token exchange returned no access token")
+        profile_response = httpx.get("https://openidconnect.googleapis.com/v1/userinfo", headers={"Authorization": f"Bearer {access_token}"}, timeout=10.0)
+        profile_response.raise_for_status()
+        profile = profile_response.json()
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail="Google sign-in could not be completed") from exc
+
+    email = str(profile.get("email", "")).strip().lower()
+    if not email or profile.get("email_verified") is not True:
+        raise HTTPException(status_code=403, detail="Google account must provide a verified email")
+    user = _oauth_user(session, email, str(profile.get("name", "FlashQuest learner")))
+    return _oauth_finish(request, session, user)
+
+
+@router.get("/github/start")
+def github_start(next: str | None = None) -> RedirectResponse:
+    _require_oauth(settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub")
+    state = secrets.token_urlsafe(32)
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
+    params = urlencode({
+        "client_id": settings.GITHUB_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": "read:user user:email",
+        "state": state,
+    })
+    return _oauth_start_response(f"https://github.com/login/oauth/authorize?{params}", state, _safe_next(next))
+
+
+@router.get("/github/callback")
+def github_callback(request: Request, code: str | None = None, state: str | None = None, session: Session = Depends(get_session)) -> RedirectResponse:
+    _require_oauth(settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub")
+    _validate_oauth_state(request, state)
+    if not code:
+        raise HTTPException(status_code=400, detail="GitHub did not return an authorization code")
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
+    try:
+        token_response = httpx.post(
+            "https://github.com/login/oauth/access_token",
+            headers={"Accept": "application/json"},
+            data={"client_id": settings.GITHUB_CLIENT_ID, "client_secret": settings.GITHUB_CLIENT_SECRET, "code": code, "redirect_uri": redirect_uri},
+            timeout=10.0,
+        )
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=502, detail="GitHub token exchange returned no access token")
+        headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+        profile_response = httpx.get("https://api.github.com/user", headers=headers, timeout=10.0)
+        emails_response = httpx.get("https://api.github.com/user/emails", headers=headers, timeout=10.0)
+        profile_response.raise_for_status()
+        emails_response.raise_for_status()
+        profile = profile_response.json()
+        emails = emails_response.json()
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail="GitHub sign-in could not be completed") from exc
+
+    verified = [row for row in emails if row.get("verified") and row.get("email")]
+    primary = next((row for row in verified if row.get("primary")), verified[0] if verified else None)
+    if primary is None:
+        raise HTTPException(status_code=403, detail="GitHub account must provide a verified email")
+    email = str(primary["email"]).strip().lower()
+    display_name = str(profile.get("name") or profile.get("login") or "FlashQuest learner")
+    user = _oauth_user(session, email, display_name)
+    return _oauth_finish(request, session, user)
+
+
 @router.post("/signup", status_code=201)
 def signup(payload: SignupRequest, session: Session = Depends(get_session)) -> dict:
-    """Create an unverified account and send a one-time verification email."""
     email = str(payload.email).strip().lower()
     name = payload.display_name.strip()
     if len(name) < 2:
         raise HTTPException(status_code=422, detail="Display name is too short")
     if len(payload.password) < 8:
         raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
-
     if session.exec(select(User).where(User.email == email)).first() is not None:
         raise HTTPException(status_code=409, detail="An account with that email already exists")
-
-    user = User(
-        email=email,
-        display_name=name,
-        password_hash=hash_password(payload.password),
-        is_verified=False,
-    )
+    user = User(email=email, display_name=name, password_hash=hash_password(payload.password), is_verified=False)
     session.add(user)
     try:
-        session.commit()
-        session.refresh(user)
+        session.commit(); session.refresh(user)
     except IntegrityError as exc:
         session.rollback()
         raise HTTPException(status_code=409, detail="Account already exists") from exc
-
     raw = create_verification_token(session, user)
     try:
         send_verification_email(user, raw)
     except (RuntimeError, httpx.HTTPError) as exc:
-        raise HTTPException(
-            status_code=503,
-            detail="Account created, but the verification email could not be sent. Use resend verification.",
-        ) from exc
-
-    return {
-        "ok": True,
-        "message": "Check your inbox to verify your email and unlock deck creation.",
-        "email": user.email,
-    }
+        raise HTTPException(status_code=503, detail="Account created, but the verification email could not be sent. Use resend verification.") from exc
+    return {"ok": True, "message": "Check your inbox to verify your email and unlock deck creation.", "email": user.email}
 
 
 @router.post("/resend-verification")
 def resend_verification(payload: dict, session: Session = Depends(get_session)) -> dict:
-    """Send a new verification link without revealing whether an account exists."""
     email = str(payload.get("email", "")).strip().lower()
     user = session.exec(select(User).where(User.email == email)).first()
     if user is not None and not user.is_verified:
@@ -100,80 +229,52 @@ def resend_verification(payload: dict, session: Session = Depends(get_session)) 
         try:
             send_verification_email(user, raw)
         except (RuntimeError, httpx.HTTPError) as exc:
-            raise HTTPException(
-                status_code=503, detail="Verification email service is unavailable"
-            ) from exc
+            raise HTTPException(status_code=503, detail="Verification email service is unavailable") from exc
     return {"ok": True, "message": "If that account needs verification, a new link was sent."}
 
 
 @router.post("/verify")
 def verify_email(payload: dict, session: Session = Depends(get_session)) -> dict:
-    """Verify an email using a one-time opaque token."""
     raw = str(payload.get("token", "")).strip()
     if not raw:
         raise HTTPException(status_code=422, detail="Verification token is required")
-
-    token = session.exec(
-        select(EmailVerificationToken).where(
-            EmailVerificationToken.token_hash == hash_token(raw)
-        )
-    ).first()
+    token = session.exec(select(EmailVerificationToken).where(EmailVerificationToken.token_hash == hash_token(raw))).first()
     if token is None or token.used_at is not None:
         raise HTTPException(status_code=400, detail="Verification link is invalid or already used")
     if _aware_utc(token.expires_at) <= datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="Verification link expired. Request a new one.")
-
     user = session.get(User, token.user_id)
     if user is None:
         raise HTTPException(status_code=400, detail="Verification account no longer exists")
-
     user.is_verified = True
     token.used_at = datetime.now(timezone.utc)
-    session.add(user)
-    session.add(token)
-    session.commit()
+    session.add(user); session.add(token); session.commit()
     return {"ok": True, "message": "Email verified. You can now make your own decks."}
 
 
 @router.post("/login")
 def login(payload: LoginRequest, session: Session = Depends(get_session)) -> dict:
-    """Exchange email/password for an opaque bearer session."""
     email = str(payload.email).strip().lower()
     user = session.exec(select(User).where(User.email == email)).first()
     if user is None or not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=401, detail="Email or password is incorrect")
     if not user.is_verified:
         raise HTTPException(status_code=403, detail="Verify your email before signing in")
-
     access_token = create_auth_session(session, int(user.id or 0))
-    return {
-        "access_token": access_token,
-        "token_type": "bearer",
-        "user": _user_read(user).model_dump(mode="json"),
-    }
+    return {"access_token": access_token, "token_type": "bearer", "user": _user_read(user).model_dump(mode="json")}
 
 
 @router.get("/me", response_model=UserRead)
 def me(user: User = Depends(get_current_user)) -> UserRead:
-    """Return the current signed-in account."""
     return _user_read(user)
 
 
 @router.post("/logout")
-def logout(
-    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
-    session: Session = Depends(get_session),
-) -> dict:
-    """Revoke the current bearer session."""
+def logout(credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme), session: Session = Depends(get_session)) -> dict:
     if credentials is None:
         return {"ok": True}
-    auth_session = session.exec(
-        select(AuthSession).where(
-            AuthSession.token_hash == hash_token(credentials.credentials)
-        )
-    ).first()
+    auth_session = session.exec(select(AuthSession).where(AuthSession.token_hash == hash_token(credentials.credentials))).first()
     if auth_session is not None and auth_session.revoked_at is None:
         auth_session.revoked_at = datetime.now(timezone.utc)
-        session.add(auth_session)
-        session.commit()
+        session.add(auth_session); session.commit()
     return {"ok": True}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -16,15 +16,34 @@ from sqlmodel import Session, select
 from ..config import settings
 from ..db import get_session
 from ..email_service import create_verification_token, send_verification_email
-from ..models import AuthSession, EmailVerificationToken, LoginRequest, SignupRequest, User, UserRead
-from ..security import bearer_scheme, create_auth_session, get_current_user, hash_password, hash_token, verify_password
+from ..models import (
+    AuthSession,
+    EmailVerificationToken,
+    LoginRequest,
+    SignupRequest,
+    User,
+    UserRead,
+)
+from ..security import (
+    bearer_scheme,
+    create_auth_session,
+    get_current_user,
+    hash_password,
+    hash_token,
+    verify_password,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 OAUTH_COOKIE_MAX_AGE = 600
 
 
 def _user_read(user: User) -> UserRead:
-    return UserRead(id=int(user.id or 0), email=user.email, display_name=user.display_name, is_verified=user.is_verified)
+    return UserRead(
+        id=int(user.id or 0),
+        email=user.email,
+        display_name=user.display_name,
+        is_verified=user.is_verified,
+    )
 
 
 def _aware_utc(value: datetime) -> datetime:
@@ -41,14 +60,32 @@ def _safe_next(value: str | None) -> str:
 
 def _require_oauth(client_id: str, client_secret: str, provider: str) -> None:
     if not client_id or not client_secret:
-        raise HTTPException(status_code=503, detail=f"{provider} sign-in is not configured")
+        raise HTTPException(
+            status_code=503, detail=f"{provider} sign-in is not configured"
+        )
 
 
 def _oauth_start_response(url: str, state: str, next_path: str) -> RedirectResponse:
     response = RedirectResponse(url, status_code=302)
     secure = settings.APP_ENV.lower() == "production"
-    response.set_cookie("fq_oauth_state", state, max_age=OAUTH_COOKIE_MAX_AGE, httponly=True, secure=secure, samesite="lax", path="/auth")
-    response.set_cookie("fq_oauth_next", next_path, max_age=OAUTH_COOKIE_MAX_AGE, httponly=True, secure=secure, samesite="lax", path="/auth")
+    response.set_cookie(
+        "fq_oauth_state",
+        state,
+        max_age=OAUTH_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        path="/auth",
+    )
+    response.set_cookie(
+        "fq_oauth_next",
+        next_path,
+        max_age=OAUTH_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        path="/auth",
+    )
     return response
 
 
@@ -76,7 +113,9 @@ def _oauth_user(session: Session, email: str, display_name: str) -> User:
             session.rollback()
             user = session.exec(select(User).where(User.email == normalized)).first()
             if user is None:
-                raise HTTPException(status_code=409, detail="Could not create OAuth account")
+                raise HTTPException(
+                    status_code=409, detail="Could not create OAuth account"
+                )
     elif not user.is_verified:
         user.is_verified = True
         session.add(user)
@@ -89,7 +128,10 @@ def _oauth_finish(request: Request, session: Session, user: User) -> RedirectRes
     access_token = create_auth_session(session, int(user.id or 0))
     next_path = _safe_next(request.cookies.get("fq_oauth_next"))
     fragment = urlencode({"token": access_token, "next": next_path})
-    response = RedirectResponse(f"{settings.FRONTEND_URL.rstrip('/')}/oauth/callback#{fragment}", status_code=302)
+    response = RedirectResponse(
+        f"{settings.FRONTEND_URL.rstrip('/')}/oauth/callback#{fragment}",
+        status_code=302,
+    )
     response.delete_cookie("fq_oauth_state", path="/auth")
     response.delete_cookie("fq_oauth_next", path="/auth")
     return response
@@ -97,100 +139,190 @@ def _oauth_finish(request: Request, session: Session, user: User) -> RedirectRes
 
 @router.get("/google/start")
 def google_start(next: str | None = None) -> RedirectResponse:
-    _require_oauth(settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google")
+    _require_oauth(
+        settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google"
+    )
     state = secrets.token_urlsafe(32)
     redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/google/callback"
-    params = urlencode({
-        "client_id": settings.GOOGLE_CLIENT_ID,
-        "redirect_uri": redirect_uri,
-        "response_type": "code",
-        "scope": "openid email profile",
-        "state": state,
-        "prompt": "select_account",
-    })
-    return _oauth_start_response(f"https://accounts.google.com/o/oauth2/v2/auth?{params}", state, _safe_next(next))
+    params = urlencode(
+        {
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": "openid email profile",
+            "state": state,
+            "prompt": "select_account",
+        }
+    )
+    return _oauth_start_response(
+        f"https://accounts.google.com/o/oauth2/v2/auth?{params}",
+        state,
+        _safe_next(next),
+    )
 
 
 @router.get("/google/callback")
-def google_callback(request: Request, code: str | None = None, state: str | None = None, session: Session = Depends(get_session)) -> RedirectResponse:
-    _require_oauth(settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google")
+def google_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    session: Session = Depends(get_session),
+) -> RedirectResponse:
+    _require_oauth(
+        settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET, "Google"
+    )
     _validate_oauth_state(request, state)
     if not code:
-        raise HTTPException(status_code=400, detail="Google did not return an authorization code")
+        raise HTTPException(
+            status_code=400,
+            detail="Google did not return an authorization code",
+        )
+
     redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/google/callback"
     try:
-        token_response = httpx.post("https://oauth2.googleapis.com/token", data={
-            "code": code,
-            "client_id": settings.GOOGLE_CLIENT_ID,
-            "client_secret": settings.GOOGLE_CLIENT_SECRET,
-            "redirect_uri": redirect_uri,
-            "grant_type": "authorization_code",
-        }, timeout=10.0)
-        token_response.raise_for_status()
-        access_token = token_response.json().get("access_token")
-        if not access_token:
-            raise HTTPException(status_code=502, detail="Google token exchange returned no access token")
-        profile_response = httpx.get("https://openidconnect.googleapis.com/v1/userinfo", headers={"Authorization": f"Bearer {access_token}"}, timeout=10.0)
-        profile_response.raise_for_status()
-        profile = profile_response.json()
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail="Google sign-in could not be completed") from exc
-
-    email = str(profile.get("email", "")).strip().lower()
-    if not email or profile.get("email_verified") is not True:
-        raise HTTPException(status_code=403, detail="Google account must provide a verified email")
-    user = _oauth_user(session, email, str(profile.get("name", "FlashQuest learner")))
-    return _oauth_finish(request, session, user)
-
-
-@router.get("/github/start")
-def github_start(next: str | None = None) -> RedirectResponse:
-    _require_oauth(settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub")
-    state = secrets.token_urlsafe(32)
-    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
-    params = urlencode({
-        "client_id": settings.GITHUB_CLIENT_ID,
-        "redirect_uri": redirect_uri,
-        "scope": "read:user user:email",
-        "state": state,
-    })
-    return _oauth_start_response(f"https://github.com/login/oauth/authorize?{params}", state, _safe_next(next))
-
-
-@router.get("/github/callback")
-def github_callback(request: Request, code: str | None = None, state: str | None = None, session: Session = Depends(get_session)) -> RedirectResponse:
-    _require_oauth(settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub")
-    _validate_oauth_state(request, state)
-    if not code:
-        raise HTTPException(status_code=400, detail="GitHub did not return an authorization code")
-    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
-    try:
         token_response = httpx.post(
-            "https://github.com/login/oauth/access_token",
-            headers={"Accept": "application/json"},
-            data={"client_id": settings.GITHUB_CLIENT_ID, "client_secret": settings.GITHUB_CLIENT_SECRET, "code": code, "redirect_uri": redirect_uri},
+            "https://oauth2.googleapis.com/token",
+            data={
+                "code": code,
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
             timeout=10.0,
         )
         token_response.raise_for_status()
         access_token = token_response.json().get("access_token")
         if not access_token:
-            raise HTTPException(status_code=502, detail="GitHub token exchange returned no access token")
-        headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
-        profile_response = httpx.get("https://api.github.com/user", headers=headers, timeout=10.0)
-        emails_response = httpx.get("https://api.github.com/user/emails", headers=headers, timeout=10.0)
+            raise HTTPException(
+                status_code=502,
+                detail="Google token exchange returned no access token",
+            )
+
+        profile_response = httpx.get(
+            "https://openidconnect.googleapis.com/v1/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10.0,
+        )
+        profile_response.raise_for_status()
+        profile = profile_response.json()
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502, detail="Google sign-in could not be completed"
+        ) from exc
+
+    email = str(profile.get("email", "")).strip().lower()
+    if not email or profile.get("email_verified") is not True:
+        raise HTTPException(
+            status_code=403,
+            detail="Google account must provide a verified email",
+        )
+
+    user = _oauth_user(
+        session,
+        email,
+        str(profile.get("name", "FlashQuest learner")),
+    )
+    return _oauth_finish(request, session, user)
+
+
+@router.get("/github/start")
+def github_start(next: str | None = None) -> RedirectResponse:
+    _require_oauth(
+        settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub"
+    )
+    state = secrets.token_urlsafe(32)
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
+    params = urlencode(
+        {
+            "client_id": settings.GITHUB_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": "read:user user:email",
+            "state": state,
+        }
+    )
+    return _oauth_start_response(
+        f"https://github.com/login/oauth/authorize?{params}",
+        state,
+        _safe_next(next),
+    )
+
+
+@router.get("/github/callback")
+def github_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    session: Session = Depends(get_session),
+) -> RedirectResponse:
+    _require_oauth(
+        settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, "GitHub"
+    )
+    _validate_oauth_state(request, state)
+    if not code:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub did not return an authorization code",
+        )
+
+    redirect_uri = f"{settings.API_PUBLIC_URL.rstrip('/')}/auth/github/callback"
+    try:
+        token_response = httpx.post(
+            "https://github.com/login/oauth/access_token",
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": settings.GITHUB_CLIENT_ID,
+                "client_secret": settings.GITHUB_CLIENT_SECRET,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+            timeout=10.0,
+        )
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(
+                status_code=502,
+                detail="GitHub token exchange returned no access token",
+            )
+
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        profile_response = httpx.get(
+            "https://api.github.com/user", headers=headers, timeout=10.0
+        )
+        emails_response = httpx.get(
+            "https://api.github.com/user/emails", headers=headers, timeout=10.0
+        )
         profile_response.raise_for_status()
         emails_response.raise_for_status()
         profile = profile_response.json()
         emails = emails_response.json()
     except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail="GitHub sign-in could not be completed") from exc
+        raise HTTPException(
+            status_code=502, detail="GitHub sign-in could not be completed"
+        ) from exc
 
-    verified = [row for row in emails if row.get("verified") and row.get("email")]
-    primary = next((row for row in verified if row.get("primary")), verified[0] if verified else None)
+    verified = [
+        row for row in emails if row.get("verified") and row.get("email")
+    ]
+    primary = next(
+        (row for row in verified if row.get("primary")),
+        verified[0] if verified else None,
+    )
     if primary is None:
-        raise HTTPException(status_code=403, detail="GitHub account must provide a verified email")
+        raise HTTPException(
+            status_code=403,
+            detail="GitHub account must provide a verified email",
+        )
+
     email = str(primary["email"]).strip().lower()
-    display_name = str(profile.get("name") or profile.get("login") or "FlashQuest learner")
+    display_name = str(
+        profile.get("name") or profile.get("login") or "FlashQuest learner"
+    )
     user = _oauth_user(session, email, display_name)
     return _oauth_finish(request, session, user)
 
@@ -202,26 +334,53 @@ def signup(payload: SignupRequest, session: Session = Depends(get_session)) -> d
     if len(name) < 2:
         raise HTTPException(status_code=422, detail="Display name is too short")
     if len(payload.password) < 8:
-        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+        raise HTTPException(
+            status_code=422,
+            detail="Password must be at least 8 characters",
+        )
     if session.exec(select(User).where(User.email == email)).first() is not None:
-        raise HTTPException(status_code=409, detail="An account with that email already exists")
-    user = User(email=email, display_name=name, password_hash=hash_password(payload.password), is_verified=False)
+        raise HTTPException(
+            status_code=409,
+            detail="An account with that email already exists",
+        )
+
+    user = User(
+        email=email,
+        display_name=name,
+        password_hash=hash_password(payload.password),
+        is_verified=False,
+    )
     session.add(user)
     try:
-        session.commit(); session.refresh(user)
+        session.commit()
+        session.refresh(user)
     except IntegrityError as exc:
         session.rollback()
         raise HTTPException(status_code=409, detail="Account already exists") from exc
+
     raw = create_verification_token(session, user)
     try:
         send_verification_email(user, raw)
     except (RuntimeError, httpx.HTTPError) as exc:
-        raise HTTPException(status_code=503, detail="Account created, but the verification email could not be sent. Use resend verification.") from exc
-    return {"ok": True, "message": "Check your inbox to verify your email and unlock deck creation.", "email": user.email}
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Account created, but the verification email could not be sent. "
+                "Use resend verification."
+            ),
+        ) from exc
+
+    return {
+        "ok": True,
+        "message": "Check your inbox to verify your email and unlock deck creation.",
+        "email": user.email,
+    }
 
 
 @router.post("/resend-verification")
-def resend_verification(payload: dict, session: Session = Depends(get_session)) -> dict:
+def resend_verification(
+    payload: dict, session: Session = Depends(get_session)
+) -> dict:
     email = str(payload.get("email", "")).strip().lower()
     user = session.exec(select(User).where(User.email == email)).first()
     if user is not None and not user.is_verified:
@@ -229,27 +388,56 @@ def resend_verification(payload: dict, session: Session = Depends(get_session)) 
         try:
             send_verification_email(user, raw)
         except (RuntimeError, httpx.HTTPError) as exc:
-            raise HTTPException(status_code=503, detail="Verification email service is unavailable") from exc
-    return {"ok": True, "message": "If that account needs verification, a new link was sent."}
+            raise HTTPException(
+                status_code=503,
+                detail="Verification email service is unavailable",
+            ) from exc
+    return {
+        "ok": True,
+        "message": "If that account needs verification, a new link was sent.",
+    }
 
 
 @router.post("/verify")
 def verify_email(payload: dict, session: Session = Depends(get_session)) -> dict:
     raw = str(payload.get("token", "")).strip()
     if not raw:
-        raise HTTPException(status_code=422, detail="Verification token is required")
-    token = session.exec(select(EmailVerificationToken).where(EmailVerificationToken.token_hash == hash_token(raw))).first()
+        raise HTTPException(
+            status_code=422, detail="Verification token is required"
+        )
+
+    token = session.exec(
+        select(EmailVerificationToken).where(
+            EmailVerificationToken.token_hash == hash_token(raw)
+        )
+    ).first()
     if token is None or token.used_at is not None:
-        raise HTTPException(status_code=400, detail="Verification link is invalid or already used")
+        raise HTTPException(
+            status_code=400,
+            detail="Verification link is invalid or already used",
+        )
     if _aware_utc(token.expires_at) <= datetime.now(timezone.utc):
-        raise HTTPException(status_code=400, detail="Verification link expired. Request a new one.")
+        raise HTTPException(
+            status_code=400,
+            detail="Verification link expired. Request a new one.",
+        )
+
     user = session.get(User, token.user_id)
     if user is None:
-        raise HTTPException(status_code=400, detail="Verification account no longer exists")
+        raise HTTPException(
+            status_code=400,
+            detail="Verification account no longer exists",
+        )
+
     user.is_verified = True
     token.used_at = datetime.now(timezone.utc)
-    session.add(user); session.add(token); session.commit()
-    return {"ok": True, "message": "Email verified. You can now make your own decks."}
+    session.add(user)
+    session.add(token)
+    session.commit()
+    return {
+        "ok": True,
+        "message": "Email verified. You can now make your own decks.",
+    }
 
 
 @router.post("/login")
@@ -257,11 +445,20 @@ def login(payload: LoginRequest, session: Session = Depends(get_session)) -> dic
     email = str(payload.email).strip().lower()
     user = session.exec(select(User).where(User.email == email)).first()
     if user is None or not verify_password(payload.password, user.password_hash):
-        raise HTTPException(status_code=401, detail="Email or password is incorrect")
+        raise HTTPException(
+            status_code=401, detail="Email or password is incorrect"
+        )
     if not user.is_verified:
-        raise HTTPException(status_code=403, detail="Verify your email before signing in")
+        raise HTTPException(
+            status_code=403, detail="Verify your email before signing in"
+        )
+
     access_token = create_auth_session(session, int(user.id or 0))
-    return {"access_token": access_token, "token_type": "bearer", "user": _user_read(user).model_dump(mode="json")}
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": _user_read(user).model_dump(mode="json"),
+    }
 
 
 @router.get("/me", response_model=UserRead)
@@ -270,11 +467,20 @@ def me(user: User = Depends(get_current_user)) -> UserRead:
 
 
 @router.post("/logout")
-def logout(credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme), session: Session = Depends(get_session)) -> dict:
+def logout(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+) -> dict:
     if credentials is None:
         return {"ok": True}
-    auth_session = session.exec(select(AuthSession).where(AuthSession.token_hash == hash_token(credentials.credentials))).first()
+
+    auth_session = session.exec(
+        select(AuthSession).where(
+            AuthSession.token_hash == hash_token(credentials.credentials)
+        )
+    ).first()
     if auth_session is not None and auth_session.revoked_at is None:
         auth_session.revoked_at = datetime.now(timezone.utc)
-        session.add(auth_session); session.commit()
+        session.add(auth_session)
+        session.commit()
     return {"ok": True}

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -11,13 +11,13 @@ primary_region = 'dfw'
   dockerfile = "./Dockerfile"
 
 [deploy]
-  # Schema first, then idempotently repair/seed the featured curriculum.
   release_command = "sh -c 'alembic -c /app/alembic.ini upgrade head && python -m app.seed'"
 
 [env]
   PORT = "8080"
   APP_ENV = "production"
   FRONTEND_URL = "https://flaskquest.netlify.app"
+  API_PUBLIC_URL = "https://flashcards-tobias.fly.dev"
   EMAIL_DELIVERY_MODE = "resend"
 
 [[vm]]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#090d18" />
+    <link rel="icon" type="image/svg+xml" href="/flashquest-logo.svg" />
+    <link rel="apple-touch-icon" href="/flashquest-logo.svg" />
     <meta
       name="description"
       content="FlashQuest’s game-like spaced repetition experience is powered by FastAPI, React, PostgreSQL, and Docker."

--- a/frontend/public/flashquest-logo.svg
+++ b/frontend/public/flashquest-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">FlashQuest logo</title>
+  <desc id="desc">Pink brain with a white lightning bolt on a dark rounded square.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#171532"/>
+      <stop offset="1" stop-color="#090d18"/>
+    </linearGradient>
+    <linearGradient id="brain" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff6fb0"/>
+      <stop offset="1" stop-color="#ff3f93"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="18" width="476" height="476" rx="104" fill="url(#bg)"/>
+  <g fill="url(#brain)" stroke="#12142d" stroke-width="18" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M250 116c-30-25-81-20-98 15-44-5-76 33-69 74-42 18-52 70-27 102-19 34 2 80 42 90 7 42 51 66 90 47 21 28 47 33 62 29V116Z"/>
+    <path d="M262 116c30-25 81-20 98 15 44-5 76 33 69 74 42 18 52 70 27 102 19 34-2 80-42 90-7 42-51 66-90 47-21 28-47 33-62 29V116Z"/>
+    <path d="M152 169c-6 26 11 48 34 54" fill="none"/>
+    <path d="M121 245c24 1 42 12 51 30" fill="none"/>
+    <path d="M143 338c18-18 40-24 62-19" fill="none"/>
+    <path d="M360 169c6 26-11 48-34 54" fill="none"/>
+    <path d="M391 245c-24 1-42 12-51 30" fill="none"/>
+    <path d="M369 338c-18-18-40-24-62-19" fill="none"/>
+  </g>
+  <path d="M302 91 205 269h68l-53 154 111-190h-70l41-142Z" fill="#fff" stroke="#ff3f93" stroke-width="10" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Library from "./pages/Library";
 import LibraryDeck from "./pages/LibraryDeck";
 import Login from "./pages/Login";
 import MyDecks from "./pages/MyDecks";
+import OAuthCallback from "./pages/OAuthCallback";
 import Plans from "./pages/Plans";
 import Preferences from "./pages/Preferences";
 import Room from "./pages/Room";
@@ -23,14 +24,13 @@ import VerifyEmail from "./pages/VerifyEmail";
 import Welcome from "./pages/Welcome";
 
 const DOCS_URL = "https://flashquest-docs.netlify.app/";
+const LOGO_URL = "/flashquest-logo.svg";
 
 function RequireAccount({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth();
   const location = useLocation();
-
   if (loading) return <div className="game-panel mx-auto max-w-lg p-8 text-center text-slate-400">Loading your quest…</div>;
   if (user) return children;
-
   const next = `${location.pathname}${location.search}`;
   return <Navigate to={`/signup?next=${encodeURIComponent(next)}`} replace />;
 }
@@ -51,64 +51,27 @@ function Shell() {
   return (
     <div className="game-shell min-h-screen text-slate-100">
       <div className="game-grid" aria-hidden="true" />
-
       <header className="relative z-20 border-b border-[#faa307]/10 bg-[#03071e]/90 backdrop-blur-xl">
         <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
           <NavLink to={user ? "/study" : "/"} className="group flex min-w-0 items-center gap-3">
-            <div className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-[#faa307]/25 bg-[#6a040f]/55 text-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-6 group-hover:scale-105">🧠</div>
+            <img src={LOGO_URL} alt="FlashQuest" className="h-11 w-11 shrink-0 rounded-2xl shadow-lg shadow-black/30 transition group-hover:-rotate-3 group-hover:scale-105" />
             <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-lg font-black tracking-tight text-white">FlashQuest</span>
-                <span className="whitespace-nowrap rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.12em] leading-none text-[#ffba08]">Quest Mode</span>
-              </div>
+              <div className="flex flex-wrap items-center gap-2"><span className="text-lg font-black tracking-tight text-white">FlashQuest</span><span className="whitespace-nowrap rounded-full border border-[#ffba08]/25 bg-[#ffba08]/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.12em] leading-none text-[#ffba08]">Quest Mode</span></div>
               <p className="text-xs font-medium text-slate-400">Any topic. One memory engine.</p>
             </div>
           </NavLink>
-
           <div className="flex min-w-0 flex-1 flex-wrap items-center justify-start gap-2 lg:justify-end">
             <nav className="flex flex-wrap gap-1 rounded-2xl border border-white/10 bg-white/[0.035] p-1.5" aria-label="Primary navigation">
-              {navItems.map((item) => (
-                <NavLink key={`${item.to}-${item.label}`} to={item.to} className={({ isActive }) => ["flex items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}>
-                  <span aria-hidden="true">{item.icon}</span><span>{item.label}</span>
-                </NavLink>
-              ))}
+              {navItems.map((item) => <NavLink key={`${item.to}-${item.label}`} to={item.to} className={({ isActive }) => ["flex items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-bold transition", isActive ? "bg-[#faa307] text-[#370617] shadow-lg shadow-black/20" : "text-slate-300 hover:bg-white/10 hover:text-white"].join(" ")}><span aria-hidden="true">{item.icon}</span><span>{item.label}</span></NavLink>)}
             </nav>
-
-            {user ? (
-              <>
-                <NavLink
-                  to="/deck-lab"
-                  className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
-                >
-                  <span aria-hidden="true">🧪</span><span>Deck Lab</span>
-                </NavLink>
-                <NavLink
-                  to="/status"
-                  className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black 2xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
-                >
-                  <span aria-hidden="true">🗺️</span><span>Deck Map</span>
-                </NavLink>
-                <SoundToggle />
-                <NavLink
-                  to="/preferences"
-                  aria-label="Settings"
-                  title="Settings"
-                  className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}
-                >
-                  <span aria-hidden="true">⚙️</span><span className="hidden 2xl:inline">Settings</span>
-                </NavLink>
-                <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button hidden items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] 2xl:flex">📖 Docs</a>
-                <div className="flex items-center gap-2">
-                  <span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 2xl:inline">👋 {user.display_name}</span>
-                  <button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button>
-                </div>
-              </>
-            ) : (
-              <div className="flex gap-2">
-                <NavLink className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" to="/login">Sign in</NavLink>
-                <NavLink className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]" to="/signup">Create account</NavLink>
-              </div>
-            )}
+            {user ? <>
+              <NavLink to="/deck-lab" className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}><span aria-hidden="true">🧪</span><span>Deck Lab</span></NavLink>
+              <NavLink to="/status" className={({ isActive }) => `game-button game-chip hidden items-center gap-2 px-3 py-2 text-xs font-black 2xl:flex ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}><span aria-hidden="true">🗺️</span><span>Deck Map</span></NavLink>
+              <SoundToggle />
+              <NavLink to="/preferences" aria-label="Settings" title="Settings" className={({ isActive }) => `game-button game-chip flex items-center gap-2 px-3 py-2 text-xs font-black ${isActive ? "text-[#ffba08]" : "text-slate-200"}`}><span aria-hidden="true">⚙️</span><span className="hidden 2xl:inline">Settings</span></NavLink>
+              <a href={DOCS_URL} target="_blank" rel="noreferrer" className="game-button hidden items-center gap-2 border border-[#faa307]/20 bg-[#370617]/55 px-3 py-2 text-sm text-[#ffba08] 2xl:flex">📖 Docs</a>
+              <div className="flex items-center gap-2"><span className="game-chip hidden px-3 py-2 text-xs font-bold text-slate-300 2xl:inline">👋 {user.display_name}</span><button className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" onClick={() => void signOut()}>Sign out</button></div>
+            </> : <div className="flex gap-2"><NavLink className="game-button border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-black text-white" to="/login">Sign in</NavLink><NavLink className="game-button bg-[#ffba08] px-3 py-2 text-xs font-black text-[#370617]" to="/signup">Create account</NavLink></div>}
           </div>
         </div>
       </header>
@@ -117,6 +80,7 @@ function Shell() {
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/demo" element={<Demo />} />
+          <Route path="/oauth/callback" element={<OAuthCallback />} />
           <Route path="/welcome" element={<RequireAccount><Welcome /></RequireAccount>} />
           <Route path="/study" element={<RequireAccount><Study /></RequireAccount>} />
           <Route path="/arcade" element={<RequireAccount><Arcade /></RequireAccount>} />
@@ -134,28 +98,14 @@ function Shell() {
           <Route path="/signup" element={<Signup />} />
           <Route path="/login" element={<Login />} />
           <Route path="/verify-email" element={<VerifyEmail />} />
-          <Route path="*" element={<div className="game-panel mx-auto max-w-lg p-8 text-center"><div className="text-5xl">🌀</div><h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1><p className="mt-2 text-slate-400">That route slipped into another dimension.</p><NavLink to={user ? "/study" : "/"} className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">Back home</NavLink></div>} />
+          <Route path="*" element={<div className="game-panel mx-auto max-w-lg p-8 text-center"><img src={LOGO_URL} alt="FlashQuest" className="mx-auto h-16 w-16 rounded-2xl" /><h1 className="mt-4 text-2xl font-black text-white">Secret level not found</h1><p className="mt-2 text-slate-400">That route slipped into another dimension.</p><NavLink to={user ? "/study" : "/"} className="game-button mt-6 inline-flex bg-[#faa307] px-4 py-2 text-[#370617]">Back home</NavLink></div>} />
         </Routes>
       </main>
-
-      <footer className="relative z-10 mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500">
-        <span>{user ? "Learn · play · create · study together" : "Try the memory loop. Create an account when you want the full experience."}</span>
-        {user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">Docs ↗</a>}
-      </footer>
+      <footer className="relative z-10 mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-6 pb-8 text-xs font-medium text-slate-500"><span className="flex items-center gap-2"><img src={LOGO_URL} alt="" aria-hidden="true" className="h-5 w-5 rounded-md" />{user ? "Learn · play · create · study together" : "Try the memory loop. Create an account when you want the full experience."}</span>{user && <a className="transition hover:text-[#ffba08]" href={DOCS_URL} target="_blank" rel="noreferrer">Docs ↗</a>}</footer>
     </div>
   );
 }
 
 export default function App() {
-  return (
-    <ExperienceProvider>
-      <GameFeelProvider>
-        <BrowserRouter>
-          <AuthProvider>
-            <Shell />
-          </AuthProvider>
-        </BrowserRouter>
-      </GameFeelProvider>
-    </ExperienceProvider>
-  );
+  return <ExperienceProvider><GameFeelProvider><BrowserRouter><AuthProvider><Shell /></AuthProvider></BrowserRouter></GameFeelProvider></ExperienceProvider>;
 }

--- a/frontend/src/components/SocialAuthButtons.tsx
+++ b/frontend/src/components/SocialAuthButtons.tsx
@@ -1,0 +1,38 @@
+import { apiBaseURL } from "../api";
+
+function GoogleMark() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5">
+      <path fill="#4285F4" d="M21.6 12.2c0-.7-.1-1.3-.2-1.9H12v3.6h5.4a4.6 4.6 0 0 1-2 3v2.5h3.2c1.9-1.8 3-4.3 3-7.2Z" />
+      <path fill="#34A853" d="M12 22c2.7 0 5-.9 6.6-2.4l-3.2-2.5c-.9.6-2 1-3.4 1-2.6 0-4.8-1.8-5.6-4.1H3.1v2.6A10 10 0 0 0 12 22Z" />
+      <path fill="#FBBC05" d="M6.4 14a6 6 0 0 1 0-3.9V7.5H3.1a10 10 0 0 0 0 9.1L6.4 14Z" />
+      <path fill="#EA4335" d="M12 5.9c1.5 0 2.8.5 3.9 1.5l2.9-2.9A9.8 9.8 0 0 0 3.1 7.5l3.3 2.6C7.2 7.7 9.4 5.9 12 5.9Z" />
+    </svg>
+  );
+}
+
+function GitHubMark() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current">
+      <path d="M12 .7a11.5 11.5 0 0 0-3.6 22.4c.6.1.8-.3.8-.6v-2.2c-3.4.7-4.1-1.4-4.1-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.6-1.4-5.6-6.1 0-1.4.5-2.5 1.2-3.4-.1-.3-.5-1.6.1-3.4 0 0 1-.3 3.5 1.3A12 12 0 0 1 12 6.7c1.1 0 2.2.1 3.2.4 2.5-1.6 3.5-1.3 3.5-1.3.6 1.8.2 3.1.1 3.4.8.9 1.2 2 1.2 3.4 0 4.8-2.9 5.8-5.6 6.1.4.4.8 1.1.8 2.1v3.1c0 .3.2.7.8.6A11.5 11.5 0 0 0 12 .7Z" />
+    </svg>
+  );
+}
+
+export default function SocialAuthButtons({ next }: { next?: string | null }) {
+  const suffix = next ? `?next=${encodeURIComponent(next)}` : "";
+  const start = (provider: "google" | "github") => {
+    window.location.assign(`${apiBaseURL()}/auth/${provider}/start${suffix}`);
+  };
+
+  return (
+    <div className="grid gap-3">
+      <button type="button" onClick={() => start("google")} className="game-button flex w-full items-center justify-center gap-3 border border-white/15 bg-white px-5 py-3 font-black text-slate-900 hover:bg-slate-100">
+        <GoogleMark /> Continue with Google
+      </button>
+      <button type="button" onClick={() => start("github")} className="game-button flex w-full items-center justify-center gap-3 border border-white/15 bg-[#111827] px-5 py-3 font-black text-white hover:bg-[#1f2937]">
+        <GitHubMark /> Continue with GitHub
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -41,54 +41,31 @@ export default function Landing() {
     <div className="grid gap-16 pb-14 pt-4 sm:pt-10">
       <section className="grid items-center gap-10 lg:grid-cols-[1.08fr_.92fr]">
         <div>
-          <div className="game-chip inline-flex items-center gap-2 px-3 py-1.5 text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">
-            ⚡ Learn by doing
-          </div>
-          <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[.98] tracking-[-0.045em] text-white sm:text-6xl lg:text-7xl">
-            Turn what you need to remember into a <span className="ember-text">quest.</span>
-          </h1>
-          <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-            FlashQuest is a game-like study engine that helps you practice actively, revisit what you miss, track mastery, build your own decks, and study with other people when you want to.
-          </p>
-          <div className="mt-7 flex flex-wrap gap-3">
-            {user ? (
-              <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">⚡ Continue learning</Link>
-            ) : (
-              <>
-                <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/signup">Create free account</Link>
-                <Link className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white" to="/demo">Try the 60-second demo</Link>
-              </>
-            )}
-          </div>
-          {!user && (
-            <div className="mt-5 grid max-w-2xl gap-2 text-sm text-slate-400 sm:grid-cols-3">
-              <span>✓ Create private decks</span>
-              <span>✓ Keep your progress</span>
-              <span>✓ Join Quest Rooms</span>
+          <div className="mb-5 flex items-center gap-4">
+            <img src="/flashquest-logo.svg" alt="FlashQuest" className="h-20 w-20 rounded-3xl shadow-xl shadow-black/30" />
+            <div>
+              <p className="text-sm font-black uppercase tracking-[0.2em] text-[#ffba08]">FlashQuest</p>
+              <p className="mt-1 text-sm text-slate-400">Any topic. One memory engine.</p>
             </div>
-          )}
+          </div>
+          <div className="game-chip inline-flex items-center gap-2 px-3 py-1.5 text-xs font-black uppercase tracking-[0.16em] text-[#ffba08]">⚡ Learn by doing</div>
+          <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[.98] tracking-[-0.045em] text-white sm:text-6xl lg:text-7xl">Turn what you need to remember into a <span className="ember-text">quest.</span></h1>
+          <p className="mt-6 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">FlashQuest is a game-like study engine that helps you actively recall, revisit what you miss, track mastery, create your own decks, play review modes, and study with other people in persistent Quest Rooms.</p>
+          <div className="mt-7 flex flex-wrap gap-3">
+            {user ? <Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/study">⚡ Continue learning</Link> : <><Link className="game-button bg-[#ffba08] px-5 py-3 text-sm font-black text-[#370617]" to="/signup">Create free account</Link><Link className="game-button border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-black text-white" to="/demo">Try the 60-second demo</Link></>}
+          </div>
+          {!user && <div className="mt-5 grid max-w-2xl gap-2 text-sm text-slate-400 sm:grid-cols-3"><span>✓ Create private decks</span><span>✓ Keep your progress</span><span>✓ Join Quest Rooms</span></div>}
         </div>
 
         <div className="quest-card p-6 sm:p-8">
           <div className="relative z-10">
-            <span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">ONE MEMORY LOOP</span>
+            <div className="flex items-center gap-3"><img src="/flashquest-logo.svg" alt="" aria-hidden="true" className="h-10 w-10 rounded-xl" /><span className="game-chip px-3 py-1 text-xs font-black text-[#ffba08]">ONE MEMORY LOOP</span></div>
             <p className="mt-7 text-xs font-black uppercase tracking-[0.18em] text-[#f48c06]">Question</p>
             <h2 className="mt-3 text-2xl font-black leading-tight text-white sm:text-3xl">What would you check first?</h2>
             <div className="mt-6 grid gap-3 sm:grid-cols-3">
-              {[
-                ["1", "Try it"],
-                ["2", "Get a hint"],
-                ["3", "Reveal + remember"],
-              ].map(([step, label]) => (
-                <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-                  <span className="text-xs font-black text-[#f48c06]">STEP {step}</span>
-                  <p className="mt-2 font-black text-white">{label}</p>
-                </div>
-              ))}
+              {[["1", "Try it"], ["2", "Get a hint"], ["3", "Reveal + remember"]].map(([step, label]) => <div key={step} className="rounded-2xl border border-white/10 bg-black/15 p-4"><span className="text-xs font-black text-[#f48c06]">STEP {step}</span><p className="mt-2 font-black text-white">{label}</p></div>)}
             </div>
-            <div className="mt-6 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-4 text-sm leading-6 text-slate-300">
-              Miss it? FlashQuest brings it back sooner. Get it right consistently? It moves farther out. Your study queue changes with you.
-            </div>
+            <div className="mt-6 rounded-2xl border border-[#faa307]/20 bg-[#faa307]/[0.06] p-4 text-sm leading-6 text-slate-300">Miss it? FlashQuest brings it back sooner. Get it right consistently? It moves farther out. Your study queue changes with you.</div>
           </div>
         </div>
       </section>
@@ -97,19 +74,10 @@ export default function Landing() {
         <div className="max-w-3xl">
           <p className="metric-label">Why FlashQuest</p>
           <h2 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl">More than flashcards. A whole learning loop.</h2>
-          <p className="mt-3 text-base leading-7 text-slate-400">
-            The point is not to stare at cards. The point is to make yourself retrieve, practice, compare, repeat, and eventually stop forgetting.
-          </p>
+          <p className="mt-3 text-base leading-7 text-slate-400">The point is not to stare at cards. The point is to retrieve, practice, compare, repeat, and eventually stop forgetting.</p>
         </div>
-
         <div className="mt-7 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {features.map((feature) => (
-            <article key={feature.title} className="game-panel p-5 sm:p-6">
-              <div className="text-2xl" aria-hidden="true">{feature.icon}</div>
-              <h3 className="mt-4 text-xl font-black text-white">{feature.title}</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-400">{feature.copy}</p>
-            </article>
-          ))}
+          {features.map((feature) => <article key={feature.title} className="game-panel p-5 sm:p-6"><div className="text-2xl" aria-hidden="true">{feature.icon}</div><h3 className="mt-4 text-xl font-black text-white">{feature.title}</h3><p className="mt-2 text-sm leading-6 text-slate-400">{feature.copy}</p></article>)}
         </div>
       </section>
 
@@ -117,51 +85,20 @@ export default function Landing() {
         <div className="game-panel p-6 sm:p-8">
           <p className="metric-label">Why make an account?</p>
           <h2 className="mt-2 text-3xl font-black text-white">The demo shows the loop. Your account makes it yours.</h2>
-          <p className="mt-4 text-sm leading-7 text-slate-400">
-            Signing up turns FlashQuest from a sample experience into your personal study system. Your decks, mastery, history, room memberships, and progress stay with you between sessions.
-          </p>
-          <div className="mt-5 grid gap-3 text-sm text-slate-300">
-            <span>🗂️ Build and manage your own private decks</span>
-            <span>📈 Save mastery and review progress</span>
-            <span>👥 Create and join collaborative Quest Rooms</span>
-            <span>🎮 Use your own material in Arcade and study modes</span>
-          </div>
+          <p className="mt-4 text-sm leading-7 text-slate-400">Signing up turns FlashQuest from a sample into your personal study system. Your decks, mastery, history, room memberships, and progress stay with you between sessions.</p>
+          <div className="mt-5 grid gap-3 text-sm text-slate-300"><span>🗂️ Build and manage private decks</span><span>📈 Save mastery and review progress</span><span>👥 Create and join collaborative Quest Rooms</span><span>🎮 Use your own material in Arcade and study modes</span></div>
         </div>
-
         <div className="quest-card p-6 sm:p-8">
           <div className="relative z-10">
             <p className="metric-label">A study flow you can actually keep using</p>
             <div className="mt-5 grid gap-3 sm:grid-cols-2">
-              {[
-                ["01", "Pick a deck", "Start with a featured deck or one you created."],
-                ["02", "Attempt first", "Answer from memory before you reveal anything."],
-                ["03", "Review intelligently", "Missed cards return sooner; stronger cards wait longer."],
-                ["04", "Play or study together", "Switch into Arcade or open a Quest Room with a crew."],
-              ].map(([number, title, copy]) => (
-                <div key={number} className="rounded-2xl border border-white/10 bg-black/15 p-4">
-                  <span className="text-xs font-black text-[#f48c06]">{number}</span>
-                  <h3 className="mt-2 font-black text-white">{title}</h3>
-                  <p className="mt-1 text-sm leading-6 text-slate-400">{copy}</p>
-                </div>
-              ))}
+              {[["01", "Pick a deck", "Start with a featured deck or one you created."], ["02", "Attempt first", "Answer from memory before you reveal anything."], ["03", "Review intelligently", "Missed cards return sooner; stronger cards wait longer."], ["04", "Play or study together", "Switch into Arcade or open a Quest Room with a crew."]].map(([number, title, copy]) => <div key={number} className="rounded-2xl border border-white/10 bg-black/15 p-4"><span className="text-xs font-black text-[#f48c06]">{number}</span><h3 className="mt-2 font-black text-white">{title}</h3><p className="mt-1 text-sm leading-6 text-slate-400">{copy}</p></div>)}
             </div>
           </div>
         </div>
       </section>
 
-      {!user && (
-        <section className="game-panel border-[#faa307]/25 p-7 text-center sm:p-10">
-          <p className="metric-label">Ready when you are</p>
-          <h2 className="mt-2 text-3xl font-black text-white sm:text-4xl">Build a study system around what you actually want to learn.</h2>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">
-            Start free, make your first deck, keep your progress, and invite people into a Quest Room when studying alone gets old.
-          </p>
-          <div className="mt-6 flex flex-wrap justify-center gap-3">
-            <Link className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]" to="/signup">Create free account →</Link>
-            <Link className="game-button border border-white/10 bg-white/[0.04] px-6 py-3 font-black text-white" to="/demo">Try demo first</Link>
-          </div>
-        </section>
-      )}
+      {!user && <section className="game-panel border-[#faa307]/25 p-7 text-center sm:p-10"><img src="/flashquest-logo.svg" alt="FlashQuest" className="mx-auto h-16 w-16 rounded-2xl" /><p className="metric-label mt-4">Ready when you are</p><h2 className="mt-2 text-3xl font-black text-white sm:text-4xl">Build a study system around what you actually want to learn.</h2><p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">Start free, make your first deck, keep your progress, and invite people into a Quest Room when studying alone gets old.</p><div className="mt-6 flex flex-wrap justify-center gap-3"><Link className="game-button bg-[#ffba08] px-6 py-3 font-black text-[#370617]" to="/signup">Create free account →</Link><Link className="game-button border border-white/10 bg-white/[0.04] px-6 py-3 font-black text-white" to="/demo">Try demo first</Link></div></section>}
     </div>
   );
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import SocialAuthButtons from "../components/SocialAuthButtons";
 import { useAuth } from "../auth";
 
 function welcomeKey(userId: number) {
@@ -43,19 +44,24 @@ export default function Login() {
   return (
     <div className="mx-auto max-w-xl py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
-        <p className="metric-label">Welcome back</p>
-        <h1 className="mt-2 text-3xl font-black text-white">Sign in to FlashQuest</h1>
-        <p className="mt-2 text-sm text-slate-400">Pick up your decks, progress, and Quest Rooms where you left off.</p>
-        <div className="mt-6 grid gap-4">
-          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
-            <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />
-          </label>
-          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password
-            <input className="game-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" required />
-          </label>
+        <div className="flex items-center gap-4">
+          <img src="/flashquest-logo.svg" alt="FlashQuest" className="h-16 w-16 rounded-2xl" />
+          <div>
+            <p className="metric-label">Welcome back</p>
+            <h1 className="mt-1 text-3xl font-black text-white">Sign in to FlashQuest</h1>
+          </div>
+        </div>
+        <p className="mt-4 text-sm leading-6 text-slate-400">Pick up your decks, mastery, Arcade progress, and Quest Rooms where you left off.</p>
+
+        <div className="mt-6"><SocialAuthButtons next={explicitNext} /></div>
+        <div className="my-6 flex items-center gap-3 text-xs font-black uppercase tracking-[0.15em] text-slate-500"><span className="h-px flex-1 bg-white/10" /><span>or use email</span><span className="h-px flex-1 bg-white/10" /></div>
+
+        <div className="grid gap-4">
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email<input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required /></label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password<input className="game-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" required /></label>
         </div>
         {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
-        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Signing in…" : "Sign in →"}</button>
+        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Signing in…" : "Sign in with email →"}</button>
         <p className="mt-5 text-center text-sm text-slate-500">Need an account? <Link className="font-bold text-[#faa307]" to={`/signup${safeQueryNext ? `?next=${encodeURIComponent(safeQueryNext)}` : ""}`}>Create one</Link></p>
       </form>
     </div>

--- a/frontend/src/pages/OAuthCallback.tsx
+++ b/frontend/src/pages/OAuthCallback.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { setAccessToken } from "../api";
+import { useAuth } from "../auth";
+
+export default function OAuthCallback() {
+  const navigate = useNavigate();
+  const { refresh } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fragment = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const token = fragment.get("token");
+    const next = fragment.get("next");
+    const safeNext = next?.startsWith("/") ? next : null;
+    if (!token) {
+      setError("OAuth sign-in did not return a FlashQuest session.");
+      return;
+    }
+
+    setAccessToken(token);
+    window.history.replaceState({}, document.title, window.location.pathname);
+    void refresh()
+      .then(() => navigate(safeNext ?? "/welcome", { replace: true }))
+      .catch(() => setError("FlashQuest could not finish signing you in."));
+  }, [navigate, refresh]);
+
+  return (
+    <div className="mx-auto max-w-lg py-10">
+      <div className="game-panel p-8 text-center">
+        <img src="/flashquest-logo.svg" alt="FlashQuest" className="mx-auto h-20 w-20 rounded-3xl" />
+        <p className="metric-label mt-5">Secure sign-in</p>
+        <h1 className="mt-2 text-2xl font-black text-white">Finishing your FlashQuest login…</h1>
+        {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { resendVerification, signup } from "../api";
 import { DEMO_ACCOUNT_EMAIL, useAuth } from "../auth";
+import SocialAuthButtons from "../components/SocialAuthButtons";
 
 const DEMO_PASSWORD = "QuestRoomDemo!";
 
@@ -33,7 +34,13 @@ export default function Signup() {
       setSentTo(result.email);
       setMessage(result.message);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not create account");
+      const text = e instanceof Error ? e.message : "Could not create account";
+      if (text.includes("HTTP 503") || text.includes("HTTP 409")) {
+        setSentTo(email.trim().toLowerCase());
+        setMessage("Your account may already exist. You can resend verification below, or use Google/GitHub instead.");
+      } else {
+        setError(text);
+      }
     } finally {
       setLoading(false);
     }
@@ -69,18 +76,14 @@ export default function Signup() {
     return (
       <div className="mx-auto max-w-xl py-10">
         <div className="game-panel p-7 text-center sm:p-10">
-          <div className="text-6xl">📬</div>
+          <img src="/flashquest-logo.svg" alt="FlashQuest" className="mx-auto h-20 w-20 rounded-3xl" />
           <p className="metric-label mt-5">Almost there</p>
-          <h1 className="mt-2 text-3xl font-black text-white">Check your inbox!</h1>
-          <p className="mt-3 text-slate-300">We sent a verification link to <b className="text-[#ffba08]">{sentTo}</b>.</p>
-          <p className="mt-2 text-sm text-slate-500">
-            {joiningRooms
-              ? "Verify your email, then sign in and FlashQuest will send you to Quest Rooms."
-              : "Verify your email, then sign in to continue your quest."}
-          </p>
+          <h1 className="mt-2 text-3xl font-black text-white">Finish your account</h1>
+          <p className="mt-3 text-slate-300">Email account: <b className="text-[#ffba08]">{sentTo}</b></p>
           {message && <p className="mt-5 rounded-xl border border-[#faa307]/20 bg-[#faa307]/10 p-3 text-sm text-[#ffba08]">{message}</p>}
           {error && <p className="mt-5 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
-          <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <div className="mt-6"><SocialAuthButtons next={safeNext} /></div>
+          <div className="mt-5 flex flex-wrap justify-center gap-3">
             <button className="game-button bg-[#ffba08] px-4 py-2 text-sm font-black text-[#370617]" onClick={() => void resend()} disabled={loading}>Resend email</button>
             <Link className="game-button border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-black text-white" to={loginTarget}>Go to sign in</Link>
           </div>
@@ -92,53 +95,33 @@ export default function Signup() {
   return (
     <div className="mx-auto grid max-w-xl gap-5 py-6 sm:py-10">
       <form onSubmit={onSubmit} className="game-panel p-6 sm:p-8">
-        <p className="metric-label">{joiningRooms ? "👥 Join Quest Rooms" : "Continue your quest"}</p>
-        <h1 className="mt-2 text-3xl font-black text-white">Create your FlashQuest account</h1>
-        <p className="mt-2 text-sm leading-6 text-slate-400">
-          {joiningRooms
-            ? "Create and verify an account so FlashQuest can take you directly to the room experience you chose."
-            : "You’ve tried the public demo. Create an account to unlock the full FlashQuest experience."}
-        </p>
-
-        {joiningRooms && (
-          <div className="mt-5 rounded-2xl border border-[#faa307]/25 bg-[#faa307]/[0.07] p-4 text-sm leading-6 text-slate-300">
-            <b className="text-[#ffba08]">Why an account?</b> Quest Rooms need a signed-in identity for membership and realtime participation.
+        <div className="flex items-center gap-4">
+          <img src="/flashquest-logo.svg" alt="FlashQuest" className="h-16 w-16 rounded-2xl" />
+          <div>
+            <p className="metric-label">{joiningRooms ? "Join Quest Rooms" : "Continue your quest"}</p>
+            <h1 className="mt-1 text-3xl font-black text-white">Create your FlashQuest account</h1>
           </div>
-        )}
-
-        <div className="mt-6 grid gap-4">
-          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Name
-            <input className="game-input" value={displayName} onChange={(e) => setDisplayName(e.target.value)} autoComplete="name" required />
-          </label>
-          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email
-            <input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required />
-          </label>
-          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password
-            <input className="game-input" type="password" minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="new-password" required />
-            <span className="text-xs font-normal text-slate-500">At least 8 characters.</span>
-          </label>
         </div>
-
+        <p className="mt-4 text-sm leading-6 text-slate-400">Sign up to save mastery, build private decks, play Arcade with your own material, and join persistent Quest Rooms.</p>
+        <div className="mt-6"><SocialAuthButtons next={safeNext} /></div>
+        <p className="mt-3 text-center text-xs text-slate-500">Google/GitHub accounts are verified by the provider — no FlashQuest verification email required.</p>
+        <div className="my-6 flex items-center gap-3 text-xs font-black uppercase tracking-[0.15em] text-slate-500"><span className="h-px flex-1 bg-white/10" /><span>or use email</span><span className="h-px flex-1 bg-white/10" /></div>
+        <div className="grid gap-4">
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Name<input className="game-input" value={displayName} onChange={(e) => setDisplayName(e.target.value)} autoComplete="name" required /></label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Email<input className="game-input" type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required /></label>
+          <label className="grid gap-1.5 text-sm font-bold text-slate-200">Password<input className="game-input" type="password" minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="new-password" required /><span className="text-xs font-normal text-slate-500">At least 8 characters. Email signups still use verification.</span></label>
+        </div>
         {error && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{error}</p>}
-        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : joiningRooms ? "Create account for Quest Rooms →" : "Create account →"}</button>
-        <p className="mt-5 text-center text-sm text-slate-500">Already verified? <Link className="font-bold text-[#faa307]" to={loginTarget}>Sign in</Link></p>
+        <button className="game-button mt-6 w-full bg-[#ffba08] px-5 py-3 font-black text-[#370617]" disabled={loading}>{loading ? "Creating account…" : "Create with email →"}</button>
+        <p className="mt-5 text-center text-sm text-slate-500">Already have an account? <Link className="font-bold text-[#faa307]" to={loginTarget}>Sign in</Link></p>
       </form>
 
       <section className="game-panel border-[#faa307]/25 p-5 sm:p-6">
-        <p className="metric-label">👀 Want to look around first?</p>
+        <p className="metric-label">Want to look around first?</p>
         <h2 className="mt-2 text-xl font-black text-white">Enter the Demo Room</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-400">
-          See realtime chat and the signed-in room experience without creating an account yet. Demo sessions reset automatically after 2 minutes.
-        </p>
+        <p className="mt-2 text-sm leading-6 text-slate-400">See the signed-in room experience before creating an account.</p>
         {demoError && <p className="mt-4 rounded-xl border border-[#d00000]/40 bg-[#6a040f]/40 p-3 text-sm text-rose-200">{demoError}</p>}
-        <button
-          type="button"
-          className="game-button mt-4 w-full border border-[#faa307]/35 bg-[#faa307]/10 px-5 py-3 font-black text-[#ffba08]"
-          disabled={demoLoading}
-          onClick={() => void enterDemoRoom()}
-        >
-          {demoLoading ? "Entering demo…" : "👥 Enter Demo Room"}
-        </button>
+        <button type="button" className="game-button mt-4 w-full border border-[#faa307]/35 bg-[#faa307]/10 px-5 py-3 font-black text-[#ffba08]" disabled={demoLoading} onClick={() => void enterDemoRoom()}>{demoLoading ? "Entering demo…" : "👥 Enter Demo Room"}</button>
       </section>
     </div>
   );


### PR DESCRIPTION
## What changed
- adds Google and GitHub OAuth as the primary signup/sign-in paths
- treats provider-verified OAuth accounts as verified, bypassing FlashQuest email verification
- keeps email/password as a fallback with existing verification flow
- recovers stranded email signups after 503/409 delivery failures
- adds branded Google and GitHub buttons
- adds OAuth state validation and backend callback handling
- adds a frontend OAuth completion route
- uses the FlashQuest brain/lightning logo across the navbar, landing page, auth screens, footer, favicon, 404 state, and README
- expands the landing page to explain spaced repetition, custom decks, Arcade, Quest Rooms, mastery tracking, saved progress, and why users should create an account
- documents OAuth configuration and architecture

## Production configuration
Fly.io expects GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GITHUB_CLIENT_ID, and GITHUB_CLIENT_SECRET as secrets. API_PUBLIC_URL is configured for https://flashcards-tobias.fly.dev.

## OAuth callbacks
- Google: https://flashcards-tobias.fly.dev/auth/google/callback
- GitHub: https://flashcards-tobias.fly.dev/auth/github/callback